### PR TITLE
Fix

### DIFF
--- a/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
@@ -18,7 +18,7 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
     {
         public override string Game => "CK2HIP";
 
-        const string LandedTitlesFileName = "0_HIP_MoreCulturalNames.txt";
+        const string LandedTitlesFileName = "swmh_landed_titles.txt";
 
         public CK2ModBuilder(
             IRepository<LanguageEntity> languageRepository,

--- a/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
@@ -150,8 +150,12 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
 
             string culturesPattern = string.Join('|', gameLanguageIds.Select(x => x.Id));
 
-            string newContent = Regex.Replace( // Break inline cultural name into multiple lines
-                content,
+            string newContent = content;
+            newContent = Regex.Replace(newContent, "^\\s*\n", "", RegexOptions.Multiline); // Remove empty/whitespace lines
+            newContent = Regex.Replace(newContent, "^\\s*#.*\n", "", RegexOptions.Multiline); // Remove comment lines
+
+            newContent = Regex.Replace( // Break inline cultural name into multiple lines
+                newContent,
                 "^(\\s*)([ekdcb]_[^\\s]*)\\s*=\\s*\\{\\s*((" + culturesPattern + ")\\s*=\\s*\"*[^\"]*\")\\s*\\}",
                 "$1$2 = {\n$1\t$3\n$1}",
                 RegexOptions.Multiline);


### PR DESCRIPTION
 - Fixed the `Crusader Kings 2` builder not generating the landed titles file correctly
 - Changed the `Crusader Kings 2 (HIP)` landed titles file name to `swmh_landed_titles.txt` so that it will override the original file completely (1)

(1) This will get rid of a lot of `duplicated entity` warnings/errors, and it apparently fixes certain names not working in-game (e.g. many italian _(Lombardo)_ names)