### PR TITLE
CK2 (vanilla) generator

### DIFF
--- a/Configuration/OutputSettings.cs
+++ b/Configuration/OutputSettings.cs
@@ -3,21 +3,19 @@ namespace MoreCulturalNamesModBuilder.Configuration
     public sealed class OutputSettings
     {
         public string ModOutputDirectory { get; set; }
+        public string ModVersion { get; set; }
+
+        public string CK2ModId { get; set; }
+        public string CK2ModName { get; set; }
 
         public string CK2HipModId { get; set; }
-
         public string CK2HipModName { get; set; }
 
         public string CK3GameVersion { get; set; }
-
         public string CK3ModId { get; set; }
-
         public string CK3ModName { get; set; }
 
         public string ImperatorRomeModId { get; set; }
-
         public string ImperatorRomeModName { get; set; }
-
-        public string ModVersion { get; set; }
     }
 }

--- a/Configuration/OutputSettings.cs
+++ b/Configuration/OutputSettings.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace MoreCulturalNamesModBuilder.Configuration
 {
     public sealed class OutputSettings
@@ -17,5 +19,22 @@ namespace MoreCulturalNamesModBuilder.Configuration
 
         public string ImperatorRomeModId { get; set; }
         public string ImperatorRomeModName { get; set; }
+
+        public string GetModId(string game)
+        {
+            switch (game.ToUpperInvariant())
+            {
+                case "CK2":
+                    return CK2ModId;
+                case "CK2HIP":
+                    return CK2HipModId;
+                case "CK3":
+                    return CK3ModId;
+                case "ImperatorRome":
+                    return ImperatorRomeModId;
+                default:
+                    throw new ArgumentException("Invalid game identifier");
+            }
+        }
     }
 }

--- a/Data/ck2_landed_titles.txt
+++ b/Data/ck2_landed_titles.txt
@@ -1,0 +1,52686 @@
+e_rebels = {
+	rebel = yes
+	landless = yes
+	primary = yes
+
+	culture = swedish
+	religion = pagan
+	tribe = yes
+
+	color={ 0 0 0 }
+	color2={ 0 0 0 }
+}
+
+e_pirates = {
+	pirate = yes
+	landless = yes
+	primary = yes
+
+	culture = swedish
+	religion = pagan
+	tribe = yes
+
+	color={ 0 0 0 }
+	color2={ 0 0 0 }
+}
+
+# SPECIAL TITLES
+
+e_outremer = {
+	color={ 180 180 180 }
+	color2={ 255 255 255 }
+
+	capital = 774
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOR = {
+					religion = catholic
+					religion = fraticelli
+				}
+			}
+			OR = {
+				religion = catholic
+				religion = fraticelli
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				e_outremer = {
+					is_titular = yes
+				}
+			}
+			e_outremer = {
+				is_titular = no
+			}
+		}
+	}
+}
+
+e_nicaea = {
+	color={ 240 17 17 }
+	color2={ 255 255 20 }
+
+	capital = 750 # Nikaea
+
+	culture = greek
+
+	short_name = yes
+
+	has_top_de_jure_capital = yes
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				e_nicaea = {
+					is_titular = yes
+				}
+			}
+			e_nicaea = {
+				is_titular = no
+			}
+		}
+	}
+}
+
+e_lechczechrus = {
+	color={ 0 90 30 }
+	color2={ 255 255 255 }
+	short_name = yes
+
+	capital = 547	#Kiev
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				e_lechczechrus = {
+					is_titular = yes
+				}
+			}
+			e_lechczechrus = {
+				is_titular = no
+			}
+		}
+	}
+}
+
+e_bulgaria = {
+	color={ 108 78 110 }
+	color2={ 255 255 255 }
+	
+	culture = bulgarian
+	
+	capital = 499 # Tyrnovo
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				e_bulgaria = {
+					is_titular = yes
+				}
+			}
+			e_bulgaria = {
+				is_titular = no
+			}
+		}
+	}
+}
+
+k_papal_state = {
+	color={ 255 249 198 }
+	color2={ 220 220 0 }
+	
+	capital = 333 # Rome
+	
+	title = "POPE"
+	foa = "POPE_FOA"
+	short_name = yes
+	location_ruler_title = yes
+	
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = catholic
+	
+	religion = catholic
+	
+	# Cannot be held as a secondary title
+	primary = yes
+
+	assimilate = no
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+
+	dignity = 200
+	
+	# Regnal names
+	male_names = {
+		Alexander Anastasius Benedictus Caelestinus Callistus Clemens Eugenius Leo
+		Gregorius Hadrianus Honorius Innocentius Ioannes Lucius Marinus Martinus
+		Nicolaus Sergius Silvester Stephanus Urbanus Victor
+	}
+}
+
+
+d_papal_guards = {
+	color={ 255 240 240 }
+	color2 = { 220 220 0}
+
+	capital = 333 # Rome
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	allow = {
+		has_landed_title = k_papal_state
+	}
+
+	# Always exists
+	landless = yes
+
+	mercenary = yes
+
+	mercenary_type = papal_guard_composition
+
+	strength_growth_per_century = 1.00
+
+	religion = catholic
+
+	# Cannot be held as a secondary title
+	primary = yes
+}
+
+k_hellenic_pagan = {
+	color={ 124 0 175 }
+	color2={ 220 220 0 }
+	
+	capital = 333 # Rome
+	
+	title = "PONTIFEX_MAXIMUS"
+	title_female = "PONTIFEX_MAXIMA"
+	foa = "POPE_FOA"
+	short_name = yes
+
+	# Always exists
+	landless = yes
+
+	creation_requires_capital = no
+	
+	dignity = 100 # Counted as having this many more counties than it does
+	
+	# Controls a religion
+	controls_religion = hellenic_pagan_reformed
+	
+	religion = hellenic_pagan_reformed
+
+	assimilate = no
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+k_orthodox = {
+#	color={ 150 90 30 }
+	color={ 183 60 155 }
+	color2={ 220 220 0 }
+	
+	capital = 496 # Constantinople
+	
+	title = "ECUMENICAL_PATRIARCH"
+	foa = "ECUMENICAL_PATRIARCH_FOA"
+	short_name = yes
+
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = orthodox
+	
+	religion = orthodox
+	
+	# Cannot be held as a secondary title
+	primary = yes
+
+	assimilate = no
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	# Regnal names
+	male_names = {
+		Alexios Anastasios Arsenios Athanasios Antonios	Basileios Dositheos Eustathios Eustratios
+		Euthymios Georgios Gerasimos Germanos Gregorios Ignatios Ioannes Ioseph Isaias Isidoros
+		Kallistos Konstantinos Kosmas Leon Loukas Makarios Manuel Matthaios Maximos Methodios
+		Metrophanes Michael Neophytos Nephon Nikolaos Nikephoros Nilos Pavlos Philotheos Photios
+		Polyeuktos Sergios Sisinnios Stephanos Tarasios Theodoros Theodosios Theodotos Theoleptos
+		Theophanes Theophylaktos Tryphon Zacharias
+	}
+}
+
+k_antioch = {
+	color={ 228 53 53 }
+	color2={ 216 216 84 }
+
+	capital = 764 # Antioch
+
+	title = "principality_title"
+	title_female = "principality_title_female"
+	foa = "principality_foa"
+	title_prefix = "principality_prefix"
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				k_antioch = {
+					is_titular = yes
+				}
+			}
+			k_antioch = {
+				is_titular = no
+			}
+		}
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				religion = catholic
+			}
+		}
+	}
+}
+
+k_switzerland = {
+	color={ 255 80 80 }
+	color2={ 200 50 50 }
+
+	capital = 244 #Bern
+
+	short_name = yes
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				k_switzerland = {
+					is_titular = yes
+				}
+			}
+			k_switzerland = {
+				is_titular = no
+			}
+		}
+	}
+}
+
+e_sunni = {
+	# OBSOLETE
+	color={ 40 160 40 }
+	color2={ 220 220 0 }
+	
+	#capital = 719 # Mecca
+	
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion=sunni
+	
+	# controls_religion = sunni
+	
+	caliphate = yes
+}
+
+e_shiite = {
+	# OBSOLETE
+	color={ 60 190 60 }
+	color2={ 220 220 0 }
+	
+	#capital = 719 # Mecca
+	
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion=shiite
+	
+	# controls_religion = shiite
+
+	caliphate = yes
+}
+
+d_sunni = {
+	color={ 40 160 40 }
+	color2={ 220 220 0 }
+	
+	capital = 719 # Mecca
+	
+	creation_requires_capital = no
+	
+	dignity = 100 # Counted as having this many more counties than it does
+	
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion=sunni
+	
+	# Controls a religion
+	controls_religion = sunni
+	
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					has_alternate_start_parameter = { key = religion_names value = random }
+				}
+			}
+			custom_tooltip = {
+				text = sunni_creation_independent
+				hidden_tooltip = {
+					in_revolt = no
+					OR = {
+						independent = yes
+						NOT = {
+							any_liege = {
+								OR = {
+									in_revolt = yes
+									NOT = { religion = sunni }
+								}
+							}
+						}
+					}
+				}
+			}
+		
+			OR = {
+				trait = mirza
+				trait = sayyid
+				piety = 1000
+			}
+			OR = {
+				AND = {
+					trait = sayyid
+					piety = 1000
+				}
+				conditional_tooltip = {
+					trigger = {
+						NOT = {
+							has_global_flag = destroyed_caliphates
+						}
+					}
+
+					custom_tooltip = { 
+						text = controls_mecca_medina
+						hidden_tooltip = {
+							719 = { # Mecca
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+							718 = { # Medina
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+						}
+					}
+				}
+				custom_tooltip = {
+					text = controls_jerusalem_damascus_baghdad
+					hidden_tooltip = {
+						774 = { # Jerusalem
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+						728 = { # Damascus
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+						693 = { # Baghdad
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_alternate_start_parameter = { key = religion_names value = random }
+			}
+			religion = sunni
+			OR = {
+				trait = mirza
+				trait = sayyid
+				piety = 1000
+			}
+			custom_tooltip = {
+				text = THREE_HOLY_SITES_TT
+				hidden_tooltip = {
+					any_realm_title = {
+						count = 3
+						is_holy_site = ROOT
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_global_flag = destroyed_caliphates
+			}
+
+			custom_tooltip = {
+				text = controls_mecca_medina
+				hidden_tooltip = {
+					719 = { # Mecca
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+					718 = { # Medina
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	caliphate = yes
+	
+	coat_of_arms=
+	{
+		data=
+		{
+			0 0 0 3 0 2 2
+		}
+		religion=sunni
+	}
+}
+
+e_cordoba = {
+	color={ 255 218 185 }
+	color2={ 255 255 255 }
+
+	capital = 181 # Cordoba
+
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	#short_name = yes
+
+	religion = sunni
+
+	allow = {
+		always = no
+	}
+
+	caliphate = yes
+}
+
+d_shiite = {
+	color={ 60 190 60 }
+	color2={ 220 220 0 }
+	
+	capital = 719 # Mecca
+	
+	creation_requires_capital = no
+	
+	dignity = 100 # Counted as having this many more counties than it does
+	
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion=shiite
+	
+	# Controls a religion
+	controls_religion = shiite
+	
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					has_alternate_start_parameter = { key = religion_names value = random }
+				}
+			}
+			religion = shiite
+			custom_tooltip = {
+				text = shia_creation_independent
+				hidden_tooltip = {
+					in_revolt = no
+					OR = {
+						independent = yes
+						NOT = {
+							any_liege = {
+								OR = {
+									in_revolt = yes
+									NOT = { religion = shiite }
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			OR = {
+				trait = mirza
+				trait = sayyid
+				piety = 1000
+				custom_tooltip = {
+					text = shiite_bloodline_TT
+
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_shiite_leader
+						bloodline_is_active_for = PREV
+					}
+				}
+			}
+
+			custom_tooltip = {
+				text = not_shia_caliphate_revolt_ongoing
+				hidden_tooltip = {
+					NOT = { has_global_flag = shia_caliphate_revolt_ongoing }
+				}
+			}
+			
+			OR = {
+				AND = {
+					trait = sayyid
+					piety = 1000
+				}
+				AND = {
+					custom_tooltip = {
+						text = shiite_bloodline_TT
+
+						any_owned_bloodline = {
+							has_bloodline_flag = bloodline_shiite_leader
+							bloodline_is_active_for = PREV
+						}
+					}
+					piety = 500
+				}
+				conditional_tooltip = {
+					trigger = {
+						NOT = {
+							has_global_flag = destroyed_caliphates
+						}
+					}
+
+					custom_tooltip = {
+						text = controls_mecca_medina
+						hidden_tooltip = {
+							719 = { # Mecca
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+							718 = { # Medina
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+						}
+					}
+				}
+				custom_tooltip = {
+					text = controls_jerusalem_damascus_baghdad
+					hidden_tooltip = {
+						774 = { # Jerusalem
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+						728 = { # Damascus
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+						693 = { # Baghdad
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_alternate_start_parameter = { key = religion_names value = random }
+			}
+			religion = shiite
+			OR = {
+				trait = mirza
+				trait = sayyid
+				piety = 1000
+			}
+			custom_tooltip = {
+				text = THREE_HOLY_SITES_TT
+				hidden_tooltip = {
+					any_realm_title = {
+						count = 3
+						is_holy_site = ROOT
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_global_flag = destroyed_caliphates
+			}
+
+			religion = shiite
+
+			OR = {
+				piety = 500
+				custom_tooltip = {
+					text = controls_mecca_medina
+					hidden_tooltip = {
+						719 = { # Mecca
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+						718 = { # Medina
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+					}
+				}
+				custom_tooltip = {
+					text = shiite_bloodline_TT
+
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_shiite_leader
+						bloodline_is_active_for = PREV
+					}
+				}
+			}
+		}
+	}
+
+	caliphate = yes
+	
+	coat_of_arms=
+	{
+		data=
+		{
+			0 0 0 9 1 7 7
+		}
+		religion=shiite
+	}
+}
+
+d_qarmatian = {
+	color={ 60 190 60 }
+	color2={ 220 220 0 }
+	
+	capital = 652 # Al-Hasa
+	
+	creation_requires_capital = no
+	
+	dignity = 100 # Counted as having this many more counties than it does
+	
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion = qarmatian
+	
+	# Controls a religion
+	controls_religion = qarmatian
+	
+	allow = {
+		religion = qarmatian
+		piety = 500
+		OR = {
+			trait = mirza
+			trait = sayyid
+			piety = 1000
+			custom_tooltip = {
+				text = qarmatian_bloodline_TT
+
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_qarmatian_leader
+					bloodline_is_active_for = PREV
+				}
+			}
+		}
+		OR = {
+			custom_tooltip = {
+				text = THREE_HOLY_SITES_TT
+				hidden_tooltip = {
+					any_realm_title = {
+						count = 3
+						is_holy_site = ROOT
+					}
+				}
+			}
+			custom_tooltip = {
+				text = qarmatian_bloodline_TT
+
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_qarmatian_leader
+					bloodline_is_active_for = PREV
+				}
+			}
+		}
+	}
+
+	caliphate = yes
+	
+	coat_of_arms=
+	{
+		data=
+		{
+			0 0 0 9 1 7 7
+		}
+		religion = qarmatian
+	}
+}
+
+e_golden_horde = {
+	color = { 243 180 17 }
+	
+	short_name = yes
+	
+	capital = 619 # Saray
+	
+	# Always exists
+	landless = yes
+	
+	allow = {
+		always = no
+	}
+	
+	#tribe = yes
+	
+	culture = mongol
+	religion = tengri_pagan
+}
+
+e_il-khanate = {
+	color = { 140 180 20 }
+	
+	short_name = yes
+	
+	capital = 646 # Esfahan
+	
+	# Always exists
+	landless = yes
+	
+	allow = {
+		always = no
+	}
+	
+	#tribe = yes
+	
+	culture = mongol
+	religion = tengri_pagan
+}
+
+e_mongol_empire = {
+	color = { 130 180 240 }
+	color2 = { 255 20 20 }
+	
+	short_name = yes
+	
+	capital = 1457 # Kara-khorum
+	
+	landless = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = mongol
+	religion = tengri_pagan
+}
+
+e_chagatai = {
+	color = { 200 200 200 }
+	color2 = { 0 250 250 }
+	
+	capital = 903 # Samarkand
+	
+	allow = {
+		always = no
+	}
+	
+	culture = mongol
+	religion = tengri_pagan
+}
+
+e_timurids = {
+	color = { 120 20 20 }
+	
+	short_name = yes
+	
+	capital = 646 # Esfahan
+	
+	allow = {
+		always = no
+	}
+	
+	# Always exists
+	#landless = yes
+	
+	#tribe = yes
+	
+	culture = mongol
+	religion = sunni
+}
+
+# HOLY ORDERS
+
+d_knights_templar = {
+	color={ 230 230 230 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = holygfx
+	
+	capital = 138 # Orleans
+	
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	mercenary_type = knights_templar_composition
+	
+	culture = frankish
+	
+	# Parent Religion 
+	religion = catholic
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to banking, etc
+	monthly_income = 10 # (Must be an integer between 1 and 512)
+}
+
+d_teutonic_order = {
+	
+	color={ 50 50 50 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = holygfx
+	
+	capital = 258 # Lüneburg
+
+	title = "HOCHMEISTER"
+	foa = "HOCHMEISTER_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	mercenary_type = teutonic_order_composition
+	
+	# Parent Religion 
+	religion = catholic
+	
+	culture = german
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 8 # (Must be an integer between 1 and 512)
+}
+
+k_teutonic_state = {
+	color={ 50 50 50 }
+	color2={ 255 255 255 }
+
+	graphical_culture = holygfx
+
+	title = "HOCHMEISTER"
+	foa = "HOCHMEISTER_FOA"
+
+	holy_order = yes
+	mercenary_type = teutonic_order_composition
+
+	short_name = yes
+
+	assimilate = no
+
+	# Parent Religion
+	religion = catholic
+
+	culture = german
+
+	# Cannot be held as a secondary title
+	primary = yes
+
+	# Extra income due to donations, etc
+	monthly_income = 12 # (Must be an integer between 1 and 512)	
+}
+
+d_livonian_order = {
+	color={ 40 60 40 }
+	color2={ 255 255 255 }
+
+	graphical_culture = holygfx
+
+	holy_order = yes
+	mercenary_type = livonian_order_composition
+
+	short_name = yes
+
+	# Parent Religion
+	religion = catholic
+
+	culture = german
+
+	# Cannot be held as a secondary title
+	primary = yes
+
+	# Extra income due to donations, etc
+	monthly_income = 4 # (Must be an integer between 1 and 512)
+}
+
+d_knights_hospitaler = {
+
+	color={ 180 180 180 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = holygfx
+	
+	capital = 333 # Rome
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	culture = occitan
+	
+	# Parent Religion 
+	religion = catholic
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 6 # (Must be an integer between 1 and 512)
+
+	mercenary_type = knights_hospitaler_composition
+}
+
+d_hashshashin = {
+
+	color={ 100 100 0 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = hashshashingfx
+	
+	capital = 693 # Baghdad
+	
+	title = "GRANDHEADMASTER"
+	foa = "GRANDHEADMASTER_FOA"
+	
+	holy_order = yes
+
+	# Always exists
+	landless = yes
+	
+	culture = persian
+	
+	# Parent Religion 
+	religion = shiite
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 6 # (Must be an integer between 1 and 512)
+
+	mercenary_type = hashshashin_composition
+}
+
+d_bektashi = {
+
+	color={ 90 150 0 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = bektashigfx
+	
+	capital = 753 # Ancyra
+	
+	title = "DEDEBABA"
+	foa = "GRANDHEADMASTER_FOA"
+	
+	holy_order = yes
+
+	# Always exists
+	landless = yes
+	
+	culture = persian
+	
+	# Parent Religion 
+	religion = sunni
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 6 # (Must be an integer between 1 and 512)
+
+	mercenary_type = bektashi_composition
+}
+
+d_haruriyyah = {
+
+	color={ 150 200 80 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = bektashigfx
+	
+	capital = 693 # Bagdad
+	
+	title = "DEDEBABA"
+	foa = "GRANDHEADMASTER_FOA"
+	
+	holy_order = yes
+
+	# Always exists
+	landless = yes
+	
+	culture = bedouin_arabic
+	
+	# Parent Religion 
+	religion = ibadi
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 6 # (Must be an integer between 1 and 512)
+
+	mercenary_type = bektashi_composition
+}
+
+d_jomsvikings = {
+
+	color={ 50 50 50 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = norseholygfx
+	
+	capital = 303
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = norse_pagan
+	
+	culture = norse
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = jomsvikings_composition
+}
+
+d_immortals = {
+
+	color={ 180 205 20 }
+	
+	graphical_culture = immortalsgfx
+	
+	capital = 637
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = zoroastrian
+	
+	culture = persian
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = immortals_composition
+}
+
+d_zealots = {
+
+	color={ 20 100 255 }
+	
+	graphical_culture = jewishholygfx
+	
+	capital = 774
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = jewish
+	
+	culture = ashkenazi
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = zealots_composition
+}
+
+d_holy_sepulchre = {
+
+	color={ 120 0 145 }
+	
+	graphical_culture = orthodoxholygfx
+	
+	capital = 774
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = greek
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = holy_sepulchre_composition
+}
+
+d_saint_anthony = {
+
+	color={ 180 165 70 }
+	
+	graphical_culture = holygfx
+	
+	capital = 875
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = miaphysite
+	
+	culture = ethiopian
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = saint_anthony_composition
+}
+
+d_saint_addai = {
+
+	color={ 180 80 140 }
+	
+	graphical_culture = holygfx
+	
+	capital = 693 # Baghdad
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = nestorian
+	
+	culture = assyrian
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = saint_addai_composition
+}
+
+d_sky_lords = {
+
+	color={ 220 200 140 }
+	
+	capital = 898
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = tengri_pagan_reformed
+	
+	culture = cuman
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = sky_lords_composition
+}
+
+d_spirit_guardians = {
+
+	color={ 120 120 55 }
+	
+	graphical_culture = westafricanholygfx
+	
+	capital = 925
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = west_african_pagan_reformed
+	
+	culture = manden
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = spirit_guardians_composition
+}
+
+d_warriors_perun = {
+
+	color={ 100 140 100 }
+	
+	graphical_culture = slavicholygfx
+	
+	capital = 547
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = slavic_pagan_reformed
+	
+	culture = russian
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = warriors_perun_composition
+}
+
+d_chosen_perkunas = {
+
+	color={ 200 45 45 }
+	
+	graphical_culture = balticholygfx
+	
+	capital = 374
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = baltic_pagan_reformed
+	
+	culture = lettigallish
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = chosen_perkunas_composition
+}
+
+d_sons_kaleva = {
+
+	color={ 140 130 105 }
+	
+	graphical_culture = finnishholygfx
+	
+	capital = 392
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = finnish_pagan_reformed
+	
+	culture = finnish
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = sons_kaleva_composition
+}
+
+d_huitzilopochtli = {
+
+	color={ 255 200 0 }
+	
+	graphical_culture = aztecholygfx
+	
+	capital = 843
+
+	title = "HIGHPRIEST"
+	foa = "GRANDMASTER_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = aztec_reformed
+	
+	culture = nahuatl
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = huitzilopochtli_composition
+}
+
+d_knights_santiago = {
+
+	color={ 255 130 0 }
+	
+	graphical_culture = holygfx
+	
+	capital = 157 # Santiago
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	culture = castillan
+	
+	# Parent Religion 
+	religion = catholic
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 6 # (Must be an integer between 1 and 512)
+
+	mercenary_type = knights_santiago_composition
+}
+
+d_knights_calatrava = {
+
+	color={ 230 100 0 }
+	
+	graphical_culture = holygfx
+	
+	capital = 196 # Calatrava
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	culture = castillan
+	
+	# Parent Religion 
+	religion = catholic
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 6 # (Must be an integer between 1 and 512)
+
+	mercenary_type = knights_calatrava_composition
+}
+
+d_followers_arjuna = {
+	color={ 255 0 0 }
+	color2={ 255 255 255 }
+	
+	capital = 1355 # Delhi
+	
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	culture = hindustani
+	
+	# Parent Religion 
+	religion = hindu
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+	
+	mercenary_type = followers_arjuna_composition
+}
+
+d_ashokas_chosen = {
+	color={ 205 100 0 }
+	color2={ 255 255 255 }
+	
+	capital = 1355 # Delhi
+	
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	culture = marathi
+	
+	# Parent Religion 
+	religion = buddhist
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+	
+	mercenary_type = ashokas_chosen_composition
+}
+
+d_dralhas_children = {
+	color={ 205 100 0 }
+	color2={ 255 255 255 }
+	
+	capital = 1498 # Lhasa
+	
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	culture = bodpa
+	
+	# Parent Religion 
+	religion = bon_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+	
+	mercenary_type = dralhas_children_composition
+}
+
+d_bulls_rishabha = {
+	color={ 255 100 0 }
+	color2={ 255 255 255 }
+	
+	capital = 1355 # Delhi
+	
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	culture = kannada
+	
+	# Parent Religion 
+	religion = jain
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+	
+	mercenary_type = bulls_rishabha_composition
+}
+
+d_zun_warriors = {
+
+	color = { 230 255 0 }
+	
+	capital = 1185 # Kabul
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	culture = afghan
+	
+	# Parent Religion 
+	religion = zun_pagan_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = zun_warriors_composition
+}
+
+d_myrmidons = {
+
+	color = { 224 125 8 }
+	
+	capital = 482 # Atheniai
+
+	title = "MEGASTRATEGOS"
+	title_female = "MEGASTRATEGISSA"
+	foa = "GRANDMASTER_FOA"
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	culture = greek
+	
+	# Parent Religion 
+	religion = hellenic_pagan_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+
+	mercenary_type = myrmidons_composition
+}
+
+# MERCS
+
+d_sunni_turkic_company = {
+	color = { 130 173 70 }
+	color2 = { 255 255 255 }
+
+	capital = 621 # Kangly
+	
+	# Parent Religion 
+	religion = sunni
+	culture = turkish
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = muslim_turkic_company_composition
+}
+
+d_sunni_cuman_company = {
+	color = { 134 155 30 }
+	color2 = { 255 255 255 }
+
+	capital = 616 # Yaik
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = muslim
+				religion_group = zoroastrian_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = sunni
+	culture = khazar
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = muslim_cuman_company_composition
+}
+
+d_sunni_berber_company = {
+	color = { 85 155 33 }
+	color2 = { 255 255 255 }
+
+	capital = 833 # Atlas
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = muslim
+				religion_group = zoroastrian_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = sunni
+	culture = maghreb_arabic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = berber_company_composition
+}
+
+d_sunni_bedouin_company = {
+	color = { 45 155 35 }
+	color2 = { 255 255 255 }
+
+	capital = 862 # Halaban
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = muslim
+				religion_group = zoroastrian_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = sunni
+	culture = bedouin_arabic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = bedouin_company_composition
+}
+
+
+d_shiite_turkic_company = {
+	color = { 135 170 60 }
+	color2 = { 255 255 255 }
+
+	capital = 621 # Kangly
+	
+	# Parent Religion 
+	religion = shiite
+	culture = turkish
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = muslim_turkic_company_composition
+}
+
+d_shiite_cuman_company = {
+	color = { 130 150 30 }
+	color2 = { 255 255 255 }
+
+	capital = 616 # Yaik
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = muslim
+				religion_group = zoroastrian_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = shiite
+	culture = cuman
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = muslim_cuman_company_composition
+}
+
+d_shiite_berber_company = {
+	color = { 90 150 30 }
+	color2 = { 255 255 255 }
+
+	capital = 833 # Atlas
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = muslim
+				religion_group = zoroastrian_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = shiite
+	culture = maghreb_arabic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = berber_company_composition
+}
+
+d_shiite_bedouin_company = {
+	color = { 40 150 30 }
+	color2 = { 255 255 255 }
+
+	capital = 862 # Halaban
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = muslim
+				religion_group = zoroastrian_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = shiite
+	culture = bedouin_arabic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = bedouin_company_composition
+}
+
+d_white_company = {
+	color={ 235 235 235 }
+	color2={ 255 255 255 }
+
+	capital = 72 # Essex
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = white_company_composition
+	
+}
+
+d_great_company = {
+	color={ 100 100 100 }
+	color2={ 255 255 255 }
+
+	capital = 361 # Niederbayern
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = great_company_composition
+}
+
+d_company_of_st_george = {
+	color={ 50 50 200 }
+	color2={ 255 255 255 }
+
+	capital = 235 # Lombardia
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CONDOTTIERO"
+	foa = "CONDOTTIERO_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = company_of_st_george_composition
+}
+
+d_star_company = {
+	color={ 200 80 200 }
+	color2={ 255 255 255 }
+
+	capital = 353 # Ferrara
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CONDOTTIERO"
+	foa = "CONDOTTIERO_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = star_company_composition
+}
+
+d_little_hat_company = {
+	color={ 100 200 80 }
+	color2={ 255 255 255 }
+
+	capital = 354 # mantua
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CONDOTTIERO"
+	foa = "CONDOTTIERO_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = little_hat_company_composition
+}
+
+d_rose_company = {
+	color={ 230 150 150 }
+	color2={ 255 255 255 }
+
+	capital = 355 # Padua
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CONDOTTIERO"
+	foa = "CONDOTTIERO_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = rose_company_composition
+}
+
+d_catalan_company = {
+	color={ 230 100 100 }
+	color2={ 255 255 255 }
+
+	capital = 204 # Barcelona
+	
+	mercenary = yes
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+			year = 950
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	culture = catalan
+
+	title = "CONDOTTIERO"
+	foa = "CONDOTTIERO_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = catalan_company_composition
+}
+
+d_navarrese_company = {
+	color={ 150 150 100 }
+	color2={ 255 255 255 }
+	
+	title = "CONDOTTIERO"
+	foa = "CONDOTTIERO_FOA"
+
+	capital = 152 # Navarre
+	
+	mercenary = yes
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	culture = basque
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = navarrese_company_composition
+}
+
+d_swiss_company = {
+	color={ 150 40 40 }
+	color2={ 255 255 255 }
+
+	capital = 239 # Geneve
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = swiss_company_composition
+}
+
+d_breton_company = {
+	color={ 150 40 40 }
+	color2={ 255 255 255 }
+
+	capital = 102 # Penthievre
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	culture = breton
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = breton_company_composition
+}
+
+d_sardinian_company = {
+	color={ 210 165 165 }
+	color2={ 255 255 255 }
+
+	capital = 326 # Cagliari
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	culture = italian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = sardinian_company_composition
+}
+
+d_sardinian_band = {
+	color={ 210 65 65 }
+	color2={ 255 255 255 }
+
+	capital = 325 # Arborea
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	culture = italian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = sardinian_band_composition
+}
+
+d_victual_brothers = {
+	color={ 160 160 160 }
+	color2={ 255 255 255 }
+	
+	capital = 370 # Marienburg
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion = norse_pagan
+				religion = norse_pagan_reformed
+				religion = baltic_pagan
+				religion = baltic_pagan_reformed
+				religion = finnish_pagan
+				religion = finnish_pagan_reformed
+				religion_group = christian
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+	mercenary_type = victual_brothers_composition
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 0.25
+}
+
+d_varangian_guard = {
+	color={ 180 180 180 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = orthodoxholygfx
+
+	capital = 290 # Uppland
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = norse
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+	title_female = "CAPTAIN_FEMALE"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = varangian_guard_composition
+}
+
+d_cuman_company = {
+	color = { 160 160 80 }
+	color2 = { 255 255 255 }
+
+	capital = 616 # Yaik
+	
+	# Parent Religion 
+	religion = orthodox
+	culture = cuman
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = cuman_company_composition
+}
+
+d_rus_company = {
+	color = { 80 80 160 }
+	color2 = { 255 255 255 }
+
+	capital = 547 # Kiev
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			year = 950
+			OR = {
+				religion_group = pagan_group
+				religion_group = christian
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = russian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = rus_company_composition
+}
+
+d_pecheneg_company = {
+	color = { 100 100 30 }
+	color2 = { 255 255 255 }
+
+	capital = 542 # Olvia
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = pecheneg
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = pecheneg_company_composition
+}
+
+d_bulgarian_company = {
+	color = { 100 50 30 }
+	color2 = { 255 255 255 }
+
+	capital = 508 # Dorostotum
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = bulgarian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = bulgarian_company_composition
+}
+
+d_turkic_company = {
+	color = { 100 50 30 }
+	color2 = { 255 255 255 }
+
+	capital = 621 # Kangly
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = turkish
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = turkic_company_composition
+}
+
+d_lombard_band = {
+	color={ 150 60 60 }
+	color2={ 255 255 255 }
+
+	capital = 235 # Lombardia
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CONDOTTIERO"
+	foa = "CONDOTTIERO_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = lombard_band_composition
+}
+
+d_swiss_band = {
+	color={ 150 40 40 }
+	color2={ 255 255 255 }
+
+	capital = 239 # Geneve
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = swiss_band_composition
+}
+
+d_breton_band = {
+	color={ 150 65 65 }
+	color2={ 255 255 255 }
+
+	capital = 102 # Penthievre
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	culture = breton
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = breton_band_composition
+}
+
+d_catalan_band = {
+	color={ 230 100 100 }
+	color2={ 255 255 255 }
+
+	capital = 204 # Barcelona
+	
+	mercenary = yes
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+			year = 950
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	culture = catalan
+
+	title = "CONDOTTIERO"
+	foa = "CONDOTTIERO_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = catalan_band_composition
+}
+
+d_saxon_band = {
+	color={ 220 90 90 }
+	color2={ 255 255 255 }
+
+	capital = 57 # York
+	
+	mercenary = yes
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				NOT = { year = 1100 }
+				any_independent_ruler = {
+					culture = saxon
+				}
+			}
+			religion_group = christian
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	culture = saxon
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = saxon_band_composition
+}
+
+d_cuman_band = {
+	color = { 160 160 80 }
+	color2 = { 255 255 255 }
+
+	capital = 616 # Yaik
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = cuman
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = cuman_band_composition
+}
+
+d_rus_band = {
+	color = { 80 80 160 }
+	color2 = { 255 255 255 }
+
+	capital = 547 # Kiev
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			year = 950
+			OR = {
+				religion_group = christian
+				religion_group = pagan_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = russian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = rus_band_composition
+}
+
+d_finnish_band = {
+	color = { 131 35 35 }
+	color2 = { 255 255 255 }
+
+	capital = 383 # Häme
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = christian
+				religion_group = pagan_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = finnish_pagan
+	
+	culture = finnish
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = finnish_band_composition
+}
+
+d_lappish_band = {
+	color = { 101 69 30 }
+	color2 = { 255 255 255 }
+
+	capital = 386 # Kemi
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = christian
+				religion_group = pagan_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = finnish_pagan
+	
+	culture = lappish
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = lappish_band_composition
+}
+
+d_lithuanian_band = {
+	color = { 169 90 95 }
+	color2 = { 255 255 255 }
+
+	capital = 421 # Lietuva / Zhmud
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = christian
+				religion_group = pagan_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = baltic_pagan
+	
+	culture = lithuanian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = lithuanian_band_composition
+}
+
+d_abyssinian_band = {
+	color={ 180 135 60 }
+	color2 = { 255 255 255 }
+
+	capital = 875 # Axum
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = christian
+				religion_group = jewish_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = miaphysite
+	
+	culture = ethiopian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = abyssinian_band_composition
+}
+
+d_nubian_band = {
+	color = { 155 165 80 }
+	color2 = { 255 255 255 }
+
+	capital = 878 # Hayya
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			OR = {
+				religion_group = christian
+				religion_group = jewish_group
+			}
+		}
+	}
+	
+	# Parent Religion 
+	religion = miaphysite
+	
+	culture = nubian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = nubian_band_composition
+}
+
+d_scottish_band = {
+	color = { 30 90 182 }
+	color2 = { 255 255 255 }
+
+	capital = 43 # Gowrie
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			year = 950
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	culture = scottish
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = scottish_band_composition
+}
+
+d_irish_band = {
+	color = { 112 255 70 }
+	color2 = { 255 255 255 }
+
+	capital = 10 # Kildare
+	
+	# Hire Trigger
+	allow = {
+		always = yes
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	culture = irish
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = irish_band_composition
+}
+
+d_alan_band = {
+	color = { 245 210 90 }
+	color2 = { 255 255 255 }
+
+	capital = 603 # Alania
+	
+	# Hire Trigger
+	allow = {
+		always = yes
+	}
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = alan
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = alan_band_composition
+}
+
+d_pecheneg_band = {
+	color = { 100 100 30 }
+	color2 = { 255 255 255 }
+
+	capital = 542 # Olvia
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = pecheneg
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = pecheneg_band_composition
+}
+
+d_bulgarian_band = {
+	color = { 100 50 30 }
+	color2 = { 255 255 255 }
+
+	capital = 508 # Dorostotum
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = bulgarian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = bulgarian_band_composition
+}
+
+d_turkic_band = {
+	color = { 100 50 30 }
+	color2 = { 255 255 255 }
+
+	capital = 621 # Kangly
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = turkish
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = turkic_band_composition
+}
+
+d_mamluks = {
+	color={ 80 160 80 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = bektashigfx
+
+	capital = 796 # Cairo
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = muslim
+		}
+	}
+	
+	# Parent Religion 
+	religion = shiite
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = mamluks_composition
+}
+
+d_venetian_navy = { # Now "Adriatic Galleys"
+	color = { 60  175  170 }
+	color2={ 255 255 255 }
+	
+	short_name = yes
+
+	capital = 356 # Venice
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+			year = 1066
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+
+	mercenary_type = naval_merc_composition
+}
+
+d_genoese_navy = { # Now "Ligurian Galleys"
+	color={ 224 161 120 }
+	color2={ 255 255 255 }
+	
+	short_name = yes
+
+	capital = 233 # Genoa
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+			year = 1066
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+
+	mercenary_type = naval_merc_composition
+}
+
+d_hanseatic_navy = { # Now "Baltic Cogs"
+	color={ 150 150 150 }
+	color2={ 255 255 255 }
+	
+	short_name = yes
+
+	capital = 262 # Lübeck
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+			year = 1066
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+
+	mercenary_type = naval_merc_composition
+}
+
+d_frisian_navy = { # Now "North Sea Cogs"
+	color={ 245 80 20 }
+	color2={ 255 255 255 }
+	
+	short_name = yes
+
+	capital = 80 # Holland
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = christian
+			year = 1066
+		}
+	}
+	
+	# Parent Religion 
+	religion = catholic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+
+	mercenary_type = naval_merc_composition
+}
+
+d_maghreb_corsairs = {
+	color={ 174 237 125 }
+	color2={ 255 255 255 }
+	
+	short_name = yes
+
+	capital = 816 # Mahdia
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = muslim
+			year = 1066
+		}
+	}
+	
+	# Parent Religion 
+	religion = sunni
+	
+	culture = maghreb_arabic
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+
+	mercenary_type = naval_merc_composition
+}
+
+d_ghilman = {
+	color={ 60 165 80 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = bektashigfx
+
+	capital = 627 # Kara-Kum
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			religion_group = muslim
+		}
+	}
+	
+	# Parent Religion 
+	religion = sunni
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = ghilman_composition
+}
+
+d_ghanan_band = {
+	color = { 108 123 48 }
+	color2 = { 255 255 255 }
+
+	capital = 913 # Ghana
+	
+	# Hire Trigger
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					is_alternate_start = yes
+				}
+			}
+			culture_group = west_african
+		}
+	}
+	
+	# Parent Religion 
+	religion = west_african_pagan
+	
+	culture = manden
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = ghanan_band_composition
+}
+
+# EMPIRES
+
+e_hre = {                      # Created by special decision only
+	color={ 250 250 250 }
+	color2={ 0 0 0 }
+	
+	capital = 90 # Jülich / Aachen
+
+	short_name = yes
+	
+	allow = {
+		always = no # Only created through special decisions
+	}
+
+	k_saxon = {
+		color={ 70 70 70 }
+		color2={ 255 255 255 }
+
+		capital = 257
+
+		title_prefix = "GRAND_DUCHY_PREFIX"
+		title = "GRAND_DUCHY_RULER"
+		title_female = "GRAND_DUCHY_RULER_FEMALE"
+
+		allow = {
+			conditional_tooltip = {
+				k_saxon = {
+					is_titular = yes
+				}
+			}
+			k_saxon = {
+				is_titular = no
+			}
+		}
+
+		catholic = 3000 # Crusade target weight
+		norse_pagan_reformed = 500 # Crusade target weight
+	}
+	k_franconia = {
+		color={ 100 108 100 }
+		color2={ 255 255 255 }
+		
+		capital = 254 # Würzburg
+
+		title_prefix = "GRAND_DUCHY_PREFIX"
+		title = "GRAND_DUCHY_RULER"
+		title_female = "GRAND_DUCHY_RULER_FEMALE"
+
+		allow = {
+			conditional_tooltip = {
+				k_franconia = {
+					is_titular = yes
+				}
+			}
+			k_franconia = {
+				is_titular = no
+			}
+		}
+	}
+	k_swabia = {
+		color={ 206 203 203 }
+		color2={ 255 255 255 }
+		
+		capital = 249 #Schwaben
+
+		title_prefix = "GRAND_DUCHY_PREFIX"
+		title = "GRAND_DUCHY_RULER"
+		title_female = "GRAND_DUCHY_RULER_FEMALE"
+
+		allow = {
+			conditional_tooltip = {
+				k_swabia = {
+					is_titular = yes
+				}
+			}
+			k_swabia = {
+				is_titular = no
+			}
+		}
+	}
+}
+
+e_germany = {
+
+	color={ 190 200 190 }
+	color2={ 220 220 20 }
+	
+	capital = 254 # Würburg
+	
+	culture = german
+	
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = central_germanic
+				culture = old_saxon
+			}
+		}
+	}
+	
+	k_austria = {
+		color={ 240 240 240 }
+		color2={ 255 255 255 }
+
+		capital = 449
+
+		roman = "Noricum"
+
+		title = "archduchy_title"
+		title_female = "archduchy_title_female"
+		foa = "archduchy_foa"
+		title_prefix = "archduchy_prefix"
+
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_austria = {
+						is_titular = yes
+					}
+				}
+				k_austria = {
+					is_titular = no
+				}
+			}
+		}
+	}
+
+	k_eastern_marches = {
+		color={ 240 240 240 }
+		color2={ 255 255 255 }
+
+		capital = 449
+
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_eastern_marches = {
+						is_titular = yes
+					}
+				}
+				k_eastern_marches = {
+					is_titular = no
+				}
+			}
+		}
+	}
+
+	k_hansa = {
+		color={ 210 210 210 }
+		color2={ 255 255 255 }
+
+		capital = 262 # Lübeck
+	
+		dignity = 200 # Never want the Hanseatic League to change primary title
+	
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_hansa = {
+						is_titular = yes
+					}
+				}
+				k_hansa = {
+					is_titular = no
+				}
+			}
+			is_republic = yes
+		}
+	}	
+
+	k_saxony = {
+		color={ 120 25 25 }
+		culture = old_saxon
+
+		capital = 257 # Brunswick
+
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture = old_saxon
+					culture = saxon
+				}
+			}
+		}
+		
+		catholic = 3000 # Crusade target weight
+		norse_pagan_reformed = 500 # Crusade target weight
+
+		d_saxony = {
+			color={ 70 70 70 }
+			color2={ 255 255 255 }
+			
+			capital = 257 # Brunswick
+
+			old_saxon = Ostfalia
+
+			c_luneburg = {
+				color={ 195 195 195 }
+				color2={ 255 255 255 }
+
+				old_saxon = Bardengawi
+				
+				b_luneburg = {
+				}
+				b_bardowick = {
+				}
+				b_gifhorn = {
+				}
+				b_evern = {
+				}
+				b_reppenstedt = {
+				}
+				b_ludersburg = {
+				}
+				b_thomasburg = {
+				}
+				b_uelzen = {
+				}
+			}
+			c_braunschweig = {
+				color={ 192 192 192 }
+				color2={ 255 255 255 }
+
+				old_saxon = Hastfala
+				
+				b_braunschweig = {
+				}
+				b_bielefeld = {
+				}
+				b_hildesheim = {
+				}
+				b_waldeck = {
+				}
+				b_wolfenbuttel = {
+				}
+				b_helmstedt = {
+				}
+				b_gandersheim = {
+				}
+			}
+			c_verden = {
+				color={ 170 192 192 }
+				color2={ 255 255 255 }
+
+				old_saxon = "Sturmi"
+
+				b_verden = {}
+				b_rotenburg_verden = {}
+				b_ottersberg = {}
+				b_walsrode = {}
+				b_soltau = {}
+				b_kirchwalsede = {}
+				b_ouhusen = {}
+			}
+			c_altmark = {
+				color={ 189 189 189 }
+				color2={ 255 255 255 }
+
+				pommeranian = Laczyn
+				old_saxon = Osterwalde
+				
+				b_werben = {
+				}
+				b_halberstedt = {
+				}
+				b_walbeck = {
+				}
+				b_luchow = {
+				}
+				b_salzwedel = {
+				}
+				b_stendal = {
+				}
+				b_osterburg = {
+				}
+				b_tangermunde = {
+				}
+			}
+			c_magdeburg = {
+				color={ 160 189 189 }
+				color2={ 255 255 255 }
+
+				pommeranian = Dolomici
+				old_saxon = Suavia
+
+				b_magdeburg = {	
+					pommeranian = Magadoburg			
+				}
+				b_mansfeld = {
+				}
+				b_haldensleben = {
+					pommeranian = Hahaldeslevo
+				}
+				b_arnstein = {
+				}
+				b_querfurt = {
+					pommeranian = Curnfurt
+				}
+				b_bernburg = {
+				}
+				b_kloster_berge = {}
+			}
+		}
+		d_brunswick = {
+			color={ 183 172 172 }
+			color2={ 255 255 255 }
+		
+			capital = 257 # Brunswick
+
+			allow = {
+				conditional_tooltip = {
+					trigger = {
+						d_brunswick = {
+							is_titular = yes
+						}
+					}
+					d_brunswick = {
+						is_titular = no
+					}
+				}
+			}
+		}
+		d_bremen = {
+			color= { 190 201 210 }
+			color2= { 255 255 255 }
+
+			capital = 259 #Bremen
+
+			old_saxon = Heilanga
+
+			pagan_coa = {
+				religion = "norse_pagan"
+				template = 0
+				layer = {
+					texture = 11
+					texture_internal = 0
+					emblem = 0
+					color = 13
+					color = 3
+					color = 13
+				}
+			}
+					
+			c_bremen = {
+				color={ 216 216 216 }
+				color2={ 255 255 255 }
+
+				old_saxon = Hostingabi
+
+				b_hoya = {
+				}
+				b_stade = {
+				}
+				b_blumenthal = {
+				}
+				b_ritzebuttel = {
+				}
+				b_achim = {
+				}
+				b_beverstedt = {
+				} 
+				b_osterbruch = {
+				}
+			}
+			c_celle = {
+				color={ 198 198 198 }
+				color2={ 255 255 255 }
+
+				old_saxon = Wigmodia
+
+				pagan_coa = {
+					religion = "norse_pagan"
+					template = 0
+					layer = {
+						texture = 11
+						texture_internal = 0
+						emblem = 0
+						color = 13
+						color = 3
+						color = 13
+					}
+				}
+				
+				b_bremen = {
+				}
+				b_celle = {
+				}
+				b_hannover = {
+				}
+				b_herford = {
+				}
+				b_hermannsburg = {
+				}
+				b_ravensberg = {
+				}
+				b_nienburg = {
+				}
+				b_wedemark = {
+				}
+				b_wittingen = {
+				}
+			}
+		}
+		d_angria = {
+			color={ 180 165 165 }
+			color2={ 255 255 255 }
+
+			capital = 1979 # Minden
+
+			c_osnabruck = {
+				color={ 213 213 213 }
+				color2={ 255 255 255 }
+
+				old_saxon = Leriga
+				
+				b_osnabruck = {
+				}
+				b_lingen = {
+				}
+				b_bentheim = {
+				}
+				b_wildeshausen = {
+				}
+				b_tecklenburg = {
+				}
+				b_quackenbruck = {
+				}
+				b_meppen = {
+				}
+			}
+			c_oldenburg = {
+				color={ 214 214 214 }
+				color2={ 255 255 255 }
+
+				old_saxon = Lara
+				
+				b_oldenburg = {
+				}
+				b_cloppenburg = {
+				}
+				b_jever = {
+				}
+				b_delmenhorst = {
+				}
+				b_loningen = {
+				}
+				b_nordenham = {
+				}
+				b_kniphausen = {
+				}
+				b_varel = {
+				}
+			}
+			c_minden = {
+				color={ 214 214 190 }
+				color2={ 255 255 255 }
+
+				old_saxon = Derve
+
+				b_minden = {
+					old_saxon = Derve
+				}
+				b_hockeleve = {
+					old_saxon = Huculvi
+				}
+				b_petershagen = {}
+				b_diepholz = {}
+				b_auburg = {}
+				b_wagenfeld = {}
+				b_drebber = {}
+			}
+		}
+		d_munster_germany = {
+			color={ 213 216 212 }
+			color2={ 255 255 255 }
+
+			capital = 88 # Munster
+
+			old_saxon = Westfalia
+
+			c_munster = {
+				color={ 212 212 212 }
+				color2={ 255 255 255 }
+				
+				old_saxon = Dreini
+
+				b_munster = {
+				}
+				b_dortmund = {
+				}
+				b_essen = {
+				}
+				b_greven = {
+				}
+				b_gutersloh = {
+				}
+				b_steinfurt = {
+				}
+				b_gronau = {
+				}
+				b_ahlen = {
+				}
+			}
+			c_gottingen = {
+				color={ 210 210 210 }
+				color2={ 255 255 255 }
+
+				holy_site = norse_pagan
+				holy_site = norse_pagan_reformed
+
+				old_saxon = Patherga
+				
+				b_paderborn = {
+					old_saxon = Irminsul
+				}
+				b_gottingen = {
+				}
+				b_corvey = {
+				}
+				b_lippe = {
+				}
+				b_kassel = {
+				}
+				b_goslar = {
+				}
+				b_northeim = {
+				}
+				b_eisenach = {
+				}
+				b_detmold = {
+				}
+			}
+		}
+	}
+	
+	k_frisia = {
+		color={ 245 100 20 }
+		color2={ 220 220 20 }
+		
+		culture = dutch
+		
+		capital = 80 #Holland
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture = dutch
+					culture = frisian
+				}
+			}
+		}
+		
+		catholic = 700 # Crusade target weight
+		norse_pagan_reformed = 200 # Crusade target weight
+		
+		d_holland = {
+			color={ 235 80 30 }
+			color2={ 255 255 255 }
+		
+			capital = 80 #Holland
+			
+			culture = dutch
+			
+			c_holland = {
+				color={ 235 85 30 }
+				color2={ 255 255 255 }
+			
+				b_haarlem = {
+				}
+				b_amsterdam = {
+				}
+				b_vlaardingen = {
+				}
+				b_sgravenhage = {
+				}
+				b_dordrecht = {
+				}
+				b_gouda = {
+				}
+				b_leiden = {
+				}
+				b_muiden = {
+				}
+			}
+			c_sticht = {
+				color={ 215 85 35 }
+				color2={ 255 255 255 }
+			
+				b_woerden = {
+				}
+				b_utrecht = {
+				}
+				b_dorestad = {
+				}
+				b_gorinchem = {
+				}
+				b_zeist = {
+				}
+				b_buren = {
+				}
+				b_ijsselstein = {
+				}
+				b_oudewater = {
+				}
+			}
+			c_westfriesland = {
+				color={ 245 99 50 }
+				color2={ 255 255 255 }
+			
+				b_alkmaar = {
+				}
+				b_hoorn = {
+				}
+				b_medemblik = {
+				}
+				b_enkhuizen = {
+				}
+				b_heerhugowaard = {
+				}
+				b_texel = {
+				}
+				b_egmond = {
+				}
+				b_schagen = {
+				}
+			}
+			c_zeeland = {
+				color={ 200 100 30 }
+				color2={ 255 255 255 }
+
+				holy_site = norse_pagan
+				holy_site = norse_pagan_reformed
+				
+				b_middelburg = {
+				}
+				b_tholen = {
+				}
+				b_veere = {
+				}
+				b_cadzand = {
+				}
+				b_vlissingen = {
+				}
+				b_renesse = {
+				}
+				b_borsele = {
+				}
+				b_zierikzee = {
+				}
+			}
+		}
+		d_gelre = {
+			color={ 200 100 25 }
+			color2={ 255 255 255 }
+			
+			capital = 83 #Gelre
+			
+			culture = dutch
+			
+			c_gelre = {
+				color={ 200 100 30 }
+				color2={ 255 255 255 }
+			
+				b_nijmegen = {
+				}
+				b_zutphen = {
+				}
+				b_lohn = {
+				}
+				b_arnhem = {
+				}
+				b_bergh = {
+				}
+				b_bronckhorst = {
+				}
+				b_duetinghem = {}
+			}
+			c_overijssel = {
+				color={ 180 70 25 }
+				color2={ 255 255 255 }
+
+				b_deventer = {}
+				b_zwolle = {}
+				b_enschede = {}
+				b_drenthe = {}
+				b_coevorden = {}
+				b_kampen = {}
+				b_vollenhove = {}
+			}			
+			c_ostfriesland = {
+				color={ 190 90 10 }
+				color2={ 255 255 255 }
+			
+				b_emden = {
+				}
+				b_aurich = {
+				}
+				b_borkum = {
+				}
+				b_norden = {
+				}
+				b_norderney = {
+				}
+				b_leer = {
+				}
+				b_wittmund = {
+				}
+				b_esens = {
+				}
+			}
+			c_frisia = {
+				color={ 170 80 15 }
+				color2={ 255 255 255 }
+			
+				b_groningen = {
+				}
+				b_leeuwarden = {
+				}
+				b_stavoren = {
+				}
+				b_bolsward = {
+				}
+				b_franeker = {
+				}
+				b_dokkum = {
+				}
+				b_assen = {
+				}
+				b_harlingen = {
+				}
+			}
+		}
+	}
+	
+	k_lotharingia = {
+		color={ 110 110 160 }
+		color2={ 220 220 20 }
+		
+		culture = frankish
+		
+		capital = 115 #Luxemburg
+
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					NAND = {
+						has_landed_title = k_germany
+						start_date = 936.8.7
+					}
+				}
+			}
+		}
+		
+		catholic = 5000 # Crusade target weight
+		
+		dignity = 17 # One more than Burgundy
+		
+		d_brabant = {
+			color={ 200 100 60 }
+			color2={ 255 255 255 }
+			
+			capital = 117 #Brabant
+			
+			culture = dutch
+		
+			c_brabant = {
+				color={ 200 100 65 }
+				color2={ 255 255 255 }
+			
+				b_leuven = {
+				}
+				b_mechelen = {
+				}
+				b_brussel = {
+				}
+				b_antwerpen = {
+				}
+				b_aarschot = {
+				}
+				b_grimbergen = {
+				}
+				b_herstal = {
+				}
+				b_lier = {
+				}
+			}
+			c_hainaut = {
+				color={ 210 120 40 }
+				color2={ 255 255 255 }
+			
+				b_valenciennes = {
+				}
+				b_cambrai = {
+				}
+				b_avesnes = {
+				}
+				b_mons = {
+				}
+				b_chievres = {
+				}
+				b_enghien = {
+				}
+				b_charleroi = {
+				}
+				b_ath = {
+				}
+			}
+			c_breda = {
+				color={ 234 145 54 }
+				color2={ 255 255 255 }
+			
+				b_breda = {
+				}
+				b_shertogenbosch = {
+				}
+				b_tilburg = {
+				}
+				b_willemstad = {
+				}
+				b_bergenopzoom = {
+				}
+				b_cuijck = {
+				}
+				b_ravenstein = {
+				}
+				b_horn = {
+				}
+			}
+		}
+		d_upper_lorraine = {
+			color={ 90 90 125 }
+			color2={ 255 255 255 }
+			
+			capital = 127 #Lorraine		
+			c_lorraine = {
+				color={ 92 92 127 }
+				color2={ 255 255 255 }
+			
+				b_nancy = {
+				}
+				b_toul = {
+				}
+				b_sarrebourg = {
+				}
+				b_epinal = {
+				}
+				b_luneville = {
+				}
+				b_charpeigne = {
+				}
+				b_mortagnedevosges = {
+				}
+				b_saintavoid = {
+				}
+			}
+			c_saintois = {
+				color={ 105 105 135 }
+				color2={ 255 255 255 }
+		
+				b_saintois = {
+				}
+				b_vaudemont = {
+				}
+				b_brixey = {
+				}
+				b_sorcystmartin = {
+				}
+				b_ivios = {
+				}
+				b_ornois = {
+				}
+				b_saulnois = {
+				}
+				b_dompaire = {
+				}
+			}
+			c_bar = {
+				color={ 115 115 145 }
+				color2={ 255 255 255 }
+				
+				b_barleduc = {
+				}
+				b_vaucouleurs = {
+				}
+				b_saintmihel = {
+				}
+				b_commercy = {
+				}
+				b_joinville = {
+				}
+				b_saintdizier = {
+				}
+				b_saintmartinengourgandelle = { # Fictional, for prosperity
+				}
+			}
+			c_verdun = {
+				color={ 130 130 165 }
+				color2={ 255 255 255 }
+			
+				b_verdun = {
+				}
+				b_grandpre = {
+				}
+				b_barlecomte = {
+				}
+				b_longuyon = {
+				}
+				b_doaumont = {
+				}
+				b_stenay = {
+				}
+				b_etain = {
+				}
+			}
+		}
+		d_lower_lorraine = {
+			color={ 144 144 177 }
+			color2={ 255 255 255 }
+			
+			capital = 115 #Luxembourg
+			
+			c_luxembourg = {
+				color={ 113 113 158 }
+				color2={ 255 255 255 }
+			
+				b_luxembourg = {
+				}
+				b_bouillon = {
+				}
+				b_saintvith = {
+				}
+				b_arlon = {
+				}
+				b_neufchateau = {
+				}
+				b_longwy = {
+				}
+				b_differdange = {
+				}
+				b_ettelbruck = {
+				}
+			}
+			c_liege = {
+				color={ 120 120 165 }
+				color2={ 255 255 255 }
+			
+				b_liege = {
+				}
+				b_bastogne = {
+				}
+				b_namur = {
+				}
+				b_huy = {
+				}
+				b_laroche = {
+				}
+				b_cine = {
+				}
+				b_salm = {
+				}
+				b_stavelot = {
+				}
+			}
+			c_julich = {
+				color={ 100 100 141 }
+				color2={ 255 255 255 }
+			
+				b_julich = {
+				}
+				b_aachen = {
+				}
+				b_prum = {
+				}
+				b_geldern = {
+				}
+				b_roermond = {
+				}
+				b_duren = {
+				}
+				b_moers = {
+				}
+				b_monschau = {
+				}
+			}
+			c_loon = {
+				color={ 115 115 175 }
+				color2={ 255 255 255 }
+			
+				b_loon = {
+				}
+				b_maastricht = {
+				}
+				b_hasselt = {
+				}
+				b_valkenburg = {
+				}
+				b_heinsberg = {
+				}
+				b_hesbaie = {
+				}
+				b_wassenberg = {
+				}
+				b_tongeren = {
+				}
+			}
+		}
+		d_trier = {
+			color={ 188 188 224 }
+			color2={ 255 255 255 }
+
+			capital = 118 # Trier
+
+			c_trier = {
+				color={ 144 144 177 }
+				color2={ 255 255 255 }
+			
+				b_andernach = {
+				}
+				b_trier = {
+				}
+				b_coblenz = {
+				}
+				b_sponheim = {
+				}
+				b_wittlich = {
+				}
+				b_gerolstein = {
+				}
+				b_laach = {
+				}
+				b_bitburg = {
+				}
+			}
+			c_metz = {	
+				color={ 150 150 185 }
+				color2={ 255 255 255 }
+			
+				b_metz = {
+				}
+				b_thionville = {
+				}
+				b_saintjulien = {
+				}
+				b_marslatour = {
+				}
+				b_bouzonville = {
+				}
+				b_briey = {
+				}
+				b_joudreville = {
+				}
+				b_audunleroman = {
+				}
+			}
+			c_saargau = {
+				color={ 130 165 130 }
+				color2={ 255 255 255 }
+
+				b_saarbrucken = {}
+				b_merkingen = {}
+				b_st_arnual = {}
+				b_fechingen = {}
+				b_eschringen = {}
+				b_malstatt = {}
+				b_dudweiler = {}
+			}
+		}
+		d_koln = {
+			color={ 105 105 148 }
+			color2={ 255 255 255 }
+			
+			capital = 119 #Cologne
+			
+			norse = Köln
+			swedish = Köln
+			danish = Köln
+			norwegian = Köln
+			german = Köln
+			lombard = Köln
+			old_frankish = Köln
+			suebi = Köln
+			dutch = Keulen
+			frisian = Keulen
+			saxon = Köln
+			old_saxon = Köln
+			
+			c_koln = {
+				color={ 141 141 141 }
+				color2={ 255 255 255 }
+
+				holy_site = catholic
+				
+				norse = Köln
+				swedish = Köln
+				danish = Köln
+				norwegian = Köln
+				german = Köln
+				lombard = Köln
+				old_frankish = Köln
+				suebi = Köln
+				dutch = Keulen
+				frisian = Keulen
+				saxon = Köln
+				old_saxon = Köln
+				
+				b_koln = {
+					norse = Köln
+					swedish = Köln
+					danish = Köln
+					norwegian = Köln
+					german = Köln
+					lombard = Köln
+					old_frankish = Köln
+					suebi = Köln
+					dutch = Keulen
+					frisian = Keulen
+					saxon = Köln
+					old_saxon = Köln
+				}
+				b_mark = {
+				}
+				b_bonn = {
+				}
+				b_dietz = {
+				}
+				b_saffenburg = {
+				}
+				b_hochstaden = {
+				}
+				b_brauweiler = {
+				}
+			}
+			c_kleve = {
+				color={ 132 132 132 }
+				color2={ 255 255 255 }
+		
+				b_kleve = {
+				}
+				b_goch = {
+				}
+				b_rees = {
+				}
+				b_anholt = {
+				}
+				b_Xanten = {
+				}
+				b_wesel = {
+				}
+				b_emmerich = {
+				}
+				b_isselburg = {
+				}
+			}
+			c_berg = {
+				color={ 132 132 115 }
+				color2={ 255 255 255 }
+
+				b_berg = {}
+				b_werth = {}
+				b_dusseldorf = {}
+				b_elberfeld = {}
+				b_essen_berg = {}
+				b_throtmanni = {}
+				b_barmen = {}
+			}
+		}
+	}
+	
+	k_bavaria = {
+		color={ 91 100 100 }
+		color2={ 220 220 20 }
+		
+		culture = german
+		
+		roman = "Raetia"
+
+		capital = 1700 # Regensburg
+
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					NAND = {
+						has_landed_title = k_germany
+						start_date = 936.8.7
+					}
+				}
+			}
+		}
+		
+		catholic = 2000 # Crusade target weight
+		
+		d_bavaria = {
+			color={ 128 121 121 }
+			color2={ 255 255 255 }
+			
+			capital = 1700 # Regensburg
+			
+			c_passau = {
+				color={ 54 54 54 }
+				color2={ 255 255 255 }
+		
+				b_passau = {
+				}
+				b_ortenburg = {
+				}
+				b_schaumberg = {
+				}
+				b_formbach = {
+				}
+				b_ulrichsberg = {
+				}
+				b_raab = {
+				}
+				b_freyung = {
+				}
+			}
+			c_oberbayern = {
+				color={ 66 66 66 }
+				color2={ 255 255 255 }
+			
+				b_munchen = {
+				}
+				b_dachau = {
+				}
+				b_freising = {
+				}
+				b_andechs = {
+				}
+				b_diessen = {
+				}
+				b_dingolfing = {
+				}
+				b_pfaffenberg = {
+				}
+				b_ebersberg = {
+				}
+			}
+			c_regensburg = {
+				color={ 70 50 70 }
+				color2={ 255 255 255 }
+
+				b_regensburg = {
+				}
+				b_landshut = {
+				}
+				b_ingolstadt = {
+				}
+				b_straubing = {
+				}
+				b_rohrbach = {
+				}
+				b_lerchenfeld = {}
+				b_kelheim = {}
+			}
+			c_niederbayern = {
+				color={ 60 60 60 }
+				color2={ 255 255 255 }
+		
+				b_regenstauf = {}
+				b_cham = {
+				}
+				b_schwandorf = {}
+				b_kirchroth = {
+				}
+				b_sankt_englmar = {}
+				b_roding = {}
+				b_wittelsbach = {
+				}
+			}
+		}
+		d_nordgau = {
+			color={ 57 57 70 }
+			color2={ 255 255 255 }
+
+			capital = 314 # Nurnberg
+
+			c_nurnberg = {
+				color={ 57 57 57 }
+				color2={ 255 255 255 }
+		
+				b_nurnberg = {
+				}
+				b_ellwangen = {
+				}
+				b_furth = {
+				}
+				b_kulmbach = {
+				}
+				b_hohenburg = {
+				}
+				b_nordlingen = {
+				}
+				b_erlangen = {
+				}
+			}
+			c_eichstadt = {
+				color={ 57 57 40 }
+				color2={ 255 255 255 }
+
+				b_eichstadt = {}
+				b_weissenburg = {}
+				b_abenberg = {}
+				b_lechtgemund = {}
+				b_trubendingen = {}
+				b_hirschberg = {}
+				b_pollenfeld = {}
+			}
+		}
+		d_salzburg = {
+			color={ 180 190 200 }
+			color2= { 255 255 255 }
+
+			capital = 448 # Salzburg
+
+			c_salzburg = {
+				color={ 63 63 63 }
+				color2={ 255 255 255 }
+
+				carantanian = "Solnograd"
+			
+				b_salzburg = {
+					carantanian = "Solnograd"
+				}
+				b_durmberg = {
+				}
+				b_waging = {
+				}
+				b_plain = {}
+				b_berchtesgaden = {
+				}
+				b_tittmoning = {
+				}
+				b_laufen = {
+				}
+				b_muhldorf = {
+				}
+				b_gastein = {
+				}
+			}
+			c_pongau = {
+				color={ 68 68 68 }
+				color2 = { 255 255 255 }
+
+				b_pongau = {}
+				b_zelle = {}
+				b_taemswich = {}
+				b_salvet = {}
+				b_mittersill = {}
+				b_hoven = {}
+				b_st_maximillian = {}
+			}
+		}
+		d_osterreich = { 
+			color={ 191 182 182 }
+			color2={ 255 255 255 }
+			
+			capital = 449 #Österreich
+
+			roman = "Noricum"
+		
+			c_steiermark = {
+				color={ 45 45 45 }
+				color2={ 255 255 255 }
+
+				carantanian = "Stajerska"
+				
+				b_steyr = {
+				}
+				b_losenstein = {}
+				b_garstina = {}
+				b_ternberg = {}
+				b_rubinicha = {}
+				b_behamberg = {}
+				b_grobraming = {}
+			}
+			c_traungau = {
+				color={ 60 40 80 }
+				color2={ 255 255 255 }
+
+				carantanian = "Traun"
+
+				b_enisiburg = {}
+				b_linz = {
+					carantanian = "Linec"
+					bohemian = "Linec"
+				}
+				b_wels = {}
+				b_eferding = {}
+				b_gmunden = {}
+				b_hallstatt = {}
+				b_pons_veckelahe = {}
+				b_ebensee = {}
+			}
+			c_krems = {
+				color={ 40 50 40 }
+				color2={ 255 255 255 }
+
+				german = Krems
+				old_saxon = Krems
+
+				b_krems = {}
+				b_gars = {}
+				b_eggenburg = {}
+				b_kuenring = {}
+				b_horn_krems = {}
+				b_zwettl = {}
+				b_retz = {}
+			}
+			c_osterreich = {
+				color={ 48 48 48 }
+				color2={ 255 255 255 }
+
+				dutch = Wenen
+				frisian = Wenen
+				carantanian = "Dunaj"
+				bohemian = "Víden"
+				croatian = "Bec"
+			
+				b_wien = {
+					norse = Wien
+					swedish = Wien
+					danish = Wien
+					norwegian = Wien
+					german = Wien
+					lombard = Wien
+					old_frankish = Wien
+					suebi = Wien
+					dutch = Wenen
+					frisian = Wenen
+					saxon = Wien
+					old_saxon = Wien
+					carantanian = "Dunaj"
+					bohemian = "Víden"
+					croatian = "Bec"
+				}
+				b_wagram = {
+				}
+				b_klosterneuburg = {}
+				b_baden_wien = {}
+				b_korneuburg = {}
+				b_modling = {}
+				b_heiligenkreuz = {}
+			}
+			c_freistadt = {
+				color={ 30 40 30 }
+				color2={ 255 255 255 }
+
+				bohemian = "Zahlow"
+				pommeranian = "Zahlow"
+				croatian = "Zahlow"
+				carantanian = "Zahlow"
+
+				b_freistadt = {}
+				b_steyregg = {}
+				b_grein = {}
+				b_pergkirchen = {}
+				b_zell = {}
+				b_aschach = {}
+				b_taversheim = {}
+			}
+			c_medelike = {
+				color={ 25 35 45 }
+				color2={ 255 255 255 }
+
+				b_zelking = {}
+				b_melk = {}
+				b_stpolten = {}
+				b_ybbs = {}
+				b_waidhofen = {}	
+				b_gaming = {}
+				b_pochlarn = {}
+				b_lilienfeld = {}
+			}
+		}
+
+		d_styria = {
+			color={ 150 140 140 }
+			color2={ 255 255 255 }
+
+			capital = 1693
+
+			german = "Steiermark"
+			carantanian = "Gradec"
+
+			c_leoben = {
+				color={ 50 30 40 }
+				color2={ 255 255 255 }
+
+				b_eppenstein = {}
+				b_leoben = {}
+				b_neuberg = {}
+				b_judenburg = {}
+				b_gallenstein = {}
+				b_rottenmann = {}
+				b_bruck_leoben = {}
+			}
+			c_graz = {
+				color={ 150 120 150 }
+				color2={ 255 255 255 }
+
+				carantanian = "Gradec"
+				croatian = "Gradec"
+
+				b_graz = {
+					carantanian = "Gradec"
+					croatian = "Gradec"
+				}
+				b_radkersburg = {
+				}
+				b_leibnitz = {
+				}
+				b_reun = {}
+				b_friedberg_graz = {}
+				b_voitsberg = {}
+				b_stainz = {}
+				b_feldbach = {}
+
+			}
+			c_pitten = {
+				color={ 120 150 120 }
+				color2={ 255 255 255 }
+
+				b_pitten = {}
+				b_fischau = {}
+				b_wr_neustadt = {}
+				b_neunkirchen = {}
+				b_edelz = {}
+				b_ternitz = {}
+				b_gloggnitz = {}
+			}
+		}
+		
+		d_tyrol = {  
+			color={ 157 154 154 }
+			color2={ 255 255 255 }
+			
+			capital = 316 #Tirol
+		
+			c_tirol = {
+				color={ 90 90 90 }
+				color2={ 255 255 255 }
+			
+				b_bregenz = {
+				}
+				b_landeck = {
+				}
+				b_stanton = {
+				}
+				b_imst = {
+				}
+				b_sterzing = {
+				}
+				b_ried = {
+				}
+				b_dornbirn = {
+				}
+				b_nenzing = {
+				}
+			}
+			c_innsbruck = {
+				color={ 84 84 84 }
+				color2={ 255 255 255 }
+
+				carantanian = "Inomost"
+			
+				b_innsbruck = {
+					carantanian = "Inomost"
+				}
+				b_kufstein = {
+				}
+				b_stams = {
+				}
+				b_schwaz = {
+				}
+				b_kitzbuhel = {
+				}
+				b_jenbach = {
+				}
+				b_fugen = {
+				}
+			}
+			c_trent = {
+
+				german = "Trient"
+				italian = "Trento"
+
+				color={ 253 239 228 }
+				color2={ 255 255 255 }
+	
+				b_trento = {
+				}
+				b_brixen = {
+				}
+				b_molven = {
+				}
+				b_schlanders = {
+				}
+				b_bruneck = {
+				} 
+				b_riva = {
+				}
+				b_rovereto = {
+				}
+			}
+			c_bolzano = {
+
+				german = "Bozen"
+
+				color = { 210 250 180 }
+				color2 = { 255 255 255 }
+
+				b_eppan = {
+				}
+				b_bozen = {
+				}
+				b_meran = {
+				}
+				b_st_jacob = {
+				}
+				b_dolladitz = {
+				}
+				b_cortina = {
+				}
+				b_st_helena = {
+				}
+				b_florian = {
+				}
+			}
+		}
+	}
+
+	k_carinthia = {
+		color={ 140 240 200 }
+		color2={ 255 255 255 }
+
+		capital = 457 # Krain/Carniola/Krainburg
+
+		carantanian = "Carantania"
+
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = south_slavic
+				}
+			}
+		}
+
+		d_friuli = {
+			color = { 160 255 220 }
+			color2 = { 255 255 255 }
+
+			capital = 358 # Aquileia
+
+			c_aquileia = {
+				color={ 115 205 175 }
+				color2 = { 255 255 255 }
+
+				carantanian = "Oglej"
+				
+				b_aquileia = {
+					carantanian = "Oglej"
+				}
+				b_grado = {
+					carantanian = "Gradez"
+				}
+				b_trieste = {
+					german = "Triest"
+					croatian = "Trst"
+					serbian = "Trst"
+					carantanian = "Trst"
+					bosnian = "Trst"
+				}
+				b_concordia = {
+				}
+				b_portoguaro = {
+				}
+				b_sacile = {
+				}
+				b_sistiana = {}
+
+			}
+
+			c_treviso = {
+				color={ 251 226 226 }
+				color2={ 255 255 255 }
+				
+				b_treviso = {
+				}
+				b_bassano = {
+				}
+				b_oderzo = {
+				}
+				b_castelfranco = {
+				}
+				b_asola = {
+				}
+				b_citadella = {
+				}
+				b_ceneda = {
+				}
+				b_paese = {
+				}
+			}
+			c_udine = {
+				color={ 120 190 180 }
+				color2={ 255 255 255 }
+
+				carantanian = "Videm"
+
+				b_udine = {
+					carantanian = "Videm"
+				}
+				b_friuli = {
+				}
+				b_ciridale = {
+				}
+				b_tarcento = {}
+				b_gemona = {}
+				b_tolmezzo = {}
+				b_maniago = {}
+			}
+		}
+
+		d_carniola = {
+			color={ 150 200 230 }
+			color2={ 255 255 255 }
+
+			capital = 457
+
+			croatian = "Kranj"
+			carantanian = "Kranj"
+			bosnian = "Kranj"
+			german = "Krain"
+
+			c_istria = {
+				color={ 165 245 200 }
+				color2={ 255 255 255 }
+				
+				b_mitterburg = {
+					croatian = "Pazin"
+					serbian = "Pazin"
+					carantanian = "Pazin"
+					bosnian = "Pazin"
+					italian = "Pisino"
+					greek = "Pisino"
+				}
+				b_fiume = {
+					croatian = "Rijeka"
+					carantanian = "Reka"
+					bosnian = "Rijeka"
+				}
+				b_lovrana = {
+				}
+				b_wolauska = {
+				}
+				b_karstberg = {
+				}
+				b_duino = {
+				}
+				b_pula = {
+				}
+			}
+			c_krain = {
+				color={ 145 225 190 }
+				color2={ 255 255 255 }
+				
+				croatian = "Kranj"
+				carantanian = "Kranj"
+				bosnian = "Kranj"
+				german = "Krain"
+
+				b_gorz = {
+					carantanian = "Gorica"
+					croatian = "Gorizia"
+					bosnian = "Gorizia"
+				}
+				b_krainburg = {
+					croatian = "Kranj"
+					carantanian = "Kranj"
+					bosnian = "Kranj"
+				}
+				b_gurk = {
+				}
+				b_stain = {
+				}
+				b_guetenegg = {
+				}
+				b_auersperg = {
+				}
+				b_zerknitz = {
+				}
+				b_stveit = {
+				}
+			}
+			c_pettau = {
+				color={ 140 200 220 }
+				color2={ 255 255 255 }
+
+				croatian = "Ptuj"
+				carantanian = "Ptuj"
+				bosnian = "Ptuj"
+				roman = "Poetovio"
+				greek = "Poetovio"
+				dalmatian = "Poetovio"
+
+				b_marburg_pettau = {}
+				b_pettau = {}
+				b_friedau = {}
+				b_bistrica = {}
+				b_weitenstein = {}
+				b_studenitz = {}
+				b_seitz = {}
+			}
+		}
+
+		d_carinthia = {
+			color={ 165 255 250 }
+			color2={ 255 255 255 }
+			
+			capital = 456 # Villach
+
+			german = "Kärnten"
+			carantanian = "Carantania"
+
+			c_karnten = {
+				color={ 125 225 195 }
+				color2={ 255 255 255 }
+
+				carantanian = "Beljak"
+				
+				b_villach = {
+					carantanian = "Beljak"
+				}
+				b_klagenfurt = {
+					carantanian = "Celovec"
+				}
+				b_treffen = {
+				}
+				b_lienz = {}
+				b_spittl = {}
+				b_greifenburg = {}
+				b_vorelach = {}
+			}
+			c_friesach = {
+				color={ 150 240 250 }
+				color2={ 255 255 255 }
+
+				carantanian = "Breze"
+
+				b_petersberg = {}
+				b_sankt_veit = {}
+				b_sankt_lambrecht = {}
+				b_wolfsberg = {
+				}
+				b_micheldorf = {}
+				b_althofen = {}
+				b_st_nicholas_friesach = {}
+			}
+		}
+	}
+	
+	k_germany = {
+		color={ 160 160 160 }
+		color2={ 220 220 20 }
+		
+		dignity = 30 # Counted as having this many more counties than it does
+		
+		culture = german
+		
+		capital = 254 # Würburg
+		
+		catholic = 5000 # Crusade target weight
+		
+		norse_pagan_reformed = 200 # Crusade target weight
+		slavic_pagan_reformed = 50 # Crusade target weight
+		baltic_pagan_reformed = 50 # Crusade target weight
+		
+		d_hesse = {
+			color={ 160 160 120 }
+			color2={ 255 255 255 }
+
+			capital = 1987 # Hesse
+
+			c_hesse = {
+				color={ 173 173 160 }
+				color2={ 255 255 255 }
+
+				b_rotenburg_hesse = {}
+				b_hesse = {}
+				b_marburg = {}
+				b_wetzlar = {}
+				b_blankenstein = {}
+				b_merenberg = {}
+				b_gladenbach = {}
+				b_kirchhain = {}
+			}
+			c_nassau = {
+				color={ 171 171 171 }
+				color2={ 255 255 255 }
+			
+				b_nassau = {}
+				b_fritzlar = {}
+				b_fulda = {}
+				b_hersfeld = {}
+				b_falkenstein = {}
+				b_isenburg = {}
+				b_haerulfisfeld = {}
+			}
+			c_frankfurt = {
+				color={ 150 168 168 }
+				color2={ 255 255 255 }
+
+				b_frankfurt = {}
+				b_wiesbaden = {}
+				b_katzenelnbogen = {}
+				b_rheinfels = {}
+				b_st_goarshausen = {}
+				b_botisphaden = {}
+				b_dietigheim = {}
+			}
+		}
+		d_thuringia = {
+			color={ 207 206 226 }
+			color2={ 255 255 255 }
+		
+			capital = 255 #Thuringen
+			
+			c_thuringen = {
+				color={ 42 42 42 }
+				color2={ 255 255 255 }
+			
+				b_erfurt = {
+				}
+				b_muhlhausen = {
+				}
+				b_arnstadt = {
+				}
+				b_eichsfeld = {
+				}
+				b_reuss = {
+				}
+				b_salzungen = {
+				}
+				b_schmalkalden = {
+				}
+				b_henneberg = {
+				}
+			}
+			c_weimar = {
+				color={ 183 183 183 }
+				color2={ 255 255 255 }
+				
+				b_weimar = {
+				}
+				b_jena = {
+				}
+				b_walkenried = {
+				}
+				b_nordhausen = {
+				}
+				b_memelsen = {
+				}
+				b_gotha = {
+				}
+				b_apoldoa = {
+				}
+				b_gera = {
+				}
+			}
+		}
+		d_franconia = {
+			color={ 100 108 100 }
+			color2={ 255 255 255 }
+			
+			capital = 254 # Würzburg
+		
+			c_leiningen = {
+				color={ 126 126 126 }
+				color2={ 255 255 255 }
+			
+				b_aschaffenburg = {
+				}
+				b_leiningen = {
+				}
+				b_lorsch = {
+				}
+				b_durkheim = {
+				}
+				b_battenberg = {
+				}
+				b_hardenburg = {
+				}
+				b_ungstein = {
+				}
+				b_pfeffingen = {
+				}
+			}
+			c_wurzburg = {
+				color={ 123 123 123 }
+				color2={ 255 255 255 }
+			
+				b_wurzburg = {
+				}
+				b_schweinfurt = {
+				}
+				b_marienberg = {
+				}
+				b_hammelburg = {
+				}
+				b_schwarzenberg = {
+				}
+				b_theiheim = {
+				}
+				b_mainderheim = {
+				}
+			}
+			c_bamberg = {
+				color={ 120 120 120 }
+				color2={ 255 255 255 }
+			
+				b_ansbach = {
+				}
+				b_bamberg = {
+				}
+				b_babenberg = {
+				}
+				b_cadolzburg = {
+				}
+				b_colmberg = {
+				}
+				b_roth = {
+				}
+				b_crailsheim = {
+				}
+			}
+			c_rottenburg = {
+				color={ 125 125 105 }
+				color2={ 255 255 255 }
+
+				b_weinsberg = {}
+				b_weikersheim = {}
+				b_hohlach = {}
+				b_uffenheim = {}
+				b_rottenburg = {}
+				b_ochsenfurt = {}
+				b_weilerburg = {}
+			}
+		}
+		d_rhine = {
+			color={ 105 135 105 }
+			color2={ 255 255 255 }
+
+			capital = 123 # Mainz
+
+			c_pfalz = {
+				color={ 140 140 170 }
+				color2={ 255 255 255 }
+			
+				b_kaiserslautern = {
+				}
+				b_worms = {
+				}
+				b_hagenau = {
+				}
+				b_stahleck = {
+				}
+				b_trifels = {
+				}
+				b_speyer = {
+				}
+				b_zweibrucken = {
+				}
+			}
+			c_mainz = {
+				color={ 129 129 129 }
+				color2={ 255 255 255 }
+
+				b_mainz = {
+				}
+				b_eppstein = {
+				}
+				b_ingelheim = {
+				}
+				b_mannheim = {
+				}
+				b_weilburg = {
+				}
+				b_dornburg = {
+				}
+				b_hanau = {
+				}
+			}
+		}
+		d_baden = { 
+			color={ 115 109 109 }
+			color2={ 255 255 255 }
+			
+			capital = 125 #Baden
+		
+			c_baden = {
+				color={ 102 102 102 }
+				color2={ 255 255 255 }
+			
+				b_baden = {
+				}
+				b_karlsruhe = {
+				}
+				b_wimpfen = {
+				}
+				b_calw = {
+				}
+				b_pforzheim = {
+				}
+				b_durlach = {
+				}
+				b_rastatt = {
+				}
+				b_neuhausen = {
+				}
+			}
+			c_breisgau = {
+				color={ 105 94 105 }
+				color2={ 255 255 255 }
+		
+				b_freiburg = {
+				}
+				b_stblasien = {
+				}
+				b_offenburg = {
+				}
+				b_zahringen = {
+				}
+				b_lahr = {
+				}
+				b_lohrrach = {
+				}
+				b_breisach = {
+				}
+				b_rottweil = {
+				}
+			}
+		}
+		d_thurgau = {
+			color={ 180 220 203 }
+			color2={ 255 255 255 }
+
+			capital = 248 # Thurgau
+
+			allow = {
+				conditional_tooltip = {
+					trigger = {
+						d_thurgau = {
+							is_titular = yes
+						}
+					}
+
+					d_thurgau = {
+						is_titular = no
+					}
+				}
+			}
+			
+			c_zurichgau = {
+				color={ 95 70 75 }
+				color2={ 255 255 255 }
+				
+				b_zurich = {
+					german = "Zürich"
+					frankish = "Turic"
+					italian = "Turigo"
+				}
+				b_winterthur = {
+					frankish = "Wintertour"
+					italian = "Vinterduro"
+				}
+				b_swiss_baden = {
+				}
+				b_aarau = {
+				}
+				b_kappel = {
+					frankish = "Chapel"
+				}
+				b_kyburg = {
+					frankish = "Kybourg"
+				}
+				b_toggenburg = {
+				}
+				b_zug = {
+					frankish = "Zoug"
+				}
+				b_rapperswil = {
+				}
+			}
+			c_st_gallen = {
+				color={ 85 80 85 }
+				color2={ 255 255 255 }
+
+				frankish = "Thurgovie"
+				italian = "Turgovia"
+		
+				b_rheineck = {
+				}
+				b_stgallen = {
+					frankish = "St-Gall"
+					italian = "San Gallo"
+				}
+				b_appenzell = {
+				}
+				b_frauenfeld = {
+				}
+				b_altstatten = {
+				}
+				b_lichtensteig = {
+				}
+				b_vaduz = {
+				}
+				b_herisau = {
+				}
+			}
+		}
+		d_raetia = {
+			color={ 150 240 190 }
+			color2={ 255 255 255 }
+
+			capital = 247 # Chur
+
+			allow = {
+				conditional_tooltip = {
+					trigger = {
+						d_raetia = {
+							is_titular = yes
+						}
+					}
+
+					d_raetia = {
+						is_titular = no
+					}
+				}
+			}
+
+			german = "Churrätien"
+
+			c_chur = {
+				color={ 87 87 87 }
+				color2={ 255 255 255 }
+			
+				b_chur = {
+					frankish = "Coire"
+					italian = "Coira"
+				}
+				b_churwalden = {
+					frankish = "Coirvaud"
+					italian = "Curvalda"
+				}
+				b_davos = {
+					frankish = "Davos"
+					italian = "Tavate"
+				}
+				b_maienfeld = {
+					italian = "Maiavilla"
+					frankish = "Maieville"
+				}
+				b_illanz = {
+				}
+				b_thusis = {
+					frankish = "Thouson"
+					italian = "Tosana"
+				}
+				b_glurns = {
+					italian = "Glorenza"
+				}
+				b_zuoz = {
+					german = "Zutz"
+				}
+			}
+			c_schwyz = {
+				color={ 167 28 66 }
+				color2={ 255 255 255 }
+				
+				b_schwyz = {
+				}
+				b_engelberg = {
+				}
+				b_glarus = {
+					frankish = "Glaris"
+					italian = "Glarona"
+				}
+				b_altdorf = {
+				}
+				b_schanis = {
+				}
+				b_disentis = {
+					italian = "Mosteriou"
+					frankish = "Monstéry"
+				}
+				b_kussnacht = {
+					frankish = "Cossigny"
+					italian = "Cosenago"
+				}
+			}
+		}
+		d_swabia = {
+			color={ 206 203 203 }
+			color2={ 255 255 255 }
+			
+			capital = 249 #Schwaben
+			
+			c_schwaben = {
+				color={ 81 81 81 }
+				color2={ 255 255 255 }
+			
+				b_tubingen = {
+				}
+				b_konstanz = {
+				}
+				b_heiligenberg = {
+				}
+				b_uberlingen = {
+				}
+				b_hohenberg = {
+				}
+				b_friedrichshafen = {
+				}
+				b_wangen = {
+				}
+				b_lindau = {
+				}
+			}
+			c_ulm = {
+				color={ 78 78 78 }
+				color2={ 255 255 255 }
+			
+				b_ulm = {
+				}
+				b_zwiefalten = {
+				}
+				b_teck = {
+				}
+				b_biberach = {
+				}
+				b_memmingen = {
+				}
+				b_isny = {
+				}
+				b_goppingen = {
+				}
+				b_erbach = {
+				}
+			}
+			c_furstenberg = {
+				color={ 75 75 75 }
+				color2={ 255 255 255 }
+			
+				b_furstenberg = {
+				}
+				b_villingen = {
+				}
+				b_hirsau = {
+				}
+				b_baar = {
+				}
+				b_haslach = {
+				}
+				b_zollern = {
+				}
+				b_wolfach = {
+				}
+				b_donaueschingen = {
+				}
+			}
+			c_wurttemberg = {
+				color={ 72 72 72 }
+				color2={ 255 255 255 }
+			
+				b_stuttgart = {
+				}
+				b_heilbronn = {
+				}
+				b_reutlingen = {
+				}
+				b_waiblingen = {
+				}
+				b_esslingen = {
+				}
+				b_gmund = {
+				}
+				b_staufen = {
+				}
+				b_asperg = {
+				}
+			}
+			c_kempten = {
+				color={ 69 69 69 }
+				color2={ 255 255 255 }
+			
+				b_kempten = {
+				}
+				b_augsburg = {
+				}
+				b_zumarshausen = {
+				}
+				b_kaufbeuren = {
+				}
+				b_donauworth = {
+				}
+				b_friedberg = {
+				}
+				b_hochstadt = {
+				}
+				b_rain = {
+				}
+			}
+		}
+		d_alsace = { 
+			color={ 150 150 195 }
+			color2={ 255 255 255 }
+			
+			capital = 134 #Sundgau
+		
+			c_nordgau = {
+				color={ 160 160 210 }
+				color2={ 255 255 255 }
+			
+				b_egisheim = {
+				}
+				b_strassburg = {
+				}
+				b_lauterburg = {
+				}
+				b_selz = {
+				}
+				b_erstein = {
+				}
+				b_molsheim = {
+				}
+				b_brumath = {
+				}
+				b_schlettstadt = {
+				}
+			}
+			c_sundgau = {
+				color={ 152 152 197 }
+				color2={ 255 255 255 }
+			
+				b_ensisheim = {
+				}
+				b_kolmar = {
+				}
+				b_murbach = {
+				}
+				b_mulhouse = {
+				}
+				b_landser = {
+				}
+				b_thann = {
+				}
+				b_altkirch = {
+				}
+				b_ferette = {
+				}
+			}
+		}
+		d_mainz = {
+			color={ 129 129 129 }
+			color2={ 255 255 255 }
+
+			capital = 123 # Mainz
+
+			allow = {
+				is_theocracy = yes
+			}
+		}
+	}
+
+	k_franconia_otto = {
+		color={ 105 135 105 }
+		color2={ 255 255 255 }
+
+		capital = 254 # Würzburg
+	}
+
+	k_thuringia_otto = {
+		color={ 212 211 231 }
+		color2={ 255 255 255 }
+
+		capital = 255 # Thuringen
+	}
+
+	k_swabia_otto = {
+		color={ 173 186 255 }
+		color2={ 255 255 255 }
+
+		capital = 249 # Schwaben
+	}
+}
+
+e_roman_empire = {
+	color={ 143 12 100 }
+	color2={ 255 255 20 }
+	
+	capital = 333 # Rome
+	
+	short_name = yes
+	
+	purple_born_heirs = yes
+	
+	culture = roman
+	#religion = orthodox
+	
+	allow = {
+		always = no # Only created through special event
+	}
+}
+
+e_byzantium = {
+	color={ 143 12 125 }
+	color2={ 255 255 20 }
+	
+	capital = 496 # Byzantion
+	
+	short_name = yes
+	
+	title = "BASILEUS_TITLE"
+	title_female = "BASILEUS_TITLE_FEMALE"
+	
+	dignity = 10
+	
+	culture = greek
+	
+	has_top_de_jure_capital = yes
+	
+	purple_born_heirs = yes
+	
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				e_roman_empire = {
+					has_holder = yes
+				}
+			}
+			e_roman_empire = {
+				has_holder = no
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				e_latin_empire = {
+					has_holder = yes
+				}
+			}
+			e_latin_empire = {
+				has_holder = no
+			}
+		}
+		OR = {
+			religion = orthodox
+			religion_openly_hellenic_or_reformed_trigger = yes
+		}
+	}
+	
+	k_amalfi = {
+		color={ 140 200 230 }
+		capital = 935 # Amalfi
+
+		dignity = 20
+
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_amalfi = {
+						is_titular = yes
+					}
+				}
+				k_amalfi = {
+					is_titular = no
+				}
+			}
+			is_republic = yes
+		}
+	}
+
+	k_cyprus = {
+		color = { 85 138 236 }
+		capital = 757 # Famagusta
+		hellenic_pagan_reformed = 500 # Crusade target weight
+
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_cyprus = {
+						is_titular = yes
+					}
+				}
+				k_cyprus = {
+					is_titular = no
+				}
+			}
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = christian
+				}
+			}	
+		}
+	}
+
+	k_saruhan = {
+		color = { 144 171 225 }
+		culture = turkish
+	}
+	
+	k_trinacria = {
+		color={ 249 232 247 }
+		capital = 340 #	Palermo
+	
+		allow = {
+			OR = {
+				religion = catholic
+				is_heresy_of = catholic
+			}
+			conditional_tooltip = {
+				trigger = {
+					FROM = {
+						NOT = {
+							any_previous_holder = {
+								always = yes # The title has existed before
+							}
+						}
+					}
+				}
+				FROM = {
+					any_previous_holder = {
+						always = yes # The title has existed before
+					}
+				}
+			}
+		}
+	}
+	
+	k_tekke = {
+		color={ 244 153 189 }
+	}
+
+	k_ottoman = {
+		color = { 247 145 30 }
+		culture = turkish
+	}
+
+	k_rum = {
+		color = { 144 182 161 }
+		culture = turkish
+		dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	}
+
+	k_mentese = {
+		color = { 60 130 20 }
+		culture = turkish
+	}
+
+	k_karaman = {
+		color = { 120 41 92 }
+		culture = turkish
+	}
+
+	k_germiyan = {
+		color = { 255 180 180 }
+	}
+
+	k_eretnid = {
+		color = { 253 182 182 }
+	}
+	
+	k_aydin = {
+		color = { 238 43 172 }
+	}
+
+	k_candar = {
+		color = { 238 79 182 }
+		culture = turkish
+	}
+	
+	k_trebizond = {
+		color={ 100 151 33 }
+		capital = 678 # Trapezous
+		culture = greek
+		
+		orthodox = 1000 # Crusade target weight
+		hellenic_pagan_reformed = 5000 # Crusade target weight
+		
+		d_trebizond = {
+			color={ 125 160 30 }
+			color2={ 255 255 255 }
+			
+			capital = 678 # Trepezous
+			
+			dignity = 7
+			
+			c_theodosiopolis = {
+				color={ 140 50 100 }
+				color2={ 255 255 255 }
+				
+				b_theodosiopolis = {
+				}
+				b_argyropolis = {
+				}
+				b_citharizum = {
+				}
+				b_satala = {
+				}
+				b_thera = {
+				}
+				b_oukhiti = {
+				}
+				b_askale = {
+				}
+				b_tortum = {
+				}
+			}
+			c_trapezous = {
+				color={ 149 70 110 }
+				color2={ 255 255 255 }
+				
+				b_trapezous = {
+				}
+				b_koralla = {
+				}
+				b_rizaion = {
+				}
+				b_paiperta = {
+				}
+				b_rizini = {
+				}
+				b_alucra = {
+				}
+				b_kelkit = {
+				}
+				b_dereli = {
+				}
+			}
+			c_chaldea = {
+				color={ 159 50 90 }
+				color2={ 255 255 255 }
+				
+				b_kerasous = {
+				}
+				b_cotyora = {
+				}
+				b_camachus = {
+				}
+				b_ibora = {
+				}
+				b_podandos = {
+				}
+				b_tilgarimo = {
+				}
+				b_heracleopolis = {
+				}
+			}
+		}
+		
+		d_armeniacon = {
+			color={ 125 190 75 }
+			color2={ 255 255 20 }
+			
+			capital = 738 # Amisos
+			
+			c_amisos = {
+				color={ 255 2 169 }
+				color2={ 255 255 20 }
+				
+				turkish = "Amasya"
+				
+				b_amisos = {
+				}
+				b_amasia = {
+					turkish = "Amasya"
+				}
+				b_thermodon = {
+				}
+				b_eupatoria = {
+				}
+				b_neokaisarea = {
+				}
+				b_phadisane = {
+				}
+				b_phazimonitis = {}
+			}
+			c_sinope = {
+				color={ 255 4 171 }
+				color2={ 255 255 20 }
+				
+				b_sinope = {}
+				b_talaura = {}
+				b_themiscyra = {}
+				b_carusus = {}
+				b_laodicea_sinope = {}
+				b_halys_sinope = {}
+				b_andrapa = {}
+			}
+		}
+
+		d_paphlagonia = {
+			color={ 230 180 98 }
+			color2={ 255 255 20 }
+			
+			capital = 751 # Paphlagonia
+			
+			c_paphlagonia = {
+				color={ 231 74 177 }
+				color2={ 255 255 20 }
+				
+				turkish = "Kastamonu"
+				
+				b_anastasiopolis = {
+				}
+				b_gangra = {
+				}
+				b_safranbolu = {
+				}
+				b_cabira = {
+				}
+				b_bolu = {
+				}
+				b_zaliscus = {
+				}
+				b_leontopolis = {
+				}
+			}
+			c_amastris = {
+				color={ 210 60 190 }
+				color2={ 255 255 20 }
+
+				b_amasra = {}
+				b_amastris = {}
+				b_cyttoros = {}
+				b_tium = {}
+				b_tieion = {}
+				b_sesamus = {}
+				b_cromna = {}
+			}
+			c_kastamon = {
+				color={ 190 70 180 }
+				color2={ 255 255 20 }
+
+				b_kastamon = {}
+				b_pompeiopolis = {}
+				b_germanicopolis = {}
+				b_aboniteichos = {}
+				b_ionopolis = {}
+				b_olgassys = {}
+				b_abonon = {}
+			}
+		}
+	}
+	
+	k_thrace = {
+		color={ 120 50 120 }
+		color2={ 255 255 23 }
+
+		capital = 496 # Constantinople
+
+		culture = greek
+
+		roman = "Thracia"
+
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = byzantine
+				}
+			}
+		}
+
+		orthodox = 5000 # Crusade target weight
+		catholic = 2000 # Crusade target weight
+		hellenic_pagan_reformed = 5000 # Crusade target weight
+
+		d_optimatoi = {
+			color={ 225 90 190 }
+			color2={ 255 255 20 }
+
+			capital = 741 # Nikomedia
+
+			turkish = "Izmit"
+
+			c_nikomedeia = {
+				color={ 208 107 173 }
+				color2={ 255 255 20 }
+				
+				turkish = "Izmit"
+				
+				b_nikomedeia = {
+					turkish = "Izmit"
+				}
+				b_chalkedon = {
+				}
+				b_chrysopolis = {
+				} 
+				b_praenetos = {
+				}
+				b_palodes = {
+				}
+				b_adapazari = {
+					greek = "Mesonesion"
+				}
+				b_malagina = {
+				}
+			}
+
+			c_herakleia = {
+				color={ 235 78 181 }
+				color2={ 255 255 20 }
+				
+				turkish = "Eregli"
+				
+				b_herakleia = {
+					turkish = "Eregli"
+				}
+				b_flaviopolis = {
+				}
+				b_polis = {
+				}
+				b_zephyropoli = {
+				}
+				b_amastrine = {
+				}
+				b_calpe = {
+				}
+				b_mariandyni = {}
+			}
+		}
+
+		d_abydos = {
+			color={ 210 140 170 }
+			color2={ 255 255 20 }
+
+			capital = 744 # Abydos
+
+			turkish = "Balakhisar"
+
+			c_abydos = {
+				color={ 147 55 115 }
+				color2={ 255 255 20 }
+				
+				turkish = "Balakhisar"
+				
+				b_abydos = {
+					turkish = "Balakhisar"
+				}
+				b_lampsakos = {
+				}
+				b_alexandriatroas = {
+				}
+				b_pigai = {
+				}
+				b_aegae = {
+				}
+				b_allianoi = {
+				}
+				b_cebrene = {
+				}
+				b_elaia = {
+				}
+			}
+			c_kyzikos = {
+				color={ 214 113 179 }
+				color2={ 255 255 20 }
+				
+				turkish = "Erdek"
+				
+				b_kyzikos = {
+					turkish = "Aydincik"
+				}
+				b_artake = {
+					turkish = "Erdek"
+				}
+				b_militopolis = {
+				}
+				b_kremasti = {
+				}
+				b_adrianutherai = {
+				}
+				b_myrina = {
+				}
+				b_percote = {
+				}
+				b_arisbe = {
+				}
+			}
+			c_lesbos = {
+				color={ 153 61 121 }
+				color2={ 255 255 20 }
+				
+				turkish = "Midilli"
+				
+				b_mytilene = {
+					turkish = "Midilli"
+				}
+				b_mithymna = {
+				}
+				b_plomari = {
+				}
+				b_agiasos = {
+				}
+				b_eresos = {
+				}
+				b_kalloni = {
+				}
+				b_thasos = {
+				}
+				b_moudros = {
+				}
+			}
+		}
+		
+		d_thrace = {
+			color={ 172 76 139 }
+			color2={ 255 255 20 }
+			
+			capital = 496 # Byzantion
+
+			roman = "Thracia"
+			
+			orthodox = 250 # Crusade target weight
+			catholic = 125 # Crusade target weight
+			muslim = 100 # Crusade target weight
+			
+			c_kaliopolis = {
+				color={ 176 80 143 }
+				color2={ 255 255 20 }
+				
+				turkish = "Gelibolu"
+				
+				b_gallipoli = {
+					turkish = "Gelibolu"
+					greek = "Kallipolis"
+				}
+				b_heraclea = {
+				}
+				b_madyta = {
+				}
+				b_rhaidestos = {
+				}
+				b_panidos = {
+				}
+				b_selymbria = {
+				}
+				b_lysimachia = {
+				}
+				b_sestus = {
+				}
+			}
+			c_byzantion = {
+				color={ 180 84 147 }
+				color2={ 255 255 20 }
+				
+				orthodox = 500 # Crusade target weight
+				catholic = 250 # Crusade target weight
+				muslim = 250 # Crusade target weight
+				
+				top_de_jure_capital = yes
+
+				holy_site = orthodox
+				
+				turkish = "Kostantiniyye"
+				
+				b_constantinople = {
+					turkish = "Kostantiniyye"
+				}
+				b_hagiasophia = {
+					pentarchy = yes
+					turkish = "Ayasofya"
+				}
+				b_galata = {
+				}
+				b_blachernae = {
+					turkish = "Ayvansaray"
+				}
+				b_hieron = {
+					turkish = "Kadiköy"
+				}
+				b_deuteron = {
+					turkish = "Topkapi"
+				}
+				b_pempton = {
+				}
+				b_vlanga = {
+				}
+			}
+			c_thrake = {
+				color={ 184 88 151 }
+				color2={ 255 255 20 }
+				
+				turkish = "Trakya"
+				
+				b_verissa = {
+				}
+				b_sestos = {
+				}
+				b_chariopolis = {
+				}
+				b_syrallum = {
+				}
+				b_salmydessus = {
+				}
+				b_deleus = {
+				}
+				b_aulaeitichus = {
+				}
+				b_phinopolis = {
+				}
+			}
+		}
+		
+		d_adrianopolis = {
+			color={ 213 74 165 }
+			color2={ 255 255 20 }
+			
+			capital = 494 # Adrianopolis
+			
+			c_adrianopolis = {
+				color={ 216 77 168 }
+				color2={ 255 255 20 }
+				
+				turkish = "Edirne"
+				
+				b_adrianopolis = {
+					turkish = "Edirne"
+				}
+				b_didymoteichon = {}
+				b_skalothe = {}
+				b_berat = {}
+				b_kypsela = {}
+				b_demotika = {}
+				b_orestias = {}
+			}
+			c_philippopolis = {
+				color={ 219 80 171 }
+				color2={ 255 255 20 }
+				
+				turkish = "Filibe"
+				
+				b_philippopolis = {
+					turkish = "Filibe"
+				}
+				b_klokoknitsa = {}
+				b_prodromos = {}
+				b_stenimachos = {}
+				b_petrich = {}
+				b_bachkovo = {}
+				b_haskovo = {}
+			}
+			c_traianopolis = {
+				color={ 220 50 170 }
+				color2={ 255 255 20 }
+
+				b_traianopolis = {}
+				b_cypsela = {}
+				b_samothrace = {}
+				b_feres = {}
+				b_evros = {}
+				b_tychero = {}
+				b_ainos = {}
+			}
+			c_maroneia = {
+				color={ 240 50 180 }
+				color2={ 255 255 20 }
+
+				b_maroneia = {}
+				b_xantheia = {}
+				b_mosynopolis = {}
+				b_komotini = {}
+				b_peritheorion = {}
+				b_anaktoropolis = {}
+				b_polystylon = {}
+			}
+		}
+	}
+
+	k_byzantium = {
+		color={ 135 30 125 }
+		color2={ 255 255 23 }
+		
+		capital = 490 # Thessalonike
+		
+		culture = greek
+		
+		# Creation/Usurp Trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture = greek
+				}
+			}
+		}
+		
+		orthodox = 5000 # Crusade target weight
+		catholic = 2000 # Crusade target weight
+		hellenic_pagan_reformed = 5000 # Crusade target weight
+		
+		d_thessalonika = {
+			color={ 189 19 130 }
+			color2={ 255 255 20 }
+			
+			capital = 490 # Thessalonike
+			
+			c_chalkidike = {
+				color={ 192 22 133 }
+				color2={ 255 255 20 }
+
+				holy_site = orthodox
+				
+				b_mntathos = {}
+				b_chrysiopolis = {}
+				b_zicna = {}
+				b_polygyros = {}
+				b_sithonia = {}
+				b_pallene = {}
+				b_crusis = {}
+			}
+			c_thessalonike = {
+				color={ 195 25 136 }
+				color2={ 255 255 20 }
+				
+				turkish = "Salonika"
+
+				holy_site = hellenic_pagan
+				holy_site = hellenic_pagan_reformed
+				
+				b_thessaloniki = {
+					turkish = "Salonika"
+				}
+				b_thesedessa = {
+				}
+				b_voden = {
+				}
+				b_hlerin = {
+				}
+				b_cemren = {
+				}
+				b_veria = {
+				}
+				b_elasson = {
+				}
+				b_servia = {
+				}
+			}
+			c_seres = {
+				color={ 200 20 130 }
+				color2={ 255 255 255 }
+
+				b_seres = {}
+				b_philippi = {}
+				b_siderokastron = {}
+				b_melnik = {}
+				b_drama = {}
+				b_christoupolis = {}
+				b_bisaltia = {}
+			}
+		}
+		
+		d_athens = {
+			color={ 206 66 158 }
+			color2={ 255 255 20 }
+			
+			capital = 475 # Thebes
+			
+			c_demetrias = {
+				color={ 209 69 161 }
+				color2={ 255 255 20 }
+				
+				b_lebadea = {
+				}
+				b_neopatras = {
+				}
+				b_boudonitza = {
+				}
+				b_demetrias = {
+				}
+				b_ravennika = {
+				}
+				b_gravia = {
+				}
+				b_pharsalus = {}
+			}
+			c_hellas = {
+				color={ 212 72 164 }
+				color2={ 255 255 20 }
+				
+				b_thebes = {}
+				b_amphissa = {}
+				b_kastrinitsi = {}
+				b_markrynia = {}
+				b_amfissa = {}
+				b_itea = {}
+				b_levadhia = {}
+			}
+			c_thessalia = {
+				color={ 198 28 139 }
+				color2={ 255 255 20 }
+				
+				turkish = "Tesalya"
+				
+				b_larissa = {
+					turkish = "Yenisehir i-Fenari"
+				}
+				b_volos = {
+				}
+				b_neopetra = {
+				}
+				b_damasis = {
+				}
+				b_kastri = {
+				}
+				b_pharsalos = {
+				}
+				b_trikkala = {
+				}
+				b_stagi = {
+				}
+			}
+			c_atheniai = {
+				color={ 215 75 167 }
+				color2={ 255 255 20 }
+
+				holy_site = hellenic_pagan
+				holy_site = hellenic_pagan_reformed
+				
+				b_athens = {
+				}
+				b_piraeaus = {
+				}
+				b_megara = {
+				}
+				b_soula = {
+				}
+				b_daphni = {
+				}
+				b_karydi = {
+				}
+				b_salamis = {
+				}
+				b_marathon = {
+				}
+			}
+		}
+		
+		d_achaia = {
+			color={ 190 29 134 }
+			color2={ 255 255 20 }
+			
+			capital = 481 # Korinthos
+			
+			c_achaia = {
+				color={ 192 31 136 }
+				color2={ 255 255 20 }
+				
+				b_patras = {
+				}
+				b_pyrgos = {
+				}
+				b_andravida = {
+				}
+				b_kalavryta = {
+				}
+				b_akova = {
+				}
+				b_chalandritza = {
+				}
+				b_karditza = {
+				}
+				b_geraki = {
+				}
+			}
+			c_korinthos = {
+				color={ 194 33 138 }
+				color2={ 255 255 20 }
+				
+				b_corinth = {
+				}
+				b_nauplion = {
+				}
+				b_argos = {
+				}
+				b_passava = {
+				}
+				b_vostitza = {
+				}
+				b_zemenos = {
+				}
+				b_veligosti = {
+				}
+				b_megapoli = {
+				}
+			}
+			c_methone = {
+				color={ 196 35 140 }
+				color2={ 255 255 20 }
+				
+				b_modon = {
+					greek = "Methone"
+					italian = "Modone"
+				}
+				b_kiparissia = {
+				}
+				b_kalamata = {
+				}
+				b_coron = {
+				}
+				b_karytaina = {
+				}
+				b_gritzena = {
+				}
+				b_pilos = {
+				}
+				b_androusa = {
+				}
+			}
+			c_monemvasia = {
+				color={ 198 37 142 }
+				color2={ 255 255 20 }
+				
+				b_monemvasia = {
+				}
+				b_mistra = {
+				}
+				b_arkadia = {
+				}
+				b_nikli = {
+				}
+				b_sparta = {
+				}
+				b_lacedaemonia = {
+				}
+				b_gythio = {
+				}
+				b_elos = {
+				}
+			}
+		}
+		
+		d_aegean_islands = {
+			color={ 104 8 103 }
+			color2={ 255 255 20 }
+			
+			capital = 484 # Naxos
+			
+			c_naxos = {
+				color={ 149 57 117 }
+				color2={ 255 255 20 }
+				
+				turkish = "Kiklad"
+				italian = "Egeopelagi"
+				
+				b_naxos = {
+					turkish = "Naksa"
+					italian = "Nasso"
+				}
+				b_hermoupolis = {
+					turkish = "Sire"
+					italian = "Syra"
+				}
+				b_santorini = {
+					greek = "Thera"
+					turkish = "Santoron"
+				}
+				b_andros = {
+				}
+				b_tinos = {
+				}
+				b_mykonos = {
+				}
+				b_kastraki = {
+				}
+				b_filoti = {
+				}
+			}
+			c_euboia = {
+				color={ 151 59 119 }
+				color2={ 255 255 20 }
+				
+				italian = "Negroponte"
+				turkish = "Egriboz"
+				
+				b_chalkis = {
+					italian = "Negroponte"
+					turkish = "Egriboz"
+				}
+				b_kymi = {
+				}
+				b_karystos = {
+				}
+				b_oreoi = {
+				}
+				b_artemisio = {
+				}
+				b_istiaia = {
+				}
+				b_lilantia = {
+				}
+				b_messapia = {
+				}
+			}
+		}
+		
+		d_krete = {
+			color={ 205 110 35 }
+			color2={ 255 255 20 }
+			
+			capital = 480 # Chandax
+			
+			c_kaneia = {
+				color={ 178 11 120 }
+				color2={ 255 255 20 }
+				
+				bedouin_arabic = "Al-Hanim"
+				maghreb_arabic = "Al-Hanim"
+				levantine_arabic = "Al-Hanim"
+				egyptian_arabic = "Al-Hanim"
+				andalusian_arabic = "Al-Hanim"
+				turkish = "Hanya"
+				
+				b_kandia = {
+					bedouin_arabic = "Al-Hanim"
+					maghreb_arabic = "Al-Hanim"
+					levantine_arabic = "Al-Hanim"
+					egyptian_arabic = "Al-Hanim"
+					andalusian_arabic = "Al-Hanim"
+					turkish = "Hanya"
+				}
+				b_rethymno = {
+				}
+				b_matala = {
+				}
+				b_kastellikissamos = {
+				}
+				b_paleohora = {
+				}
+				b_akrotin = {
+				}
+				b_nikiforosfokas = {
+				}
+				b_arkadi = {
+				}
+			}
+			c_chandax = {
+				color={ 182 15 124 }
+				color2={ 255 255 20 }
+				
+				greek = Gortyn
+				italian = Gortyn
+				
+				b_iraklio = {
+					greek = "Gortyn"
+					italian = "Candia"
+					turkish = "Kandiye"
+					maghreb_arabic = "Khandaq"
+					levantine_arabic = "Khandaq"
+					egyptian_arabic = "Khandaq"
+					bedouin_arabic = "Khandaq"
+					andalusian_arabic = "Khandaq"
+				}
+				b_agiosnikolaos = {
+				}
+				b_lassithi = {
+				}
+				b_malia = {
+				}
+				b_kastelli = {
+				}
+				b_sitia = {
+				}
+				b_ierapetra = {
+				}
+				b_knossos = {
+				}
+			}
+		}
+	}
+
+	k_epirus = {
+		color={ 150 40 60 }
+		color2={ 255 255 20 }
+
+		capital = 472 # Epieros
+		
+		#serbian = "Draugabitia"
+		hellenic_pagan_reformed = 2000 # Crusade target weight
+
+		d_ohrid = {
+			color={ 150 30 70 }
+			color2={ 255 255 20 }
+
+			capital = 471
+
+			greek = "Lychnidos"
+			arberian = "Ohri"
+
+			c_ochrid = {
+				color={ 141 31 103 }
+				color2={ 255 255 20 }
+				
+				greek = "Lychnidos"
+				arberian = "Ohri"
+				
+				b_debar = {
+				}
+				b_ohrid = {
+					greek = "Lychnidos"
+					arberian = "Ohri"
+				}
+				b_kicevo = {
+				}
+				b_svetigrad = {
+				}
+				b_tomot = {
+				}
+				b_krusevo = {
+				}
+				b_struga = {
+				}
+			}
+			c_kastoria = {
+				color={ 120 20 103 }
+				color2={ 255 255 20 }
+
+				arberian = "Kostur"
+				serbian = "Kostur"
+				bulgarian = "Kostur"
+				turkish = "Kesriye"
+
+				b_kastoria = {}
+				b_chlerinon = {}
+				b_kailara = {}
+				b_argos_orestikon = {}
+				b_orestis = {}
+				b_eordaia = {}
+				b_mesopotamia_kastoria = {}
+			}
+			c_lyncestis = {
+				color={ 130 25 103 }
+				color2={ 255 255 20 }
+
+				b_bitola = {}
+				b_lyncestis = {}
+				b_heraclea_lyncestis = {}
+				b_neoljani = {}
+				b_magarevo = {}
+				b_prilap = {
+					greek = "Styberra"
+				}
+				b_pelagonia = {}
+			}
+		}
+
+		d_dyrrachion = {
+			color={ 137 27 99 }
+			color2={ 255 255 20 }
+			
+			capital = 470 # Dyrrachion
+
+			arberian = "Arbanon"
+			
+			c_dyrrachion = {
+				color={ 143 33 105 }
+				color2={ 255 255 20 }
+				
+				italian = "Durazzo"
+				serbian = "Drac"
+				bulgarian = "Drach"
+				arberian = "Arbanon"
+				
+				b_durazzo = {
+					greek = "Dyrrhachion"
+					italian = "Durazzo"
+				}
+				b_chounavia = {
+				}
+				b_kruje = {
+					greek = Krougia
+				}
+				b_elbasan = {
+				}
+				b_geziq = {
+				}
+				b_beat = {
+				}
+				b_petrela = {}
+			}
+			c_aulon = {
+				color={ 135 40 120 }
+				color2={ 255 255 20 }
+
+				arberian = "Savra"
+
+				b_aulon = {}
+				b_spinarizza = {}
+				b_kanine = {}
+				b_himara = {}
+				b_sopot_aulon = {}
+				b_berat_aulon = {}
+				b_saranda = {}
+			}
+		}
+		
+		d_epirus = {
+			color={ 134 63 109 }
+			color2={ 255 255 20 }
+			
+			capital = 473 # Arta
+			
+			c_epeiros = {
+				color={ 138 67 113 }
+				color2={ 255 255 20 }
+				
+				b_butrint = {
+					greek = "Bouthroton"
+				}
+				b_paramythia = {
+				}
+				b_ioannina = {
+				}
+				b_sopot = {
+					greek = "Koritsa"
+				}
+				b_pogonia = {
+				}
+				b_gjirokaster = {
+					greek = Argyrokastron
+				}
+				b_igoumenitsa = {
+				}
+				b_sagiada = {
+				}
+			}
+			c_arta = {
+				color={ 142 71 117 }
+				color2={ 255 255 20 }
+				
+				b_preveza = {
+				}
+				b_angelokastron = {
+				}
+				b_arta = {
+				}
+				b_agnanta = {
+				}
+				b_thomokastron = {
+				}
+				b_vonitsza = {
+				}
+				b_vlacherna = {
+				}
+				b_rogoi = {
+				}
+			}
+			c_naupactus = {
+				color={ 154 79 125 }
+				color2={ 255 255 20 }
+
+				b_naupaktos = {}
+				b_paravola = {}
+				b_agrinio = {}
+				b_mesolongi = {}
+				b_lidoriki = {}
+				b_alyzeia = {}
+				b_sollion = {}
+			}
+		}
+		d_cephalonia = {
+			color={ 222 155 155 }
+			color2={ 255 255 20 }
+
+			capital = 474
+
+			c_cephalonia = {
+				color={ 146 75 121 }
+				color2={ 255 255 20 }
+				
+				turkish = "Iyonya"
+				
+				b_lefkas = {
+					turkish = "Ayamavra"
+				}
+				b_palaiofrourio = {
+				}
+				b_kefalonia = {
+				}
+				b_paxos = {
+					italian = "Passo"
+					turkish = "Paksa"
+				}
+				b_ithaca = {
+					turkish = "Fiaki"
+				}
+				b_cerigo = {
+					turkish = "Çuha"
+				}
+				b_atros = {
+				}
+			}
+			c_zakynthos = {
+				color={ 150 70 130 }
+				color2={ 255 255 20 }
+
+				b_zakynthos = {}
+				b_strofadia = {}
+				b_navagio = {}
+				b_katastari = {}
+				b_kiliomenos = {}
+				b_volimes = {}
+				b_alikanas = {}
+			}
+			c_corfu = {
+				color={ 156 65 140 }
+				color2={ 255 255 20 }
+
+				b_korkyra = {}
+				b_corfu = {}
+				b_scheria = {}
+				b_phaeacia = {}
+				b_drepane = {}
+				b_taphos = {}
+				b_acinganorum = {}
+			}
+		}
+	}
+	
+	k_anatolia = {
+		color={ 177 60 100 }
+		color2={ 255 255 23 }
+		
+		capital = 759 # Ikonion
+		
+		culture = greek
+		
+		orthodox = 300 # Crusade target weight
+		catholic = 75 # Crusade target weight
+		muslim = 100 # Crusade target weight
+		
+		d_nikaea = {
+			color={ 202 101 167 }
+			color2={ 255 255 20 }
+			
+			capital = 750 # Nikaea
+
+			turkish = "Iznik"
+			
+			c_nikaea = {
+				color={ 205 104 170 }
+				color2={ 255 255 20 }
+				
+				turkish = "Iznik"
+				
+				b_nikaea = {
+					turkish = "Iznik"
+				}
+				b_kios = {
+				}
+				b_optimatum = {
+				}
+				b_kotyaion = {
+				}
+				b_palaeokastron = {
+				}
+				b_yalova = {
+				}
+				b_modrene = {
+				}
+			}
+			c_prusa = {
+				color={ 211 110 176 }
+				color2={ 255 255 20 }
+				
+				turkish = "Bursa"
+				
+				b_prusa = {
+					turkish = "Hüdavendigar"
+				}
+				b_darieium = {
+					greek = "Dorieion"
+					turkish = "Sögüt"
+				}
+				b_apamea = {
+					greek = "Trigleia"
+					turkish = "Tirilye"
+				}
+				b_docimium = {
+					greek = "Dokimeion"
+					turkish = "Iscehisar"
+				}
+				b_adrastea = {
+				}
+				b_thyatira = {
+				}
+				b_pelopia = {
+				}
+				b_miletopolis = {
+				}
+			}
+			c_dorylaion = {
+				color={ 176 25 124 }
+				color2={ 255 255 20 }
+				
+				turkish = "Kütahya"
+				
+				b_dorylaion = {
+					turkish = "Eskisehir"
+				}
+				b_kotiaion = {
+					turkish = "Kütahya"
+				}
+				b_orkistos = {
+				}
+				b_iustinianopolis = {
+				}
+				b_carura = {
+				}
+				b_germia = {
+				}
+				b_naeotea = {}
+			}
+		}
+
+		d_samos = {
+			color={ 115 55 100 }
+			color2={ 255 255 20 }
+			
+			capital = 486 # Samos
+			
+			c_ephesos = {
+				color={ 237 42 171 }
+				color2={ 255 255 20 }
+				
+				turkish = "Ayasoluk"
+
+				holy_site = orthodox
+				
+				b_ephesos = {
+					turkish = "Ayasoluk"
+				}
+				b_lebedos = {
+				}
+				b_miletos = {
+				}
+				b_tralles = {
+				}
+				b_iassos = {
+				}
+				b_palation = {
+				}
+				b_petron = {
+				}
+			}
+			c_smyrna = {
+				color={ 240 45 174 }
+				color2={ 255 255 20 }
+				
+				turkish = "Izmir"
+				
+				b_smyrna = {
+					turkish = "Izmir"
+				}
+				b_pergamon = {
+				}
+				b_phokaia = {
+				}
+				b_adramyttion = {
+				}
+				b_chio = {
+				}
+				b_klazomeanai = {
+				}
+				b_kydonia = {
+				}
+				b_erythrai = {
+				}
+			}
+			c_chios = {
+				color={ 243 48 177 }
+				color2={ 255 255 20 }
+				
+				turkish = "Sisam"
+				
+				b_samos = {
+					turkish = "Sisam"
+				}
+				b_chios = {
+					turkish = "Sakiz"
+				}
+				b_tigani = {
+				}
+				b_marathokampos = {
+				}
+				b_ikaria = {
+				}
+				b_fourni = {
+				}
+				b_chrysostomos = {
+				}
+				b_pagondas = {
+				}
+			}
+		}
+		
+		d_cibyrrhaeot = {
+			color={ 108 29 80 }
+			color2={ 255 255 20 }
+			
+			capital = 755 # Attaleia
+			
+			c_attaleia = {
+				color={ 112 33 84 }
+				color2={ 255 255 20 }
+				
+				turkish = "Antalya"
+				
+				b_attaleia = {
+					turkish = "Antalya"
+				}
+				b_cibyra = {
+				}
+				b_side = {
+				}
+				b_slege = {
+				}
+				b_sagalassos = {
+				}
+				b_galanauros = {
+				}
+				b_panemotichus = {
+				}
+				b_sillyon = {
+				}
+			}
+			c_rhodos = {
+				color={ 116 37 88 }
+				color2={ 255 255 20 }
+				
+				b_rhodos = {
+				}
+				b_lindos = {
+				}
+				b_kos = {
+				}
+				b_karpathos = {
+				}
+				b_pefkos = {
+				}
+				b_ialysos = {
+				}
+				b_haraki = {
+				}
+				b_koskinou = {
+				}
+			}
+			c_lykia = {
+				color={ 120 41 92 }
+				color2={ 255 255 20 }
+				
+				turkish = "Mugla"
+				
+				b_halikarnassos = {
+					turkish = "Bodrum"
+				}
+				b_myra = {
+				}
+				b_telmissos = {
+					turkish = "Mugla"
+				}
+				b_kibyra = {
+				}
+				b_patara = {
+				}
+				b_mylasa = {
+					turkish = "Milas"
+				}
+				b_limyra = {
+				}
+				b_phaselis = {
+				}
+			}
+		}
+		
+		d_anatolia = {
+			color={ 174 23 122 }
+			color2={ 255 255 20 }
+			
+			capital = 759 # Ikonion
+			
+			c_ikonion = {
+				color={ 178 27 126 }
+				color2={ 255 255 20 }
+				
+				turkish = "Konya"
+				
+				b_ikonion = {
+					turkish = "Konya"
+				}
+				b_lisdra = {
+				}
+				b_gaspadale = {
+				}
+				b_isauria = {
+				}
+				b_laranda = {
+				}
+				b_terpe = {
+				}
+				b_amblada = {
+				}
+				b_sauatra = {
+				}
+			}
+			c_akroinon = {
+				color={ 170 30 140 }
+				color2={ 255 255 20 }
+
+				turkish = "Kara Hissar"
+
+				b_akroinon = {}
+				b_nikopolis_akroinon = {}
+				b_antiochia_akroinon = {}
+				b_celenaea = {}
+				b_seleucia_akroinon = {}
+				b_eumenia = {}
+				b_apamea_akroinon = {}
+			}
+			c_amorion = {
+				color={ 150 40 150 }
+				color2={ 255 255 20 }
+
+				b_amorion = {}
+				b_polybotos = {}
+				b_krasos = {}
+				b_philomelion = {}
+				b_synnada = {}
+				b_salutaris = {}
+				b_docimium_amorion = {}
+			}
+		}
+		
+		d_thracesia = {
+			color={ 154 43 116 }
+			color2={ 255 255 20 }
+			
+			capital = 748 # Laodikeia
+			
+			c_sozopolis = {
+				color={ 158 47 120 }
+				color2={ 255 255 20 }
+				
+				turkish = "Isparta"
+				
+				b_souzopolis = {
+					turkish = "Afyonkarahisar"
+				}
+				b_cadi = {
+				}
+				b_polidorion = {
+				}
+				b_kelainai = {
+				}
+				b_dinar = {
+				}
+				b_isparta = {
+					greek = "Baris"
+				}
+				b_colossae = {}
+			}
+			c_laodikeia = {
+				color={ 162 51 124 }
+				color2={ 255 255 20 }
+				
+				turkish = "Alasehir"
+				
+				b_laodikeia = {
+				}
+				b_rhoas = {
+				}
+				b_hieropolis = {
+				}
+				b_kona = {
+				}
+				b_gordes = {
+				}
+				b_flaviupolis = {
+				}
+				b_chonai = {}
+			}
+			c_sardis = {
+				color={ 164 55 110 }
+				color2={ 255 255 20 }
+
+				greek = "Sardeis"
+
+				b_sardis = {
+					greek = "Sardeis"
+				}
+				b_philadelphia = {
+					turkish = "Alasehir"
+				}
+				b_magnesia = {}
+				b_hermus = {}
+				b_aezani = {}
+				b_macentus = {}
+				b_maeander = {}
+			}
+		}
+		
+		d_charsianon = {
+			color={ 237 58 198 }
+			color2={ 255 255 20 }
+			
+			capital = 737 # Kaisereia
+
+			roman = "Galatia"
+			
+			c_charsianon = {
+				color={ 230 80 170 }
+				color2={ 255 255 20 }
+
+				b_charsianon = {}
+				b_sebastea = {
+					armenian = "Sebasta"
+					greek = "Sebasteia"
+					turkish = "Sivas"
+				}
+				b_dazimon = {}
+				b_sebastopolis = {}
+				b_comana_charsianon = {}
+				b_mazaca = {}
+				b_zela = {}
+			}
+			c_kaisereia = {
+				color={ 240 71 181 }
+				color2={ 255 255 20 }
+				
+				turkish = Kayseri
+				
+				b_kaisereia = {
+					turkish = Kayseri
+				}
+				b_misti = {
+				}
+				b_talas = {
+				}
+				b_sariz = {
+				}
+				b_masaka = {
+				}
+				b_dobada = {
+				}
+				b_venessa = {
+				}
+				b_zoropassos = {
+				}
+			}
+			c_galatia = {
+				color={ 243 74 184 }
+				color2={ 255 255 20 }
+				
+				turkish = "Kirsehir"
+				
+				b_mikissos = {
+					turkish = "Kirsehir"
+				}
+				b_tavia = {
+				}
+				b_asponia = {
+				}
+				b_carissa = {
+				}
+				b_kochisar = {
+				}
+				b_karacaviran = {
+				}
+				b_garsaura = {
+				}
+			}
+		}
+
+		d_cappadocia = {
+			color={ 160 20 130 }
+			color2={ 255 255 20 }
+
+			capital = 760
+
+			c_tyana = {
+				color={ 246 77 187 }
+				color2={ 255 255 20 }
+				
+				turkish = Aksaray
+				
+				b_tyana = {}
+				b_anatoliaheraklea = {}
+				b_cybistra = {}
+				b_gamar = {}
+				b_tomarza = {}
+				b_faustinopolis = {}
+				b_loulon = {}
+			}
+			c_nyssa = {
+				color={ 240 70 190 }
+				color2={ 255 255 20 }
+
+				b_nyssa = {}
+				b_archelais = {
+					turkish = Aksaray
+				}
+				b_malakopeia = {}
+				b_nazianus = {}
+				b_koron = {}
+				b_parnassus = {}
+				b_thebasa = {}
+			}
+		}
+
+		d_bucellarian = {
+			color={ 234 157 207 }
+			color2={ 255 255 20 }
+
+			capital = 753
+
+			greek = "Boukellarion"
+			turkish = "Ankara"
+
+			c_ankyra = {
+				color={ 239 82 185 }
+				color2={ 255 255 20 }
+				
+				turkish = Ankara
+				
+				b_ankyra = {
+					turkish = Ankara
+				}
+				b_germa = {}
+				b_gordium = {}
+				b_gordoservon = {}
+				b_nakoleia = {}
+				b_haymana = {}
+				b_tectosagii = {}
+			}
+			c_claudiopolis = {
+				color={ 240 60 180 }
+				color2={ 255 255 20 }
+
+				turkish = "Boli"
+
+				b_claudiopolis = {}
+				b_iuliopolis = {}
+				b_bithynium = {}
+				b_petobriga = {}
+				b_honorias = {}
+				b_sangarius = {}
+				b_pessinus = {}
+			}
+		}
+		
+		d_armenia_minor = { # Cilicia in-game
+			color={ 214 140 190 }
+			color2={ 255 255 255 }
+			
+			capital = 761 # Tarsos
+			
+			armenian = "Armenia Minor"
+	
+			c_lykandos = {
+				color={ 214 140 195 }
+				color2={ 255 255 255 }
+				
+				turkish = "Elbistan"
+	
+				b_lykandos = {
+					turkish = "Elbistan"
+				}
+				b_tzamandos = {
+				}
+				b_comanagene = {
+				}
+				b_symposion = {
+				}
+				b_papurius = {
+				}
+				b_cocussus = {
+				}
+				b_germanikeia = {
+				}
+				b_arabissus = {
+				}
+			}
+			c_tarsos = {
+				color={ 194 140 175 }
+				color2={ 255 255 255 }
+				
+				turkish = "Mersin"
+				armenian = "Darson"
+	
+				b_tarsos = {
+					turkish = "Mersin"
+					armenian = "Darson"
+				}
+				b_lamas = {
+				}
+				b_castabala = {
+				}
+				b_lampron = {
+				}
+				b_zephyrium = {
+				}
+				b_pendosis = {
+				}
+				b_korikos = {
+				}
+				b_bardzerben = {
+				}
+			}
+			c_adana = {
+				color={ 194 110 145 }
+				color2={ 255 255 255 }
+	
+				b_adana = {
+				}
+				b_sis = {
+				}
+				b_anazarba = {
+				}
+				b_mamistra = {
+				}
+				b_lajazzo = {
+					armenian = "Ayas"
+					greek = "Aegeas"
+				}
+				b_trazak = {
+				}
+				b_vahka = {
+				}
+				b_mopsuestia = {
+				}
+			}
+			c_teluch = {
+				color={ 145 90 105 }
+				color2={ 255 255 255 }
+				
+				greek = "Doliche"
+				turkish = "Gâvur"
+	
+				b_teluch = {
+					greek = "Doliche"
+					turkish = "Kadirli"
+				}
+				b_germanias = {
+					turkish = "Haruniye"
+				}
+				b_perre = {
+				}
+				b_komanal = {
+				}
+				b_kapan = {
+				}
+				b_tavplur = {
+				}
+				b_koksen = {
+				}
+				b_hajin = {
+				}
+			}
+			c_seleukeia = {
+				color={ 165 70 105 }
+				color2={ 255 255 255 }
+	
+				turkish = "Silifke"
+			
+				b_seleukeia = {
+					turkish = "Silifke"
+				}
+				b_germanak = {
+				}
+				b_irenopolis = {
+				}
+				b_corycus = {
+				}
+				b_ninica = {
+				}
+				b_selinus = {
+				}
+				b_anemurium = {
+				}
+				b_dalisandus = {
+				}
+			}
+		}
+
+		d_cyprus = {
+			color={ 239 109 163 }
+			color2={ 255 255 20 }
+			
+			capital = 757 # Famagusta
+			
+			c_famagusta = {
+				color={ 228 19 156 }
+				color2={ 255 255 20 }
+				
+				turkish = "Magusa"
+				
+				b_famagusta = {
+					turkish = "Magusa"
+				}
+				b_cithium = {
+				}
+				b_nikosia = {
+				}
+				b_sthilarion = {
+				}
+				b_kyrenia = {
+				}
+				b_buffavento = {
+				}
+				b_kantara = {
+				}
+				b_peristerona = {
+				}
+			}
+			c_limisol = {
+				color={ 231 22 159 }
+				color2={ 255 255 20 }
+				
+				turkish = "Leymosun"
+				
+				b_limmassol = {
+					turkish = "Leymosun"
+				}
+				b_paphos = {
+				}
+				b_arsinoe = {
+				}
+				b_kolossi = {
+				}
+				b_morphou = {
+				}
+				b_agridi = {
+				}
+				b_dieudamour = {
+				}
+				b_khirokitia = {
+				}
+			}
+		}
+	}
+	
+	k_armenia = {
+		color={ 172 82 55 }
+		color2={ 255 255 255 }
+		
+		capital = 681 #	Ani
+		
+		culture = armenian
+		
+		orthodox = 300 # Crusade target weight
+		muslim = 100 # Crusade target weight
+		zoroastrian_group = 300 # Crusade target weight
+		
+		# Creation/usurpation trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = christian
+				}
+			}
+		}
+	
+		d_armenia = {
+			color={ 154 77 36 }
+			color2={ 255 255 255 }
+			
+			capital = 682 # Vaspurakan
+			
+			c_vaspurakan = {
+				color={ 144 67 36 }
+				color2={ 255 255 255 }
+				
+				turkish = "Van"
+				kurdish = "Wan"
+				
+				b_haykaberd = {
+				}
+				b_van = {
+				}
+				b_surbkhach = {
+				}
+				b_vostan = {
+				}
+				b_varagavank = {
+				}
+				b_aghtamar = {
+				}
+				b_bakear = {
+				}
+				b_hadamakert = {
+				}
+			}
+			c_dwin = {
+				color={ 138 77 40 }
+				color2={ 255 255 255 }
+				
+				turkish = "Erivan"
+				
+				holy_site = miaphysite
+				holy_site = monophysite
+				
+				b_dvin = {
+				}
+				b_etchmiadzin = {
+				}
+				b_erebuni = {
+				}
+				b_alaverdi = {
+				}
+				b_khorvirap = {
+				}
+				b_matsnaberd = {
+				}
+				b_tumanyan = {
+				}
+			}
+			c_ani = {
+				color={ 168 87 50 }
+				color2={ 255 255 255 }
+				
+				turkish = "Kars"
+				
+				b_midjnaberd = {
+				}
+				b_ani = {
+				}
+				b_surpasdvadzadzin = {
+				}
+				b_karutsberd = {
+				}
+				b_karuts = {
+				}
+				b_artashat = {
+				}
+				b_oshakan  = {
+				}
+				b_zvartnots = {
+				}
+			}
+			c_lori = {
+				color={ 142 70 45 }
+				color2={ 255 255 255 }
+			
+				b_lori_berd = {}
+				b_dzegh = {}
+				b_dmanis = {}
+				b_agarak = {}
+				b_hovk = {}
+				b_sanahin = {}
+				b_erkan = {}
+			}
+		}
+		d_mesopotamia = {
+			color={ 155 88 20 }
+			color2={ 255 255 255 }
+			
+			capital = 702 # Mesopotamia
+			
+			c_karin = {
+				color={ 155 95 20 }
+				color2={ 255 255 255 }
+				
+				turkish = "Erzurum"
+				
+				b_daroynk = {
+				}
+				b_karin = {
+					turkish = "Erzurum"
+				}
+				b_owshank = {
+				}
+				b_mardin = {
+				} 
+				b_baghesh = {
+				}
+				b_pasen = {
+				}
+				b_tercan = {
+				}
+				b_kirklarkilisesi = {
+				}
+			}
+			c_mesopotamia = {
+				color={ 165 99 25 }
+				color2={ 255 255 255 }
+				
+				b_tzimisca = {
+				}
+				b_martyropolis = {
+				}
+				b_mayafaraqin = {
+				}
+				b_jermuk = {
+				}
+				b_arghana = {
+				}
+				b_hani = {
+				}
+				b_lice = {
+				}
+				b_tigranakert = {
+				}
+			}
+			c_taron = {
+				color={ 155 70 25 }
+				color2={ 255 255 255 }
+				
+				b_manzikert = {
+				}
+				b_mush = {
+				}
+				b_glak = {
+				}
+				b_ararati = {
+				}
+				b_artchesh = {
+				}
+				b_arakelots = {
+				}
+				b_akhlat = {
+				}
+				b_sason = {
+				}
+			}
+		}
+		d_edessa = {
+			color={ 182 110 45 }
+			color2={ 255 255 255 }
+			
+			capital = 699 # Edessa
+			
+			c_edessa = {
+				color={ 175 105 45 }
+				color2={ 255 255 255 }
+				
+				holy_site = nestorian # place where faith originated
+				
+				b_edessa = {
+				}
+				b_sruk = {
+				}
+				b_bile = {
+				}
+				b_tulupe = {
+				}
+				b_kaisun = {
+				}
+				b_samsat = {
+				}
+				b_harran = {
+				}
+				b_edesurfa = {
+				}
+			}
+			c_tell_bashir = {
+				color={ 175 125 35 }
+				color2={ 255 255 255 }
+				
+				b_turbessel = {
+				}
+				b_buzaa = {
+				}
+				b_manbij = {
+				}
+				b_nizip = {
+				}
+				b_zeugma = {
+				}
+				b_makedonopolis = {
+				}
+				b_birtha = {
+				}
+				b_jarabulus = {
+				}
+			}
+			c_aintab = {
+				color={ 195 125 55 }
+				color2={ 255 255 255 }
+				
+				b_aintab = {
+				}
+				b_marash = {
+				}
+				b_kyrrhos = {
+				}
+				b_ravendan = {
+				}
+				b_duluk = {
+				}
+				b_hromgla = {
+				}
+				b_raban = {
+				}
+				b_amanus = {
+				}
+			}
+		}
+		d_coloneia = {
+			color={ 195 125 55 }
+			color2={ 255 255 255 }
+			
+			capital = 706 # Koloneia
+			
+			c_koloneia = {
+				color={ 195 120 50 }
+				color2={ 255 255 255 }
+				
+				b_koloneia = {
+				}
+				b_anatolnikopolis = {
+				}
+				b_tephrice = {
+				}
+				b_mazaka = {
+				}
+				b_celtzene = {
+				}
+				b_gamakh = {
+				}
+				b_akn = {
+				}
+				b_gerjanis = {
+				}
+			}
+			c_melitene = {
+				color={ 175 110 40 }
+				color2={ 255 255 255 }
+				
+				b_melitene = {
+				}
+				b_arca = {
+				}
+				b_samosata = {
+				}
+				b_corduene = {
+				}
+				b_seneqerim = {
+				}
+				b_arguvan = {
+				}
+				b_kigi = {
+				}
+				b_yedisu = {
+				}
+			}
+		}
+	}
+	k_bulgaria = {
+		color={ 113 88 101 }
+		color2={ 255 255 255 }
+		
+		culture = bulgarian
+		
+		capital = 499 # Tyrnovo
+		
+		orthodox = 300 # Crusade target weight
+		catholic = 100 # Crusade target weight
+		slavic_pagan_reformed = 50 # Crusade target weight
+		tengri_pagan_reformed = 50
+		
+		d_vidin = {
+			color={ 122 103 58 }
+			color2={ 255 255 255 }
+			
+			capital = 506 # Vidin
+			
+			greek = "Bononia"
+			
+			c_vidin = {
+				color={ 124 105 60 }
+				color2={ 255 255 255 }
+				
+				greek = "Bononia"
+				
+				b_vidin = {
+					greek = "Bononia"
+				}
+				b_viseslav = {
+				}
+				b_kula = {
+				}
+				b_srvljig = {
+				}
+				b_pirot = {
+				}
+				b_bolvan = {
+				}
+				b_kucevo = {
+				}
+				b_zajecar = {
+				}
+			}
+			c_naissus = {
+				color={ 126 107 62 }
+				color2={ 255 255 255 }
+				
+				serbian = "Nish"
+				croatian = "Nish"
+				bosnian = "Nish"
+				bulgarian = "Nish"
+				
+				b_nish = {
+					greek = "Naissos"
+				}
+				b_kumanovo = {
+				}
+				b_koprijan = {
+				}
+				b_brdo = {
+				}
+				b_vranje = {
+				}
+				b_lesnovo = {
+				}
+				b_kambelevac = {
+				}
+				b_knjazevac = {
+				}
+			}
+		}
+		d_turnovo = { # Moesia
+			color={ 197 39 154 }
+			color2={ 255 255 255 }
+			
+			capital = 499 # Tyrnovo
+			
+			c_tyrnovo = {
+				color={ 156 41 199 }
+				color2={ 255 255 255 }
+				
+				greek = "Moesia"
+				
+				b_tyrnovo = {
+					greek = "Noba" # Roman Novae
+				}
+				b_irinopolis = {
+				}
+				b_kilifarevski = {
+				}
+				b_hisarya = {
+				}
+				b_opan = {
+				}
+				b_chirpan = {
+				}
+				b_maglizh = {
+				}
+				b_kazanlak = {
+				}
+			}
+			c_serdica = {
+				color={ 158 43 201 }
+				color2={ 255 255 255 }
+				
+				bulgarian = "Sofia"
+				serbian = "Sofia"
+				croatian = "Sofia"
+				bosnian = "Sofia"
+				russian = "Sofia"
+				polish = "Sofia"
+				
+				b_serdica = {
+					bulgarian = "Sofia"
+					serbian = "Sofia"
+					croatian = "Sofia"
+					bosnian = "Sofia"
+					russian = "Sofia"
+					polish = "Sofia"
+				}
+				b_velbazhd = {
+				}
+				b_rila = {
+				}
+				b_etropole = {
+				}
+				b_pernik = {
+				}
+				b_breznik = {
+				}
+				b_pravets = {
+				}
+				b_samundzhievo = {
+				}
+			}
+			c_nikopolis = {
+				color={ 160 45 203 }
+				color2={ 255 255 255 }
+				
+				b_nikopolis = {
+				}
+				b_pleven = {
+				}
+				b_oescus = {
+				}
+				b_belene = {
+				}
+				b_iskar = {
+				}
+				b_pordim = {
+				}
+				b_knezha = {
+				}
+				b_dolnidabknik = {
+				}
+			}
+			c_dorostotum = {
+				color={ 162 47 205 }
+				color2={ 255 255 255 }
+				
+				b_dorosturum = {
+				}
+				b_rusi = {
+				}
+				b_shumen = {
+				}
+				b_borovo = {
+				}
+				b_byaladve = {
+				}
+				b_slivopole = {
+				}
+				b_tsenovo = {
+				}
+				b_samuil = {
+				}
+			}
+		}
+		d_karvuna = {
+			color={ 227 79 190 }
+			color2={ 255 255 255 }
+			
+			capital = 509 # Karvuna
+			
+			c_mesembria = {
+				color={ 207 92 250 }
+				color2={ 255 255 255 }
+				
+				b_mesembria = {
+				}
+				b_varna = {
+				}
+				b_anchilios = {
+				}
+				b_aetos = {
+				}
+				b_sozopolis = {
+				}
+				b_odessos = {
+				}
+				b_bourgas = {
+				}
+				b_valchidol = {
+				}
+			}
+			c_karvuna = {
+				color={ 210 95 253 }
+				color2={ 255 255 255 }
+				
+				greek = "Krounoi"
+				
+				b_karvuna = {
+					greek = "Krounoi"
+				}
+				b_kaliakra = {
+					greek = "Akrai"
+				}
+				b_silistria = {
+				}
+				b_dobrich = { # Balchik
+					greek = "Dionysopolis"
+				}
+				b_prezlav = {
+				}
+				b_venets = {
+				}
+				b_varbitsz = {
+				}
+				b_smyadovo = {
+				}
+			}
+			c_constantia = {
+				color={ 213 98 253 }
+				color2={ 255 255 255 }
+				
+				b_constantia = {
+				}
+				b_carachioi = {
+				}
+				b_adamclisi = {
+				}
+				b_mesgidia = {
+				}
+				b_cobadin = {
+				}
+				b_cogealac = {
+				}
+				b_mangalia = {
+				}
+				b_topraisar = {
+				}
+			}
+		}
+		d_strymon = {
+			color={ 175 50 170 }
+			color2={ 255 255 255 }
+
+			capital = 492
+
+			c_strymon = {
+				color={ 139 29 101 }
+				color2={ 255 255 20 }
+				
+				b_strumica = {
+				}
+				b_prilep = {
+				}
+				b_prosek = {
+				}
+				b_trikves = {
+				}
+				b_kocane = {
+				}
+				b_kratovo = {
+				}
+				b_radovish = {
+				}
+			}
+			c_astibus = {
+				color={ 140 10 120 }
+				color2={ 255 255 20 }
+
+				b_astibus = {}
+				b_veles = {}
+				b_skopje = {}
+				b_zegligovo = {}
+				b_presevo = {}
+				b_dukena = {}
+				b_stobi = {}
+			}
+		}
+	}
+	
+	k_serbia = {
+		color={ 113 98 61 }
+		color2={ 255 255 255 }
+		
+		culture = serbian
+		
+		capital = 502 # Rashka
+		
+		orthodox = 300 # Crusade target weight
+		catholic = 100 # Crusade target weight
+		
+		d_rashka = {
+			color={ 168 135 57 }
+			color2={ 255 255 255 }
+			
+			capital = 502 # Rashka
+			
+			greek = "Dardania"
+			roman = "Dardania"
+			dalmatian = "Dardania"
+			
+			c_rashka = {
+				color={ 172 139 61 }
+				color2={ 255 255 255 }
+				
+				greek = "Rascia"
+				dalmatian = "Rascia"
+				roman = "Rascia"
+				
+				b_prizren = {
+					greek = "Petrizen"
+				}
+				b_decani = {
+				}
+				b_dioclea = {
+				}
+				b_svetispas = {
+				}
+				b_trepca = {
+				}
+				b_zvecan = {
+				}
+				b_djakovica = {
+				}
+				b_polog = {
+				}
+			}
+			c_hum = { 
+				color={ 176 143 64 }
+				color2={ 255 255 255 }
+				
+				greek = "Arsa"
+				
+				b_plav = {
+				}
+				b_pec = {
+				}
+				b_novipazar = {
+					greek = "Arsa"
+				}
+				b_stupovi = {
+				}
+				b_belacrkva = {
+				}
+				b_bradarevo = {
+				}
+				b_moraca = {
+				}
+				b_medun = {
+				}
+			}
+			c_onogost = {
+				color={ 155 130 66 }
+				color2={ 255 255 255 }
+
+				greek = "Anagastum"
+				dalmatian = "Anagastum"
+				roman = "Anagastum"
+
+				b_onogost = {
+					greek = "Anagastum"
+					dalmatian = "Anagastum"
+					roman = "Anagastum"
+				}
+				b_destinik = {
+					greek = "Destinikion"
+					dalmatian = "Destinikion"
+					roman = "Destinikion"
+				}
+				b_desnik = {}
+				b_ribnica = {}
+				b_budimlja = {}
+				b_durdevi_stupovi = {}
+				b_gradina = {}
+			}
+			c_belgrade = {
+				color={ 150 124 61 }
+				color2={ 255 255 255 }
+				
+				serbian = "Belgrad"
+				croatian = "Belgrad"
+				bulgarian = "Belgrad"
+				bosnian = "Belgrad"
+				greek = "Singidounon"
+				roman = "Singidounon"
+				
+				b_belgrade = {
+					serbian = "Belgrad"
+					croatian = "Belgrad"
+					bulgarian = "Belgrad"
+					bosnian = "Belgrad"
+					greek = "Singidounon"
+					roman = "Singidounon"
+				}
+				b_zemun = {
+				}
+				b_smederevo = {
+				}
+				b_kragujevac = {
+				}
+				b_rudnik = {
+				}
+				b_branicevo = {
+				}
+				b_pozarevac = {
+				}
+				b_lipovic = {
+				}
+			}
+		}
+		d_dioclea = {
+			color={ 129 94 13 }
+			color2={ 255 255 255 }
+			
+			capital = 468 # Ragusa
+			
+			serbian = "Duklja"
+			croatian = "Duklja"
+			bulgarian = "Duklja"
+			bosnian = "Duklja"
+			roman = "Praevalitana"
+			
+			c_zeta = {
+				color={ 131 96 15 }
+				color2={ 255 255 255 }
+				
+				b_podgorica = {
+					greek = "Birziminium"
+				}
+				b_bar = {
+					italian = Antivari
+					greek = Antivarion
+				}
+				b_skadar = {
+					italian = Scutari
+					greek = Skoutarion
+				}
+				b_ulcinj = {
+				}
+				b_budva = {
+				}
+				b_danj = {
+				}
+				b_drivast = {
+				}
+			}
+			c_travunia = {
+				color={ 135 100 19 }
+				color2={ 255 255 255 }
+
+				b_travunia = {}
+				b_kotor = {
+					italian = Cattaro
+					greek = Askrivion
+					dalmatian = "Catarro"
+				}
+				b_trebinje = {}
+				b_dracevica = {}
+				b_bogorodice = {}
+				b_gripuli = {}
+				b_sv_stefan = {}
+			}
+			c_ragusa = {
+				color={ 133 98 17 }
+				color2={ 255 255 255 }
+				
+				greek = "Raugia"
+				croatian = "Dubrovnik"
+				serbian = "Dubrovnik"
+				bosnian = "Dubrovnik"
+				
+				b_ragusa = {
+					greek = "Raugia"
+					croatian = "Dubrovnik"
+					serbian = "Dubrovnik"
+					bosnian = "Dubrovnik"
+				}
+				b_narona = {
+				}
+				b_cavtat = {
+					greek = "Epidauros"
+					italian = "Ragusavecchia"
+				}
+				b_zaton = {
+				} 
+				b_slano = {
+				}
+				b_mljet = {
+				}
+				b_kolocep = {
+				}
+				b_sipan = {
+				}
+			}
+		}
+	}
+	
+	k_croatia = {
+		color={ 122 46 58 }
+		color2={ 200 0 0 }
+		
+		culture = croatian
+		
+		capital = 465 # Zadar
+
+		roman = "Dalmatia"
+		dalmatian = "Dalmatia"
+		
+		orthodox = 300 # Crusade target weight
+		catholic = 1000 # Crusade target weight
+	
+		d_slavonia = {
+			color={ 184 137 137 }
+			color2={ 255 255 255 }
+			
+			capital = 461 # Zagreb
+
+			roman = "Pannonia"
+			greek = "Pannonia"
+			dalmatian = "Pannonia"
+	
+			c_krizevci = {
+				color={ 186 139 139 }
+				color2={ 255 255 255 }
+	
+				b_krizevci = {
+				}
+				b_koprivnica = {
+				}
+				b_osijek = {
+				}
+				b_vinkovci = {
+				}
+				b_durdevac = {
+				}
+				b_pozega = {
+				}
+				b_virovitica = {
+				}
+			}
+			c_zagreb = {
+				color={ 189 141 141 }
+				color2={ 255 255 255 }
+
+				roman = "Andautonia"
+				greek = "Andautonia"
+				dalmatian = "Andautonia"
+	
+				b_zagreb = {
+				}
+				b_sisak = {
+				}
+				b_karlovac = {
+				}
+				b_cetin = {
+				}
+				b_zrin = {
+				}
+				b_dreznik = {
+				}
+				b_stenicnjak = {
+				} 
+				b_ozalj = {
+				}
+			}
+			c_varadzin = {
+				color={ 191 143 143 }
+				color2={ 255 255 255 }
+	
+				b_varazdin = {
+				}
+				b_cakovec = {
+				}
+				b_ludbreg = {
+				}
+				b_lepoglava = {
+				}
+				b_toplice = {
+				}
+				b_krapina = {
+				}
+				b_donjastubica = {
+				}
+				b_oroslavje = {
+				}
+			}
+		}
+		d_syrmia = {
+			color={ 170 140 115 }
+			color2={ 255 255 255 }
+
+			capital = 1968 # Syrmia
+
+			c_syrmia = {
+				color={ 174 144 119 }
+				color2={ 255 255 255 }
+
+				b_zvecan_syrmia = {}
+				b_zemlen = {}
+				b_zenthdemeter = {}
+				b_rittium = {}
+				b_burgenae = {}
+				b_bassiana = {}
+				b_bononia = {}
+			}
+			c_vukovar = {
+				color={ 178 148 123 }
+				color2={ 255 255 255 }
+
+				b_vukovar = {}
+				b_ilko = {}
+				b_posga = {}
+				b_posgawar = {}
+				b_valka = {}
+				b_cornacum = {}
+				b_cibalae = {}
+			}
+		}
+		d_bosnia = {
+			color={ 194 115 115 }
+			color2={ 255 255 255 }
+			
+			capital = 1971 # Vrhbosna
+	
+			c_rama = {
+				color={ 197 118 118 }
+				color2={ 255 255 255 }
+	
+				roman = "Salines"
+				greek = "Salines"
+				dalmatian = "Salines"
+				turkish = "Tuzla"
+				hungarian = "So"
+	
+				b_soli = {
+					roman = "Salines"
+					greek = "Salines"
+					dalmatian = "Salines"
+					turkish = "Tuzla"
+					hungarian = "So"
+				}
+				b_srebrenica = {
+				}
+				b_olovo = {
+					roman = "Plumbum"
+					greek = "Plumbum"
+					dalmatian = "Plumbum"
+				}
+				b_zvonik = {
+				}
+				b_kladanj = {
+				}
+				b_banovici = {
+				}
+				b_gradacac = {
+				}
+			}
+			c_usora = {
+				color={ 200 121 121 }
+				color2={ 255 255 255 }
+	
+				b_banjaluka = {
+				}
+				b_bihac = {
+				}
+				b_jajce = {
+				}
+				b_kljuc = {
+				}
+				b_prijedor = {
+				}
+				b_kotor_donjikraji = {
+				}
+				b_bocac = {
+				}
+				b_glamoc = {
+				}
+			}
+			c_soli = {
+				color={ 198 115 115 }
+				color2={ 255 255 255 }
+
+				b_doboj = {}
+				b_srebrenik = {}
+				b_brod = {}
+				b_bilino_polje = {
+					roman = "Bistua Nova"
+					greek = "Bistua Nova"
+					dalmatian = "Bistua Nova"
+				}
+				b_modrica = {}
+				b_usice = {}
+				b_maglaj = {}
+			}
+			c_bilino_polje = {
+				color={ 199 113 113 }
+				color2={ 255 255 255 }
+
+				b_visoki = {}
+				b_vrhbosna = {}
+				b_konjic = {}
+				b_prozor = {}
+				b_gorazde = {}
+				b_visegrad = {}
+				b_kresevo = {}
+			}
+		}
+		d_croatia = {
+			color={ 162 53 53 }
+			color2={ 255 255 255 }
+			
+			capital = 464 # Senj
+
+			roman = "Liburnia"
+			dalmatian = "Liburnia"
+			greek = "Liburnia"
+	
+			c_zadar = {
+				color={ 188 141 141 }
+				color2={ 255 255 255 }
+				
+				italian = "Zara"
+				greek = "Diadora"
+				roman = "Diadora"
+				dalmatian = "Jadera"
+	
+				b_zadar = {
+					italian = "Zara"
+					dalmatian = "Jadera"
+					greek = "Diadora"
+					roman = "Diadora"
+				}
+				b_nin = {
+				}
+				b_knin = {
+				}
+				b_sibenik = {
+				}
+				b_novigrad = {
+				}
+				b_benkovac = {
+				}
+				b_obrovac = {
+				}
+				b_pag = {
+				}
+			}
+			c_senj = {
+				color={ 170 61 61 }
+				color2={ 255 255 255 }
+				
+				greek = "Attienities"
+				roman = "Attienities"
+				dalmatian = "Attienities"
+				italian = "Segna"
+				german = "Zengg"
+				hungarian = "Zeng"
+	
+				b_senj = {
+					greek = "Attienities"
+					roman = "Attienities"
+					dalmatian = "Attienities"
+					italian = "Segna"
+					german = "Zengg"
+					hungarian = "Zeng"
+				}
+				b_kaseg = {
+				}
+				b_brinje = {
+				}
+				b_karlobag = {
+				}
+				b_perusic = {
+				} 
+				b_donjilapac = {
+				}
+				b_udbina = {
+				}
+				b_otocac = {
+				}
+			}
+			c_veglia = {
+				color={ 174 65 65 }
+				color2={ 255 255 255 }
+				
+				greek = "Kyrikon"
+				roman = "Kyrikon"
+				dalmatian = "Kyrikon"
+				german = "Vegl"
+				dalmatian = "Vicla"
+	
+				b_veglia = {
+					greek = "Kyrikon"
+					roman = "Kyrikon"
+					dalmatian = "Kyrikon"
+					german = "Vegl"
+				}
+				b_krk = {
+				}
+				b_kraljevica = {
+				}
+				b_frankopan = {
+				}
+				b_bakar = {
+				}
+				b_crikvenica = {
+				}
+				b_cres = {
+					dalmatian = "Crepsa"
+				}
+				b_vrbovsko = {
+				}
+			}
+			c_split = {
+				color={ 186 139 139 }
+				color2={ 255 255 255 }
+				
+				italian = "Spalato"
+				greek = "Spalathos"
+				dalmatian = "Spalato"
+				roman = "Spalato"
+	
+				b_split = {
+					italian = "Spalato"
+					roman = "Spalato"
+					dalmatian = "Spalato"
+					greek = "Spalathos"
+				}
+				b_hvar = {
+				}
+				b_trogir = {
+					greek = "Tragyrion"
+					roman = "Tragyrion"
+					italian = "Trau"
+					hungarian = "Trau"
+					dalmatian = "Tragur"
+				}
+				b_solin = {
+				}
+				b_klis = {
+				}
+				b_makarska = {
+					italian = "Macarsca"
+					greek = "Muccurum"
+					roman = "Muccurum"
+					dalmatian = "Muccurum"
+				}
+				b_sinj = {
+				}
+			}
+		}
+		d_dalmatia = {
+			color={ 184 137 137 }
+			color2={ 255 255 255 }
+			
+			capital = 466 # Zachlumia
+			
+			dalmatian = "Dalmatia"
+	
+			c_imotski = {
+				color={ 170 80 100 }
+				color2={ 255 255 255 }
+
+				roman = "Emotha"
+				greek = "Emotha"
+				dalmatian = "Emotha"
+
+				b_topana = {}
+				b_imotski = {
+					roman = "Emotha"
+					greek = "Emotha"
+					dalmatian = "Emotha"
+					}
+				b_grude = {}
+				b_blagaj = {}
+				b_posusje = {}
+				b_duvno = {
+					roman = "Delminium"
+					greek = "Delminium"
+					dalmatian = "Delminium"
+				}
+				b_livno = {}
+			}
+			c_zachlumia = {
+				color={ 166 57 57 }
+				color2={ 255 255 255 }
+
+				serbian = "Zahumlje"
+				croatian = "Zahumlje"
+				bosnian = "Zahumlje"
+				
+				b_stolac = {
+				}
+				b_ston = {
+				}
+				b_korcula = {
+					italian = "Curzola"
+				}
+				b_brac = {
+					italian = "Brazza"
+					greek = "Bretia"
+					roman = "Bretia"
+					dalmatian = "Bretia"
+
+				}
+				b_omis = {
+				}
+				b_lapcan = {
+					roman = "Biston"
+					greek = "Labineca"
+					dalmatian = "Labineca"
+				}
+				b_sirokibrijeg = {
+				}
+				b_zavala = {
+				}
+			}
+		}
+	}
+	
+	k_sicily = {
+		color = { 180 160 80 }
+		color2={ 255 255 255 }
+		
+		capital = 340 #	Palermo
+		
+		culture = italian
+		
+		catholic = 500 # Crusade target weight
+		orthodox = 50
+		muslim = 10
+		hellenic_pagan_reformed = 5000 # Crusade target weight
+
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_sicily = {
+						is_titular = yes
+					}
+				}
+				k_sicily = {
+					is_titular = no
+				}
+			}
+		}
+		
+		d_benevento = {
+			color = { 209 170 75 }
+			color2={ 255 255 255 }
+			
+			capital = 335 # Benevento
+			
+			catholic = 250 # Crusade target weight
+			
+			c_benevento = {
+				color = { 209 170 75 }
+				color2={ 255 255 255 }
+				
+				b_benevento = {
+				}
+				b_avellino = {
+				}
+				b_ascoli = {
+				}
+				b_montemarono = {
+				}
+				b_frigento = {
+				}
+				b_trevico = {
+				}
+				b_conza = {
+				}
+				b_sanangelo = {
+				}
+			}
+			c_foggia = {
+				color = { 209 170 75 }
+				color2={ 255 255 255 }
+				
+				b_foggia = {
+				}
+				b_siponto = {
+				}
+				b_lucera = {
+				}
+				b_troia = {
+				}
+				b_bovino = {
+				}
+				b_salapla = {
+				}
+				b_vieste = {
+				}
+			}
+		}
+		d_capua = {
+			color = { 240 209 100 }
+			color2={ 255 255 255 }
+			
+			greek = "Neapolis"
+			
+			capital = 851 # Capua
+			
+			catholic = 250 # Crusade target weight
+			
+			c_capua = {
+				color = { 240 209 100 }
+				color2={ 255 255 255 }
+				
+				greek = "Gaeta"
+				
+				b_capua = {
+					greek = "Kapue"
+				}
+				b_aquino = {
+				}
+				b_teano = {
+				}
+				b_gaeta = {
+				}
+				b_montecassino = {
+				}
+				b_caserta = {
+				}
+				b_calvi = {
+				}
+				b_acerra = {
+				}
+			}
+			c_napoli = {
+				color = { 240 209 100 }
+				color2={ 255 255 255 }
+				
+				greek = "Neapolis"
+				
+				b_napoli = {
+					greek = "Neapolis"
+				}
+				b_aversa = {
+				}
+				b_cumae = {
+				}
+				b_pozzuoli = {
+				}
+				b_ischia = {
+				}
+				b_portici={
+				}
+				b_turris_octava={
+				}
+				b_afragola={
+				}
+			}
+		}
+		d_apulia = {
+			color={ 167 172 63 }
+			color2={ 255 255 255 }
+			
+			greek = "Longobardia"
+			
+			capital = 347 # Apulia
+			
+			catholic = 250 # Crusade target weight
+			
+			c_apulia = {
+				color={ 167 172 63 }
+				color2={ 255 255 255 }
+				
+				b_melfi = {
+				}
+				b_trani = {
+				}
+				b_cannae = {
+				}
+				b_salapia = {
+				}
+				b_barletta = {
+				}
+				b_minervo = {
+				}
+				b_lavello = {
+				}
+				b_lucano = {
+				}
+			}
+			c_bari = {
+				color={ 167 172 63 }
+				color2={ 255 255 255 }
+				
+				greek = "Barion"
+				
+				b_bari = {
+					greek = "Barion"
+				}
+				b_conversano = {
+				}
+				b_giovinazzo = {
+				}
+				b_andria = {
+				}
+				b_ruvo = {
+				}
+				b_molietta = {
+				}
+				b_bitonto = {
+				}
+				b_polignano = {
+				}
+			}
+			c_lecce = {
+				color={ 167 172 63 }
+				color2={ 255 255 255 }
+				
+				greek = "Brendesion"
+				
+				b_lecce = {
+				}
+				b_otranto = {
+					greek = "Hydrunton"
+				}
+				b_brindisi = {
+					greek = "Brendesion"
+				}
+				b_leuca = {
+				}
+				b_castro = {
+				}
+				b_ligento = {
+				}
+				b_andrano = {
+				}
+				b_oria = {
+				}
+			}
+		}
+		d_abruzzo = {
+			color={ 210 168 190 }
+			color2={ 255 255 255 }
+
+			lombard = "Aprutium"
+
+			capital = 929 # Teramo
+
+			c_chieti = {
+				color={ 200 220 200 }
+				color2={ 255 255 255 }
+
+				b_crecchio = {}
+				b_chieti = {}
+				b_vasto = {}
+				b_lanciano = {}
+				b_termoli = {}
+				b_atessa = {}
+				b_san_salvo = {}
+			}
+
+			c_aprutium = {
+
+				color={ 205 210 205 }
+				color2={ 255 255 255 }
+				
+				lombard = "Amiternum"
+				greek = "Interamnion"
+				
+				b_avezzano = {
+				}
+				b_pescara = {
+				}
+				b_teramo = {
+				}
+				b_aquila = {
+					lombard = "Amiternum"
+				}
+				b_atri = {
+				}
+				b_aprutium_penne = {
+				}
+				b_paganica = {
+				}
+			}
+		}
+		d_salerno = {
+			color={ 245 194 199 }
+			color2={ 255 255 255 }
+			
+			greek = "Lukania"
+			
+			capital = 336 # Salerno
+			
+			catholic = 250 # Crusade target weight
+			
+			c_salerno = {
+				color={ 245 194 199 }
+				color2={ 255 255 255 }
+				
+				b_salerno = {
+				}
+				b_acenzera = {
+				}
+				b_eboli = {
+				}
+				b_nocera = {
+				}
+				b_acerno = {
+				}
+				b_lucania = {
+				}
+				b_agropoli = {
+				}
+				b_sarno = {
+				}
+			}
+			c_taranto = {
+				color={ 235 190 195 }
+				color2={ 255 255 255 }
+				
+				greek = "Lukania"
+				
+				b_taranto = {
+					greek = "Tarantas"
+				}
+				b_mottola = {
+				}
+				b_castellaneta = {
+				}
+				b_tursi = {
+				}
+				b_montepeloso = {
+				}
+				b_tricanico = {
+				}
+				b_gravina = {
+				}
+				b_cassano = {
+				}
+			}
+			
+			c_amalfi = {
+				color={ 120 200 225 }
+				color2 = { 255 255 255 }
+				
+				b_amalfi={
+				}
+				b_sorrento={
+				}
+				b_ravello={
+				}
+				b_tramonti={
+				}
+				b_positano={
+				}
+				b_castellamare = {
+				}
+				b_capri = {
+				}
+				b_minori = {
+				}
+			}
+		}
+		d_calabria = {
+			color={ 170 142 70 }
+			color2={ 255 255 255 }
+			
+			capital = 338 # Reggio
+			
+			catholic = 250 # Crusade target weight
+			
+			c_consenza = {
+				color={ 170 142 70 }
+				color2={ 255 255 255 }
+				
+				b_cosenza = {
+				}
+				b_rossano = {
+				}
+				b_umbriatico = {
+				}
+				b_strongoli = {
+				}
+				b_argentano = {
+				}
+				b_scalea = {
+				}
+				b_cerenzia = {
+				}
+			}
+			c_catanzaro = {
+				color={ 175 145 75 }
+				color2={ 255 255 255 }
+
+				greek = "Katantheros"
+
+				b_crotone = {}
+				b_catanzaro = {}
+				b_belcastro = {}
+				b_squillace = {}
+				b_neo_castrum = {}
+				b_girifalco = {}
+				b_kyterion = {}
+			}
+			c_reggio = {
+				color={ 170 142 70 }
+				color2={ 255 255 255 }
+				
+				greek = "Rhegion"
+				
+				b_reggio = {
+					greek = "Rhegion"
+				}
+				b_mileto = {
+				}
+				b_nicotera = {
+				}
+				b_bova = {
+				}
+				b_gerace = {
+				}
+				b_tropea = {
+				}
+				b_siderno = {}
+			}
+		}
+		d_sicily = {
+			color={ 155 254 86 }
+			color2={ 255 255 255 }
+			
+			capital = 340 # Palermo
+			
+			c_palermo = {
+				color={ 155 254 86 }
+				color2={ 255 255 255 }
+				
+				maghreb_arabic = "Balharm"
+				levantine_arabic = "Balharm"
+				egyptian_arabic = "Balharm"
+				bedouin_arabic = "Balharm"
+				andalusian_arabic = "Balharm"
+				greek = "Panarmos"
+				
+				b_palermo = {
+					maghreb_arabic = "Balharm"
+					levantine_arabic = "Balharm"
+					egyptian_arabic = "Balharm"
+					bedouin_arabic = "Balharm"
+					andalusian_arabic = "Balharm"
+					greek = "Panarmos"
+				}
+				b_cefalu = {
+				}
+				b_monreale = {
+				}
+				b_gratteri = {
+				}
+				b_caltavuturo = {
+				}
+				b_petralia = {
+				}
+				b_misilmeri = {
+				}
+				b_mistretta = {
+				}
+			}
+			c_messina = {
+				color={ 155 254 86 }
+				color2={ 255 255 255 }
+				
+				greek = "Messene"
+				
+				b_messina = {
+					greek = "Messene"
+				}
+				b_lipari = {
+				}
+				b_taormina = {
+					greek = "Taourmenion"
+				}
+				b_sanmarcodalunzio = {
+				}
+				b_troinia = {
+				}
+				b_furnari = {
+				}
+				b_cataratti = {
+				}
+				b_torregrota = {
+				}
+			}
+			c_siracusa = {
+				color={ 155 254 86 }
+				color2={ 255 255 255 }
+				
+				greek = "Syrakousa"
+
+				holy_site = hellenic_pagan
+				holy_site = hellenic_pagan_reformed
+				
+				b_syracusa = {
+					greek = "Syrakousa"
+				}
+				b_catania = {
+				}
+				b_lentini = {
+				}
+				b_noto = {
+				}
+				b_caltagirone = {
+				}
+				b_paterno = {
+				}
+				b_centuripe = {
+				}
+				b_augusta = {
+				}
+			}
+			c_agrigento = {
+				color={ 155 254 86 }
+				color2={ 255 255 255 }
+				
+				greek = "Agrigenton"
+				andalusian_arabic = "Kerkent"
+				maghreb_arabic = "Kerkent"
+				bedouin_arabic = "Kerkent"
+				egyptian_arabic = "Kerkent"
+				levantine_arabic = "Kerkent"
+				
+				b_agricento = {
+					greek = "Agrigenton"
+					andalusian_arabic = "Kerkent"
+					maghreb_arabic = "Kerkent"
+					bedouin_arabic = "Kerkent"
+					egyptian_arabic = "Kerkent"
+					levantine_arabic = "Kerkent"
+				}
+				b_caltabellotta = {
+				}
+				b_butera = {
+				}
+				b_sanbiagioplatani = {
+				}
+				b_gela = {
+				}
+				b_licata = {
+				}
+				b_raffadali = {
+				}
+				b_montallegro = {
+				}
+			}
+			c_trapani = {
+				color={ 155 254 86 }
+				color2={ 255 255 255 }
+				
+				greek = "Drepanon"
+				andalusian_arabic = "Mazar"
+				maghreb_arabic = "Mazar"
+				bedouin_arabic = "Mazar"
+				egyptian_arabic = "Mazar"
+				levantine_arabic = "Mazar"
+				
+				b_trapani = {
+					greek = "Drepanon"
+				}
+				b_mazara = {
+					andalusian_arabic = "Mazar"
+					maghreb_arabic = "Mazar"
+					bedouin_arabic = "Mazar"
+					egyptian_arabic = "Mazar"
+					levantine_arabic = "Mazar"
+				}
+				b_erice = {
+				}
+				b_sanguiseppelato = {
+				}
+				b_castelvertrano = {
+				}
+				b_santaninfa = {
+				}
+				b_marsala = {
+				}
+				b_alcarno = {
+				}
+			}
+			c_malta = {
+				color={ 155 254 86 }
+				color2={ 255 255 255 }
+				
+				b_mdina = {
+					greek = Melitta
+					italian = "Citta Vecchia"
+				}
+				b_sliema = {
+				}
+				b_sanpawl = {
+					italian = "San Paolo"
+				}
+				b_gozo = {
+					greek = Ogygia
+					andalusian_arabic = "Ghawdesh"
+					maghreb_arabic = "Ghawdesh"
+					bedouin_arabic = "Ghawdesh"
+					egyptian_arabic = "Ghawdesh"
+					levantine_arabic = "Ghawdesh"
+				}
+				b_birzebbuga = {
+					italian = "Birzebbugia"
+				}
+				b_marsascala = {
+					greek = Pyrgos
+					andalusian_arabic = "Marsa Sqalli"
+					maghreb_arabic = "Marsa Sqalli"
+					bedouin_arabic = "Marsa Sqalli"
+					egyptian_arabic = "Marsa Sqalli"
+					levantine_arabic = "Marsa Sqalli"
+				}
+				b_mgarr = {
+					italian = "Mugiarro"
+				}
+				b_sangjilan = {
+				}
+			}
+		}
+	}
+	
+	k_georgia = {
+		color={ 205 145 145 }
+		color2={ 255 255 255 }
+		
+		capital = 679 # Kartli
+		
+		culture = georgian
+		
+		orthodox = 200 # Crusade target weight
+		tengri_pagan_reformed = 50
+		zoroastrian_group = 200 # Crusade target weight
+		
+		d_kartli = {
+			color={ 234 119 119 }
+			color2={ 255 255 255 }
+			
+			capital = 679 # Kartli
+			
+			c_kartli = {
+				color={ 196 121 121 }
+				color2={ 255 255 255 }
+				
+				b_narikala = {}
+				b_tbilisi = {}
+				b_svetitskhoveli = {}
+				b_dmanisi = {}
+				b_tmoghvi = {}
+				b_akhalkalaki = {}
+				b_bolnisi = {}
+			}
+			c_mtskheta = {
+				color={ 190 140 140 }
+				color2={ 255 255 255 }
+
+				b_mtskheta = {}
+				b_sioni = {}
+				b_djvari = {}
+				b_gori = {} 
+				b_bebristsikhe = {}
+				b_urbnisi = {}
+				b_samtavisi = {}
+			}
+			c_imeretia = {
+				color={ 246 152 152 }
+				color2={ 255 255 255 }
+				
+				b_geguti = {
+				}
+				b_kutaisi = {
+				}
+				b_bagrati = {
+				}
+				b_tsikhegoji = {
+				}
+				b_khoni = {
+				}
+				b_ghelati = {
+				}
+				b_lentekhi = {
+				}
+				b_motsameta = {
+				}
+			}
+		}
+		d_tao = {
+			color={ 231 80 130 }
+			color2={ 255 255 255 }
+
+			capital = 680 # Tao
+
+			c_tao = {
+				color={ 238 183 183 }
+				color2={ 255 255 255 }
+				
+				turkish = "Ahiska"
+				
+				b_panaskerti = {}
+				b_khakhuli = {}
+				b_akhaltsikhe = {}
+				b_oshki = {}
+				b_tortomi = {}
+				b_mamrovani = {}
+				b_bana = {}
+			}
+			c_guria = {
+				color={ 240 185 185 }
+				color2={ 255 255 255 }
+				
+				greek = "Lazike"
+				turkish = "Batum"
+				armenian = "Yeger"
+				
+				b_bukistsikhe = {
+				}
+				b_batum = {
+				}
+				b_udabno = {
+				}
+				b_gonio = {
+				}
+				b_ozurgeti = {
+				}
+				b_skhalta = {
+				}
+				b_tsikhisdziri = {
+				}
+				b_khula = {
+				}
+			}
+			c_klarjeti = {
+				color={ 238 160 160 }
+				color2={ 255 255 255 }
+
+				b_artanuji = {}
+				b_klarjeti = {}
+				b_khertvisi = {}
+				b_tseptha = {}
+				b_ancha = {}
+				b_tbeti = {}
+				b_artaani = {}
+			}
+		}
+		d_kakheti = {
+			color={ 200 50 50 }
+			color2={ 255 255 255 }
+
+			capital = 673 # Albania
+
+			c_kakheti = {
+				color={ 202 147 147 }
+				color2={ 255 255 255 }
+				
+				b_zedazaden = {
+				}
+				b_telavi = {
+				}
+				b_sighnaghi = {
+				}
+				b_dzveligalavani = {
+				}
+				b_bochorma = {
+				}
+				b_davidgareja = {
+				}
+				b_gremi = {
+				}
+				b_bodbe = {
+				}
+			}
+			c_albania = {
+				color={ 253 176 176 }
+				color2={ 255 255 255 }
+				
+				armenian = "Aghvank"
+				georgian = "Albaneti"
+
+				b_chukhurkabala = {
+				armenian = "Kabalak"
+				georgian = "Kabala"
+				alan = "Kabala"
+				}
+				b_ganja = {
+				armenian = "Gandzak"
+				georgian = "Gandza"
+				alan = "Gandza"
+				}
+				b_shaki = {
+				armenian = "Shake"
+				georgian = "Shake"
+				alan = "Shake"
+				}
+				b_darussoltan = {
+				armenian = "Kaladasht"
+				georgian = "Kaladasht"
+				alan = "Kaladasht"
+				}
+				b_barda = {
+				armenian = "Partav"
+				georgian = "Bardavi"
+				alan = "Partavi"
+				}
+				b_emli = {
+				armenian = "Surp Yeghishe"
+				georgian = "Gish"
+				alan = "Kish"
+				}
+				b_gelersengorersen = {
+				armenian = "Kalaberd"
+				georgian = "Kalaberd"
+				alan = "Kalaberd"
+				}
+				b_kabala = {
+				armenian = "Vartashen"
+				georgian = "Vardashen"
+				alan = "Vartashen"
+				}
+			}
+		}
+		d_abkhazia = {
+			color={ 255 173 196 }
+			color2={ 255 255 255 }
+			
+			capital = 601 # Imeretia
+			
+			c_abkhazia = {
+				color={ 254 160 160 }
+				color2={ 255 255 255 }
+				
+				b_abaatha = {
+				}
+				b_tskhoumi = {
+				}
+				b_pitsunda = {
+				}
+				b_anakopia = {
+				}
+				b_gagra = {
+				}
+				b_bzyb = {
+				}
+				b_zugdidi = {
+				}
+			}
+			c_egrisi = {
+				color={ 250 150 150 }
+				color2={ 255 255 255 }
+
+				b_egrisi = {}
+				b_mokvi = {}
+				b_khobi = {}
+				b_buchlus = {}
+				b_phasis = {}
+				b_bedia = {}
+				b_nesos = {}
+			}
+		}
+	}
+}
+
+e_italy = {
+	color={ 234 217 110 }
+	color2={ 255 255 255 }
+	
+	capital = 333 # Rome
+	
+	culture = italian
+	
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture=italian
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				k_sicily = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			has_landed_title = k_sicily
+		}
+		conditional_tooltip = {
+			trigger = {
+				k_naples = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			has_landed_title = k_naples
+		}
+		conditional_tooltip = {
+			trigger = {
+				k_trinacria = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			has_landed_title = k_trinacria
+		}
+		conditional_tooltip = {
+			trigger = {
+				k_italy = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			has_landed_title = k_italy
+		}
+		conditional_tooltip = {
+			trigger = {
+				k_sardinia = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			has_landed_title = k_sardinia
+		}
+		conditional_tooltip = {
+			trigger = {
+				k_romagna = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			has_landed_title = k_romagna
+		}
+		conditional_tooltip = {
+			trigger = {
+				k_venice = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			has_landed_title = k_venice
+		}
+	}
+
+	gain_effect = {
+		if = {
+			limit = {
+				k_sicily = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			k_sicily = {
+				show_scope_change = no
+				de_jure_liege = e_italy
+			}
+		}
+		if = {
+			limit = {
+				k_naples = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			k_naples = {
+				show_scope_change = no
+				de_jure_liege = e_italy
+			}
+		}
+		if = {
+			limit = {
+				k_trinacria = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			k_trinacria = {
+				show_scope_change = no
+				de_jure_liege = e_italy
+			}
+		}
+		if = {
+			limit = {
+				k_italy = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			k_italy = {
+				show_scope_change = no
+				de_jure_liege = e_italy
+			}
+		}
+		if = {
+			limit = {
+				k_sardinia = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			k_sardinia = {
+				show_scope_change = no
+				de_jure_liege = e_italy
+			}
+		}
+		if = {
+			limit = {
+				k_romagna = {
+					is_titular = no
+					NOT = {
+						de_jure_liege = e_italy
+					}
+				}
+			}
+			k_romagna = {
+				show_scope_change = no
+				de_jure_liege = e_italy
+			}
+		}
+	}
+	
+	k_genoa = {
+		color={ 234 131 110 }
+		capital = 233 # Genoa
+		culture = italian
+		
+		dignity = 200 # Never want the Republic of Genoa to change primary title
+		
+		allow = {
+			is_republic = yes
+			k_genoa = {
+				is_titular = no
+			}
+		}
+	}
+	
+	k_pisa = {
+		color={ 196 192 140 }
+		color2={ 255 255 255 }
+		
+		capital = 327 # Pisa
+		culture = italian
+		
+		dignity = 200 # Never want the Republic of Pisa to change primary title
+		
+		allow = {
+			is_republic = yes
+			k_pisa = {
+				is_titular = no
+			}
+		}
+	}
+
+	k_naples = {
+		color = { 218 217 242 }
+		capital = 334 # Napoli
+		
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					FROM = {
+						NOT = {
+							any_previous_holder = {
+								always = yes # The title has existed before
+							}
+						}
+					}
+				}
+				FROM = {
+					any_previous_holder = {
+						always = yes # The title has existed before
+					}
+				}
+			}
+		}
+		
+		culture = italian
+	}
+
+	k_romagna = {
+		color={ 215 141 152 }
+		color2={ 255 255 255 }
+
+		capital = 351 # Rome
+
+		greek = "Ravenna"
+
+		christian = 10000 # Crusade target weight
+
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					AND = {
+						k_romagna = {
+							owner = {
+								has_landed_title = k_papal_state
+							}
+						}
+						NOT = {
+							religion = catholic
+						}
+					}
+					AND = {
+						has_landed_title = d_latium
+						has_landed_title = c_roma
+					}
+				}
+			}
+
+			conditional_tooltip = {
+				trigger = {
+					k_romagna = {
+						is_titular = yes
+					}
+				}
+
+				k_romagna = {
+					is_titular = no
+				}
+			}
+		}
+	}
+
+	k_papacy = {
+		color={ 215 141 152 }
+		color2={ 255 255 255 }
+
+		capital = 333 # Rome
+
+		short_name = yes
+
+		christian = 10000 # Crusade target weight
+		hellenic_pagan_reformed = 5000 # Crusade target weight
+
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_papacy = {
+						is_titular = yes
+					}
+				}
+
+				k_papacy = {
+					is_titular = no
+				}
+			}
+		}
+
+		gain_effect = {
+			if = {
+				limit = {
+					NOT = {
+						culture = greek
+						k_papacy = {
+							is_titular = no
+						}
+					}
+				}
+				custom_tooltip = {
+					text = romagna_TT
+				}
+			}
+			else_if = {
+				limit = {
+					culture = greek
+					k_papacy = {
+						is_titular = no
+					}
+				}
+				custom_tooltip = {
+					text = ravenna_TT
+				}
+			}
+
+			hidden_tooltip = {
+				if = {
+					limit = {
+						NOT = {
+							has_landed_title = k_papal_state
+						}
+					}
+					grant_title_no_opinion = k_romagna
+					destroy_landed_title = k_papacy
+					activate_title = {
+						title = k_papacy
+						status = no
+					}
+					k_papacy = {
+						any_direct_de_jure_vassal_title = {
+							de_jure_liege = k_romagna
+						}
+						dejure_liege_title = {
+		                    k_romagna = {
+		                        de_jure_liege = PREV
+		                    }
+		                }
+					}
+				}
+			}
+		}
+
+		d_ferrara = {
+			color={ 244 180 130 }
+			color2={ 255 255 255 }
+			
+			capital = 351 # Ravenna
+			
+			c_bologna = {
+				color={ 244 180 130 }
+				color2={ 255 255 255 }
+				
+				b_faenza = {
+				}
+				b_bologna = {
+				}
+				b_forli = {
+				}
+				b_imola = {
+				}
+				b_bentivoglio = {
+				}
+				b_budno = {
+				}
+				b_castelguelfo = {
+				}
+				b_bagnacavallo = {
+				}
+			}
+			c_ferrara = {
+				color={ 244 180 130 }
+				color2={ 255 255 255 }
+				
+				b_ferrara = {
+				}
+				b_commacchio = {
+				}
+				b_tresigallo = {
+				}
+				b_occhiobello = {
+				}
+				b_copparo = {
+				}
+				b_codigoro = {
+				}
+				b_bondeno = {
+				}
+				b_voghiera = {
+				}
+			}
+			c_ravenna = {
+				color={ 244 180 130 }
+				color2={ 255 255 255 }
+				
+				b_ravenna = {
+				}
+				b_cesena = {
+				}
+				b_cervia = {
+				}
+				b_russi = {
+				}
+				b_alfonsine = {
+				}
+				b_cesenatico = {
+				}
+				b_gambettola = {
+				}
+			}
+		}
+		d_ancona = {
+			color={ 230 227 180 }
+			color2={ 255 255 255 }
+			
+			capital = 350 # Ancona
+			
+			c_ancona = {
+				color={ 224 249 224 }
+				color2={ 255 255 255 }
+				
+				greek = "Ankon"
+				
+				b_ancona = {
+					greek = "Ankon"
+				}
+				b_matelica = {
+				}
+				b_osimo = {
+				}
+				b_fermo = {
+				}
+				b_recanati = {
+				}
+				b_camerino = {
+				}
+				b_senigallia = {}
+			}
+			c_rimini = {
+				color={ 220 245 220 }
+				color2={ 255 255 255 }
+
+				b_rimini = {}
+				b_pesaro = {}
+				b_gabicce = {}
+				b_gatteo = {}
+				b_poggio_berni = {}
+				b_pennabilli = {}
+				b_bellaria = {}
+			}
+			c_urbino = {
+				color={ 226 251 226 }
+				color2={ 255 255 255 }
+				
+				b_urbino = {
+				}
+				b_sanseverino = {
+				}
+				b_sanmarino = {
+				}
+				b_montefeltro = {
+				}
+				b_fano = {
+				}
+				b_cittadicastello = {
+				}
+				b_fossombrone = {
+				}
+			}
+		}	
+		d_spoleto = {
+			color={ 217 182 153 }
+			color2={ 255 255 255 }
+			
+			capital = 349 # Spoleto
+
+			c_spoleto = {
+				color={ 225 250 235 }
+				color2={ 255 255 255 }
+				
+				b_spoleto = {
+				}
+				b_nursia = {
+				}
+				b_todi = {
+				}
+				b_valva = {
+				}
+				b_terni = {
+				}
+				b_foligno = {
+				}
+				b_cascia = {}
+			}
+			c_perugia = {
+				color={ 220 245 225 }
+				color2={ 255 255 255 }
+
+				b_fratta = {}
+				b_perugia = {}
+				b_assisi = {
+				}
+				b_gubbio = {}
+				b_montone = {}
+				b_marsciano = {}
+				b_deruta = {}
+			}
+		}
+		d_latium = {
+			color={ 254 245 160 }
+			color2={ 255 255 255 }
+			
+			capital = 333 # Rome
+			
+			christian = 750 # Crusade target weight
+			
+			c_roma = {
+				color={ 242 233 156 }
+				color2={ 220 220 1 }
+				
+				christian = 5000 # Crusade target weight
+				aztec_reformed = 1000
+
+				holy_site = catholic
+				holy_site = aztec
+				holy_site = aztec_reformed
+				holy_site = hellenic_pagan
+				holy_site = hellenic_pagan_reformed
+				holy_site = pagan
+				
+				italian = Roma
+				castillan = Roma
+				catalan = Roma
+				basque = Roma
+				portuguese = Roma
+				visigothic = Roma
+				roman = Roma
+				norse = Rom
+				swedish = Rom
+				danish = Rom
+				norwegian = Rom
+				german = Rom
+				lombard = Rom
+				old_frankish = Rom
+				suebi = Rom
+				saxon = Rom
+				old_saxon = Rom
+				
+				b_roma = {
+					pentarchy = yes
+					used_for_dynasty_names = no
+					
+					italian = Roma
+					castillan = Roma
+					catalan = Roma
+					basque = Roma
+					portuguese = Roma
+					visigothic = Roma
+					roman = Roma
+					swedish = Rom
+					danish = Rom
+					norwegian = Rom
+					german = Rom
+					lombard = Rom
+					old_frankish = Rom
+					suebi = Rom
+					saxon = Rom
+					old_saxon = Rom
+				}
+				b_viterbo = {
+				}
+				b_tusculum = {
+				}
+				b_tivoli = {
+				}
+				b_ostia = {
+				}
+				b_sutri = {
+				}
+				b_aragni = {
+				}
+				b_terracina = {
+				}
+			}
+			
+			c_orvieto = {
+				color={ 228 253 238 }
+				color2={ 255 255 255 }
+				
+				b_orvieto = {
+				}
+				b_narni = {
+				}
+				b_alviano = {
+				}
+				b_montecastrilli = {
+				}
+				b_otricoli = {
+				}
+				b_amelia = {
+				}
+				b_baschi = {
+				}
+				b_ciconia = {
+				}
+			}
+			
+			c_orbetello = {
+				color={ 240 255 234 }
+				color2={ 255 255 255 }
+				
+				b_orbetello = {
+				}
+				b_grosseto = {
+				}
+				b_pitigliano = {
+				}
+				b_roselle = {
+				}
+				b_sorano = {
+				}
+				b_sovana = {
+				}
+				b_vetulonia = {
+				}
+				b_rusellae = {
+				}
+			}
+		}
+	}
+
+	k_italy = {
+		color={ 244 227 160 }
+		color2={ 255 255 255 }
+		#capital = 235 # Lombardia
+		
+		capital = 234 # Pavia
+		
+		culture = italian
+		
+		# Creation/usurpation trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = christian
+				}
+			}
+		}
+		
+		christian = 10000 # Crusade target weight
+		hellenic_pagan_reformed = 5000 # Crusade target weight
+		
+		d_verona = {
+			color={ 170 255 170 }
+			color2={ 255 255 255 }
+			
+			capital = 319 # Verona
+		
+			c_verona = {
+				color={ 255 230 230 }
+				color2={ 255 255 255 }
+				
+				b_verona = {
+				}
+				b_vicenza = {
+				}
+				b_sanmartino = {
+				}
+				b_schio = {
+				}
+				b_montecchio = {
+				}
+				b_arzignano = {
+				}
+				b_lonigo = {
+				}
+				b_barbarano = {
+				}
+			}
+			c_padova = {
+				color={ 255 234 234 }
+				color2={ 255 255 255 }
+				
+				b_padova = {
+				}
+				b_este = {
+				}
+				b_polesine = {
+				}
+				b_montagnana = {
+				}
+				b_adria = {
+				}
+				b_chioggia = {
+				}
+				b_rovigo = {
+				}
+				b_vigonza = {
+				}
+			}
+			c_mantua = {
+				color={ 255 238 238 }
+				color2={ 255 255 255 }
+				
+				b_mantua = {
+				}
+				b_serravalle = {
+				}
+				b_castellucchio = {
+				}
+				b_gonzaga = {
+				}
+				b_marmirolo = {
+				}
+				b_curtatone = {
+				}
+				b_virgilio = {
+				}
+				b_bagnolosanvito = {
+				}
+			}
+		}
+		d_susa = {
+			color={ 191 158 158 }
+			color2={ 255 255 255 }
+			
+			capital = 236 # Piemonte
+			
+			c_piemonte = {
+				color={ 104 12 38 }
+				color2={ 255 255 255 }
+				
+				b_torino = {
+				}
+				b_settimo = {
+				}
+				b_auriate = {
+				}
+				b_novara = {
+				}
+				b_ferrero = {
+				}
+				b_messarano = {
+				}
+				b_crevacuore = {
+				}
+			}
+			
+			c_saluzzo = {
+				color={ 155 46 76 }
+				color2={ 255 255 255 }
+				
+				b_saluzzo = {
+				}
+				b_pinerolo = {
+				} 
+				b_cuneo = {
+				}
+				b_savigliano = {
+				}
+				b_busca = {
+				}
+				b_paesana = {
+				}
+				b_verzuolo = {
+				}
+				b_caraglio = {
+				}
+			}
+			
+			c_monferrato = {
+				color={ 250 244 225 }
+				color2={ 255 255 255 }
+				
+				b_monferrato = {
+				}
+				b_casale = {
+				}
+				b_asti = {
+				}
+				b_acqui = {
+				}
+				b_tortona = {
+				}
+				b_alba = {
+				}
+				b_canelli = {
+				}
+			}
+
+			c_ivrea = {
+				color={ 240 230 220 }
+				color2={ 255 255 255 }
+
+				b_ivrea = {}
+				b_castellengo = {}
+				b_cossato = {}
+				b_biella = {}
+				b_champorcher = {}
+				b_bard = {}
+				b_pont_saint_martin = {}
+			}
+		}
+		
+		d_lombardia = {
+			color={ 200 133 222 }
+			color2={ 255 255 255 }
+			capital = 235 # Lombardia
+
+			lombard = "Lombardy"
+			
+			c_brescia = {
+				color={ 249 235 224 }
+				color2={ 255 255 255 }
+				
+				b_brescia = {
+				}
+				b_bergamo = {
+				}
+				b_peschiera = {
+				}
+				b_treviglio = {
+				}
+				b_salo = {
+				}
+				b_lumezzane = {
+				}
+				b_montichiari = {
+				}
+				b_castiglione = {
+				}
+			}
+			c_lombardia = {
+				color={ 251 237 226 }
+				color2={ 255 255 255 }
+				
+				b_milano = {
+				}
+				b_monza = {
+				}
+				b_lodi = {
+				}
+				b_vigevano = {
+				}
+				b_maggiore = {
+				}
+				b_legnano = {
+				}
+				b_chiavenna = {
+				}
+				b_mendrisio = {
+				}
+			}
+			c_leventina = {
+				color={ 240 220 182 }
+				color2={ 255 255 255 }
+
+				german = "Livinen"
+				frankish = "Léventine"
+
+				b_castelgrande = {}
+				b_bellinzona = {
+					german = "Bellenz"
+					frankish = "Bellence"
+				}
+				b_lugano = {
+					german = "Lauis"
+				}
+				b_locarno = {
+					german = "Luggarn"
+				}
+				b_faedo = {
+				}
+				b_montebello_leventina = {}		
+				b_biasca = {}	
+			}
+			c_como = {
+				color={ 235 215 178 }
+				color2={ 255 255 255 }
+
+				b_como = {}
+				b_varese = {}
+				b_albizzate = {}
+				b_besnate = {}
+				b_valtellina = {}
+				b_sottoceneri = {}
+				b_lecco = {}
+			}
+			c_pavia = {
+				color={ 255 243 232 }
+				color2={ 255 255 255 }
+				
+				b_pavia = {
+				}
+				b_bobbio = {
+				}
+				b_piacenza = {
+				}
+				b_voghera = {
+				}
+				b_alessandria = {
+				}
+				b_casteggio = {
+				}
+				b_colorno = {
+				}
+				b_montebello = {
+				}
+			}
+			c_cremona = {
+				color={ 255 245 234 }
+				color2={ 255 255 255 }
+				
+				b_cremona = {
+				}
+				b_crema = {
+				}
+				b_sospiro = {
+				}
+				b_vescovato = {
+				}
+				b_viadana = {
+				}
+				b_castelgoffredo = {
+				}
+				b_casalmaggiore = {
+				}
+				b_manerbio = {
+				}
+			}
+		}
+		d_genoa = {
+			color={ 244 141 120 }
+			color2={ 255 255 255 }
+			
+			capital = 233 # Genoa
+			
+			dignity = 10
+			
+			c_genoa = {
+				color={ 253 247 228 }
+				color2={ 255 255 255 }
+				
+				b_genoa = {
+				}
+				b_rapallo = {
+				}
+				b_luna = {
+				}
+				b_chiavari = {
+				}
+				b_fosdinovo = {
+				}
+				b_carara = {}
+				b_siestri = {}
+			}
+			c_noli = {
+				color={ 250 240 220 }
+				color2={ 255 255 255 }
+
+				b_noli = {}
+				b_savona = {}
+				b_ventimiglia = {}
+				b_albenga = {}
+				b_oneglia = {}
+				b_sanremo = {}
+				b_alaxio = {}
+			}
+		}	
+		d_modena = {
+			color={ 225 180 180 }
+			color2={ 255 255 255 }
+			
+			capital = 322 # Modena
+			
+			c_modena = {
+				color={ 251 250 226 }
+				color2={ 255 255 255 }
+				
+				b_modena = {
+				}
+				b_reggionellemila = {
+				}
+				b_carpi = {
+				}
+				b_mirandola = {
+				}
+				b_novellara = {
+				}
+				b_sabbioneta = {
+				}
+				b_sassuolo = {
+				}
+				b_bomporto = {
+				}
+			}
+			c_parma = {
+				color={ 255 254 230 }
+				color2={ 255 255 255 }
+				
+				b_parma = {
+				}
+				b_massa = {
+				}
+				b_guastalla = {
+				}
+				b_fornovo = {
+				}
+				b_fidenza = {
+				}
+				b_fontanellato = {
+				}
+				b_laspezia = {
+				}
+				b_noceto = {
+				}
+			}
+		}		
+		d_toscana = {
+			color = { 222 186 25 }
+			color2={ 255 255 255 }
+			
+			capital = 328 # Firenze
+			
+			c_lucca = {
+				color = { 232 186 25 }
+				color2={ 255 255 255 }
+				
+				b_lucca = {
+				}
+				b_pistoia = {
+				}
+				b_cascina = {
+				}
+				b_altopascio = {
+				}
+				b_viareggio = {
+				}
+				b_seravezza = {
+				}
+				b_capannori = {
+				}
+				b_calcinaia = {
+				}
+			}
+			c_firenze = {
+				color = { 232 190 25 }
+				color2={ 255 255 255 }
+				
+				italian = Firenze
+				castillan = Florencia
+				catalan = Florencia
+				basque = Florencia
+				portuguese = Florencia
+				visigothic = Florencia
+				roman = Florentiae
+				swedish = Florens
+				norse = Florens
+				german = Florenz
+				lombard = Florens
+				old_frankish = Florens
+				suebi = Florens
+				saxon = Florens
+				old_saxon = Florens
+					
+				b_firenze = {
+					italian = Firenze
+					castillan = Florencia
+					catalan = Florencia
+					basque = Florencia
+					portuguese = Florencia
+					visigothic = Florencia
+					roman = Florentiae
+					swedish = Florens
+					norse = Florens
+					german = Florenz
+					lombard = Florens
+					old_frankish = Florens
+					suebi = Florens
+					saxon = Florens
+					old_saxon = Florens
+				}
+				b_prato = {
+				}
+				b_fiesole = {
+				}
+				b_certaldo = {
+				}
+				b_empoli = {}
+				b_impruneta = {}
+				b_castello = {}
+			}
+			c_arezzo = {
+				color={ 230 180 30 }
+				color2={ 255 255 255 }
+
+				b_arezzo = {}
+				b_montevarchi = {}
+				b_lucignano = {}
+				b_sansepolcro = {}
+				b_castiglione_arezzo = {}
+				b_cortona = {}
+				b_civitella_del_vescovo = {}
+			}
+			c_siena = {
+				color = { 212 176 30 }
+				color2={ 255 255 255 }
+					
+				b_siena = {
+				}
+				b_pienza = {
+				}
+				b_montepulciano = {
+				}
+				b_montalcino = {
+				}
+				b_sangimignano = {
+				}
+				b_colledievaldelsa = {
+				}
+				b_monteriggioni = {
+				}
+			}
+		}	
+		d_pisa = {
+			color={ 196 192 140 }
+			color2={ 255 255 255 }
+			
+			capital = 327 # Pisa
+			
+			c_pisa = {
+				color={ 232 251 226 }
+				color2={ 255 255 255 }
+				
+				b_pisa = {
+				}
+				b_livorno = {
+				}
+				b_canefro = {
+				}
+				b_volterra = {
+				}
+				b_vicopisano = {
+				}
+				b_sanminiato = {
+				}
+				b_portoferraio = {
+				}
+				b_giglio = {
+				}
+			}
+			c_piombino = {
+				color={ 236 255 230 }
+				color2={ 255 255 255 }
+				
+				b_piombino = {
+				}
+				b_suvereto = {
+				}
+				b_radicofani = {
+				}
+				b_populonia = {
+				}
+				b_campiglia = {
+				}
+				b_follonica = {
+				}
+				b_sanvincenzo = {
+				}
+			}
+		}	
+	}
+	
+	k_venice = {
+		color = { 54 167 156 }
+		capital = 356 # Venice
+		culture = italian
+		
+		dignity = 200 # Never want the Republic of Venice to change primary title
+		
+		allow = {
+			is_republic = yes
+			k_venice = {
+				is_titular = no
+			}
+		}
+		
+		d_venice = {
+			color = { 34 137 126 }
+			capital = 356 # Venice
+			
+			dignity = 10
+			
+			c_venezia = {
+				color = { 40 143 132 }
+				color2 = { 255 255 255 }
+				
+				b_venezia = {
+				}
+				b_rialto = {
+				}
+				b_pallestrina = {
+				}
+				b_lido = {
+				}
+				b_jesolo = {
+				}
+				b_murano = {
+				}
+				b_torcello = {
+				}
+				b_fusina = {
+				}
+			}
+		}
+	}
+	
+	k_sardinia = {
+		color={ 210 165 255 }
+		color2={ 255 255 255 }
+		
+		capital = 326 # Cagliari
+		
+		culture = italian
+		
+		catholic = 500 # Crusade target weight
+		orthodox = 50
+		muslim = 10
+		
+		#catalan = "Sardenya i Còrsega"
+		#greek = "Sardhnia kai thn Korsikn"
+		#italian = "Sardegna e Corsica"
+		
+		d_sardinia = {
+			color={ 217 159 255 }
+			color2={ 255 255 255 }
+			
+			#catalan = "Sardenya"
+			#greek = "Sardhnia"
+			#italian = "Sardegna"
+			
+			capital = 326 # Cagliari
+		
+			c_arborea = {
+				color={ 170 182 225 }
+				color2={ 255 255 255 }
+				
+				italian = "Arboréa"
+				
+				b_oristano = {
+					catalan = "Oristany"
+					greek = "Aristanis"
+				}
+				b_tharros = {
+				}
+				b_sanluri = {
+				}
+				b_santa_giusta = {
+					greek = "Othoca"
+				}
+				b_pabillonis = {
+				}
+				b_cabras = {
+					catalan = "Cabres"
+				}
+				b_fordongianus = {
+					greek = "Hydata Hypsitana"
+				}
+				b_sorgono = {
+					catalan = "Sorgeixen"
+				}
+			}
+			c_cagliari = {
+				color={ 170 200 170 }
+				color2={ 255 255 255 }
+				
+				greek = "Karalis"
+				roman = "Caralis"
+				
+				b_cagliari = {
+					greek = "Karalis"
+					roman = "Caralis"
+				}
+				b_santaigia = {
+				}
+				b_assemini = {
+				}
+				b_dolianova = {
+				}
+				b_carbonia = {
+				}
+				b_capoterra = {
+				}
+				b_iglesias = {
+					catalan = "Esglésies"
+				}
+			}
+			c_ogliastra = {
+				color={ 169 195 170 }
+				color2={ 255 255 255 }
+				
+				
+				b_ogliastra = {
+				}
+				b_muravera = {
+					greek = "Sarcapos"
+				}
+				b_tortoli = {
+					greek = "Portus Ilii"
+				}
+				b_jerzu = {
+				}
+				b_bari_sardo = {
+				}
+				b_urzulei = {
+				}
+				b_ballao = {
+				}
+			}
+			c_torres = {
+				color={ 150 175 200 }
+				color2={ 255 255 255 }
+				
+				italian = "Logudoro"
+				
+				b_ardara = {
+				}
+				b_sassari = {
+					catalan = "Sàsser"
+				}
+				b_portotorres = {
+				}
+				b_ottana = {
+				}
+				b_oschiri = {
+				}
+				b_bosa = {
+				}
+				b_alghero = {
+					catalan = "L'Alguer"
+				}
+				b_valledoria = {
+				}
+			}
+			c_gallura = {
+				color={ 200 160 178 }
+				color2={ 255 255 255 }
+				
+				
+				b_olbia = {
+					catalan = "Civita"
+					greek = "Civita"
+					italian = "Civita"
+				}
+				b_nuoro = {
+				}
+				b_posada = {
+				}
+				b_lungone = {
+					greek = "Tibula"
+					italian = "Lungòni"
+				}
+				b_galtelli = {
+					italian = "Galtellì"
+				}
+				b_dorgali = {
+				}
+				b_bicinara = {
+					greek = "Bucina"
+				}
+				b_aggius = {
+					catalan = "Tempio Pausania"
+					greek = "Tempio Pausania"
+					italian = "Tempio Pausania"
+				}
+			}
+		}	
+		d_corsica = {
+			color={ 210 233 278 }
+			color2={ 255 255 255 }
+			
+			capital = 324 # Corsica
+			
+			catalan = "Còrsega"
+			frankish = "Corse"
+			greek = "Korsikn"
+		
+			c_corsica = {
+				color={ 226 248 251 }
+				color2={ 255 255 255 }
+				
+				catalan = "Còrsega"
+				frankish = "Corse"
+				greek = "Korsikn"
+				italian = "Cismonte"
+				lombard = "Cismonte"
+				
+				b_bastia = {
+				}
+				b_corte = {
+				}
+				b_aleria = {
+					catalan = "Aléria"
+				}
+				b_alando = {
+				}
+				b_morosaglia = {
+				}
+				b_luri = {
+				}
+				b_calvi_b = {
+				}
+				b_algajola = {
+				}
+			}
+			c_cinarca = {
+				color={ 250 243 220 }
+				color2={ 255 255 255 }
+				
+				b_ajaccio = {
+				}
+				b_bonifacio = {
+				}
+				b_portevecchio = {
+				}
+				b_filitosa = {
+				}
+				b_sartene = {
+					catalan = "Sartène"
+					italian = "Sartena"
+				}
+				b_bastelicaccia = {
+				}
+				b_cinarca = {
+				}
+				b_propriano = {
+				}
+			}
+		}
+	}
+}
+
+e_scandinavia = {
+	color={ 62 122 189 }
+	color2={ 255 255 0 }
+	capital = 290 # Uppland
+	
+	culture = swedish
+	
+	norse_pagan_reformed = 500 # Crusade target weight
+	
+	# Creation/usurpation trigger
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = north_germanic
+				culture = finnish
+			}
+		}
+	}
+
+	k_sweden = {
+		color={ 55 112 170 }
+		color2={ 255 255 0 }
+		capital = 290 # Uppland
+		
+		dignity = 10 # Counted as having this many more counties than it does
+		
+		culture = swedish
+		
+		norse_pagan_reformed = 350 # Crusade target weight
+		catholic = 100 # Crusade target weight
+		baltic_pagan_reformed = 50 # Crusade target weight
+		finnish_pagan_reformed = 50
+		
+		norse = Sviþjod
+		#swedish = "Svea Rike"
+	
+		d_gotland = {
+			color = { 170 25 25 }
+			color2={ 255 255 255 }
+			
+			capital = 301 # Gotland
+			
+			dignity = 10
+
+			allow = {
+				conditional_tooltip = {
+					trigger = {
+						d_gotland = {
+							is_titular = yes
+						}
+					}
+					d_gotland = {
+						is_titular = no
+					}
+				}
+				hidden_tooltip = {
+					OR = {
+						ai = no
+						culture	= swedish
+						culture = norse				
+					}
+				}
+			}
+			
+			c_gotland = {
+				color={ 65 80 255 }
+				color2={ 255 255 255 }
+				
+				b_visby = {
+				}
+				b_visborg = {
+				}
+				b_slite = {
+				}
+				b_geatish_roma = {
+				}
+				b_hejde = {
+				}
+				b_othem = {
+				}
+				b_alva = {
+				}
+				b_hemse = {
+				}
+			}
+		}
+		
+		d_uppland = {
+			color={ 20 20 145 }
+			color2={ 255 255 255 }
+			
+			norse_pagan_reformed = 500 # Crusade target weight
+			
+			dignity = 8
+			
+			capital = 290 # Uppland
+			
+			norse = Sviþjod
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 10
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			c_uppland = {
+				color={ 30 30 155 }
+				color2={ 255 255 255 }
+
+				holy_site = norse_pagan
+				holy_site = norse_pagan_reformed
+				
+				b_sigtuna = {
+				}
+				b_uppsala = {
+				}
+				b_osteras = {
+					norwegian = "Østerås"
+					danish = "Østerås"
+				}
+				b_hatuna = {
+				}
+				b_stockholm = {
+					used_for_dynasty_names = no
+				}
+				b_enkoping = {
+					norwegian = "Enkøping"
+					danish = "Enkøbing"
+				}
+				b_alsno = {
+					norwegian = "Alsnø"
+					danish = "Alsnø"
+				}
+				b_vaksala = {
+				}
+				b_birka = {
+				}
+			}
+			c_gastrikland = {
+				color={ 30 30 155 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Gestrikland"
+				danish = "Gestrikland"
+				
+				b_valbo = {
+				}
+				b_hille = {
+				}
+				b_farnebo = {
+					norwegian = "Færnebo"
+					danish = "Færnebo"
+				}
+				b_hedesunda = {
+				}
+				b_ockelbo = {
+				}
+				b_torsaker = {
+				}
+				b_hamrange = {
+				}
+				b_arsunda = {
+				}
+			}
+			c_aland = {
+				color = { 44 44 215 }
+				color2 = { 255 255 255 }
+				
+				b_kastelholm = {
+				}
+				b_sund = {
+				}
+				b_geta = {
+				}
+				b_saltvik = {
+				}
+				b_godby = {
+				}
+				b_finstrom = {
+					norwegian = "Finstrøm"
+					danish = "Finstrøm"
+				}
+				b_eckero = {
+					norwegian = "Eckerø"
+					danish = "Eckerø"
+				}
+				b_kumlinge = {
+				}
+			}
+			c_sodermanland = {
+				color={ 50 35 225 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Sødermanland"
+				danish = "Sødermanland"
+				norse = "Sudermanland"
+				swedish = "Södermanland"
+				
+				b_nykoping = {
+					norwegian = "Nykøping"
+					danish = "Nykøbing"
+				}
+				b_telge = {
+				}
+				b_gripsholm = {
+				}
+				b_strangnas = {
+					norwegian = "Strængnes"
+					danish = "Strængnæs"
+				}
+				b_torshalla = {
+					norwegian = "Torshælla"
+					danish = "Torshælla"
+				}
+				b_eskilstuna = {
+				}
+				b_vaderbrunn = {
+					norwegian = "Væderbrunn"
+					danish = "Væderbrunn"
+				}
+				b_hundhamra = {
+				}
+			}
+		}
+		d_ostergotland = {
+			color={ 44 20 169 }
+			color2={ 255 255 255 }
+			
+			capital = 1701 # Vista
+			
+			norwegian = "Østergøtland"
+			danish = "Østergøtland"
+			norse = "Austergautland"
+			swedish = "Östergötland"
+			
+			c_ostergotland = {
+				color={ 50 50 149 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Østergøtland"
+				danish = "Østergøtland"
+				norse = "Austergautland"
+				swedish = "Östergötland"
+				
+				b_uttersberg = {
+				}
+				b_skanninge = {
+					norwegian = "Skænninge"
+					danish = "Skænninge"
+				}
+				b_vadstena = {
+				}
+				b_linkoping = {
+					norwegian = "Linkøping"
+					danish = "Linkøbing"
+				}
+				b_norrkoping = {
+					norwegian = "Norrkøping"
+					danish = "Norrkøbing"
+				}
+				b_soderkoping = {
+					norwegian = "Søderkøping"
+					danish = "Søderkøbing"
+				}
+				b_ringstaholm = {
+				}
+				b_stegeborg = {
+				}
+				b_vreta = {
+				}
+			}
+			c_vista = {
+				color={ 85 70 180 }
+				color2={ 255 255 255 }
+				
+				b_nasborg = {
+					norwegian = "Nesborg"
+					danish = "Næsborg"
+				}
+				b_alvastra = {
+				}
+				b_jonkoping = {
+					norwegian = "Jønkøping"
+					danish = "Jønkøbing"
+				}
+				b_rumlaborg = {
+				}
+				b_granna = {
+				}
+				b_odeshog = {
+				}
+				b_vireda = {
+				}
+			}
+			c_kinda = {
+				color={ 45 80 200 }
+				color2={ 255 255 255 }
+				
+				
+				pagan_coa = {
+					template = 0
+					layer = {
+						texture = 3
+						texture_internal = 1
+						emblem = 0
+						color = 0
+						color = 0
+						color = 0
+					}
+					religion = "norse_pagan"
+				}
+								
+				b_kisa = {
+				}
+				b_horn2 = {
+				}
+				b_oppeby = {
+				}
+				b_hagerstad = {
+				}
+				b_tjarstad = {
+				}
+				b_hycklinge = {
+				}
+				b_tidersrum = {
+				}
+			}
+		}
+		d_vastergotland = {
+			color={ 46 30 205 }
+			color2={ 255 255 255 }
+			capital = 297 # Västergötland
+			
+			swedish = "Västergötland"
+			norwegian = "Vestergøtland"
+			danish = "Vestergøtland"
+			norse = "Vestergautland"
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 11
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			c_vastergotland = {
+				color={ 60 55 255 }
+				color2={ 255 255 255 }
+				
+				swedish = "Västergötland"
+				norwegian = "Vestergøtland"
+				danish = "Vestergøtland"
+				norse = "Vestergautland"
+
+				holy_site = pagan
+				
+				b_lodose = {
+					norwegian = "Lødøse"
+					danish = "Lødøse"
+				}
+				b_falkoping = {
+					norwegian = "Falkøping"
+					danish = "Falkøbing"
+				}
+				b_lacko = {
+					norwegian = "Læckø"
+					danish = "Læckø"
+				}
+				b_skalunda = {
+				}
+				b_lindholmen = {
+				}
+				b_lena = {
+				}
+				b_alvsborg = {
+				}
+			}
+			c_narke = {
+				color={ 68 58 255 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Nerike"
+				danish = "Nerke"
+				norse = Nerike
+				
+				b_goksholm = {
+					norwegian = "Gøksholm"
+					danish = "Gøksholm"
+				}
+				b_orebro = {
+					norwegian = "Ørebro"
+					danish = "Ørebro"
+				}
+				b_mosas = {
+				}
+				b_kumla = {
+				}
+				b_riseberga = {
+				}
+				b_nora = {
+				}
+				b_askersund = {
+				}
+				b_hallsberg = {
+				}
+			}
+			c_dal = {
+				color={ 35 30 225 }
+				color2={ 255 255 255 }
+				
+				b_dalaborg = {
+				}
+				b_bolstad = {
+				}
+				b_sundal = {
+				}
+				b_nordal = {
+				}
+				b_vedbo = {
+				}
+				b_tossbo = {
+				}
+				b_amordh = {
+				}
+				b_mellerud = {
+				}
+			}
+			c_skara = {
+				color={ 55 35 215 }
+				color2={ 255 255 255 }
+				
+				
+				pagan_coa = {
+					template = 0
+					layer = {
+						texture = 3
+						texture_internal = 2
+						emblem = 0
+						color = 0
+						color = 0
+						color = 0
+					}
+					religion = "norse_pagan"
+				}
+				
+				b_skara = {
+				}
+				b_galakvist = {
+					norwegian = "Gælakvist"
+					danish = "Gælakvist"
+				}	
+				b_ymseborg = {
+				}
+				b_axevalla = {
+				}
+				b_husaby = {
+				}
+				b_varnhem = {
+				}
+				b_forsholm = {
+				}
+			}
+		}
+		d_norrland = {
+			color={ 50 50 160 }
+			color2={ 255 255 255 }
+			
+			capital = 285 # Hälsingland
+
+			c_angermanland = {
+				color={ 24 0 255 }
+				color2={ 255 255 255 }
+				
+				norse = Angermanland
+				
+				b_bjartra = {
+					norwegian = "Bjertrå"
+					danish = "Bjærtrå"
+				}
+				b_ulvo = {
+					norwegian = "Ulvø"
+					danish = "Ulvø"
+				}
+				b_natra = {
+				}
+				b_skulnas = {
+					norwegian = "Skulnes"
+					danish = "Skulnæs"
+				}
+				b_solleftea = {
+				}
+				b_harnosand = {
+					norwegian = "Hærnøsand"
+					danish = "Hærnøsand"
+				}
+				b_ornskoldsvik = {
+					norwegian = "Ørnskøldsvik"
+					danish = "Ørnskøldsvik"
+				}
+				b_biedsta = {
+				}
+			}
+			c_medelpad = {
+				color={ 21 37 175 }
+				color2={ 255 255 255 }
+				
+				b_selanger = {
+				}
+				b_alno = {
+					norwegian = "Alnø"
+					danish = "Alnø"
+				}
+				b_njurunda = {
+				}
+				b_skon = {
+					norwegian = "Skøn"
+					danish = "Skøn"
+				}
+				b_liden = {
+				}
+				b_otman = {
+				}
+				b_torp = {
+				}
+				b_sundsvall = {
+				}
+			}
+			c_halsingland = {
+				color={ 5 55 155 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Helsingland"
+				danish = "Helsingland"
+				norse = "Helsingland"
+				
+				b_norrala = {
+				}
+				b_hog = {
+				}
+				b_jattendal = {
+					norwegian = "Jættendal"
+					danish = "Jættendal"
+				}
+				b_forsa = {
+				}
+				b_tasta = {
+				}
+				b_nordanstig = {
+				}
+				b_alir = {
+				}
+				b_sundhed = {
+				}
+			}
+		}
+		d_bergslagen = { 
+			color={ 60 60 200 }
+			color2={ 255 255 255 }
+			capital = 289 # Västmanland
+			
+			c_dalarna = {
+				color={ 20 20 230 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Jernbæraland"
+				danish = "Jernbæraland"
+				english = Dalecarlia
+				norse = Járnberaland
+				
+				b_borganas = {
+				}
+				b_kopparberg = {
+				}
+				b_hedemora = {
+				}
+				b_husby = {
+				}
+				b_sater = {
+				}
+				b_mora = {
+				}
+				b_tuna = {
+				}
+				b_idre = {
+				}
+			}
+			c_varmland = {
+				color={ 35 35 210 }
+				color2={ 255 255 255 }
+				
+				swedish = "Värmland"
+				german = "Värmland"
+				norwegian = "Vermland"
+				danish = "Værmland"
+				norse = "Vermaland"
+				
+				b_saxholm = {
+				}
+				b_arvika = {
+				}
+				b_josse = {
+				}
+				b_nordmark = {
+				}
+				b_fryksdal = {
+				}
+				b_kil = {
+				}
+				b_vase = {
+				}
+				b_gillberg = {
+				}
+			}
+			c_vastmanland = {
+				color={ 10 10 240 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Vestmanland"
+				danish = "Vestmanland"
+				norse = "Vestmannaland"
+				
+				b_vasteras = {
+					norwegian = "Vesterås"
+					danish = "Vesterås"
+				}
+				b_arboga = {
+				}
+				b_kopingshus = {
+					norwegian = "Køpingshus"
+					danish = "Købingshus"
+				}
+				b_koping = {
+					norwegian = "Køping"
+					danish = "Købing"
+				}
+				b_norberg = {
+				}
+				b_skinnskatteberg = {
+				}
+				b_badelunda = {
+				}
+				b_munktorp = {
+				}
+			}
+		}
+		d_smaland = {
+			color={ 60 40 255 }
+			color2={ 255 255 255 }
+			capital = 931 # Möre
+			
+			norse = "Smáland"
+			
+			c_more = {
+				color={ 105 55 215 }
+				color2={ 255 255 255 }
+				
+				danish = Møre
+				norwegian = Møre
+				
+				b_kalmar = {
+				}
+				b_kalmar_hus = {
+				}
+				b_torsas = {
+				}
+				b_rostocka = {
+				}
+				b_soderakra = {
+				}
+				b_madesjo = {
+				}
+				b_alem = {
+				}
+			}
+			
+			c_tjust = {
+				color={ 75 60 190 }
+				color2={ 255 255 255 }
+				
+				b_tornsfall = {
+					norwegian = "Tørnsfall"
+					danish = "Tørnsfall"
+				}
+				b_vastervik = {
+					norwegian = "Vestervik"
+					danish = "Vestervik"
+				}
+				b_stegsholm = {
+				}
+				b_vinas = {
+				}
+				b_jangolsrum = {
+				}
+				b_almvik = {
+				}
+				b_gunnebo = {
+				}
+				b_vraka = {
+				}
+			}		
+			
+			c_sevede = {
+				color={ 85 44 225 }
+				color2={ 255 255 255 }
+							
+				pagan_coa = {
+					template = 0
+					layer = {
+						texture = 3
+						texture_internal = 3
+						emblem = 0
+						color = 0
+						color = 0
+						color = 0
+					}
+					religion = "norse_pagan"
+				}
+				
+				b_kronsborg = {
+				}
+				b_vimmerby = {
+				}			
+				b_doderhult = {
+					norwegian = "Døderhult"
+					danish = "Døderhult"
+				}
+				b_hulingsryd = { # Now Hultsfred
+				}	
+				b_monsteras = {
+				}				
+				b_hogsby = {
+				}	
+				b_simpevarp = {
+				}			
+			}
+			
+			c_oland = {
+				color={ 75 60 255 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Øland"
+				danish = "Øland"
+				
+				b_borgholm = {
+				}
+				b_ottenby = {
+				}
+				b_mykleby = {
+				}
+				b_algutsrum = {
+				}
+				b_glomminge = {
+				}
+				b_hulterstad = {
+				}
+				b_gardby = {
+				}
+				b_gronhogen = {
+					norwegian = "Grønhøgen"
+					danish = "Grønhøgen"
+				}
+				b_kopingsvik = {
+					danish = "Købingsvik"
+					norwegian = "Køpingsvik"
+				}
+			}
+		}
+		d_tioharad = {
+			color={ 30 70 225 }
+			color2={ 255 255 255 }
+			
+			capital = 291 # Värend
+			
+			swedish = "Tiohärad"
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 3
+					texture_internal = 0
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			c_smaland = { # Now called Värend
+				color={ 95 30 215 }
+				color2={ 255 255 255 }
+				
+				b_kronoberg = {
+				}
+				b_vaxjo = {
+					danish = Vexjø
+					norwegian = Vexjø
+				}
+				b_aringsas = {
+				}
+				b_alvesta = {
+				}
+				b_furuby = {
+				}
+				b_bergkvara = {
+				}
+				b_skir = {
+				}
+			}
+			
+			c_finnveden = {
+				color={ 75 32 233 }
+				color2={ 255 255 255 }
+				
+				b_piksborg = {
+				}				
+				b_markaryd = {
+					norse = Madkharydh
+				}				
+				b_bolmso = {
+				}				
+				b_ljungby = {
+				}				
+				b_olmestad = {
+				}				
+				b_varnamo = {
+				}				
+				b_gislaved = {
+				}
+			}
+			
+			c_njudung = {
+				color={ 95 45 190 }
+				color2={ 255 255 255 }
+				
+				b_hultaby = {
+				}
+				b_vitala = {
+				}
+				b_komstad = {
+				}
+				b_ljunga = {
+				}
+				b_savsjo = {
+				}
+				b_kornstad = {
+				}
+				b_femtinge = {
+				}
+			}
+		}
+	}
+	
+	k_denmark = {
+		color={ 247 77 54 }
+		color2={ 136 157 23 }
+		
+		dignity = 10 # Counted as having this many more counties than it does
+		
+		culture = danish
+		
+		capital = 266 # Sjaelland
+		
+		norse_pagan_reformed = 350 # Crusade target weight
+		baltic_pagan_reformed = 50 # Crusade target weight
+		
+		#norse = Danmark
+		#danish = Danmark
+		#swedish = Danmark
+		#norwegian = Danmark
+		
+		d_skane = {
+			color={ 210 2 2 }
+			color2={ 255 255 255 }
+		
+			capital = 303 # Skåne
+			
+			swedish = Skåne
+			norse = Skåne
+			danish = Skåne
+			norwegian = Skåne
+			
+			c_skane = {
+				color={ 215 5 5 }
+				color2={ 255 255 255 }
+				
+				swedish = Skåne
+				norse = Skåne
+				danish = Skåne
+				norwegian = Skåne
+			
+				b_lund = {
+				}
+				b_dalby = {
+				}
+				b_uppakra = {
+				}
+				b_herrevad = {
+				}
+				b_lillohus = {
+					danish = "Lilløhus"
+					norwegian = "Lilløhus"
+				}
+				b_helsingborg = {
+				}
+				b_malmo = {
+					danish = "Malmø"
+					norwegian = "Malmø"
+				}
+				b_ystad = {
+				}
+				b_trelleborg = {
+				}
+			}
+			c_halland = {
+				color={ 220 10 15 }
+				color2={ 255 255 255 }
+			
+				b_varberg = {
+				}
+				b_falkenberg = {
+				}
+				b_halmstad = {
+				}
+				b_laholm = {
+				}
+				b_kungsbacka = {
+				}
+				b_aranaes = {
+					danish = "Aranæs"
+					norwegian = "Aranes"
+				}
+				b_baastad = {
+				}
+				b_getinge = {
+				}
+			}
+			c_bornholm = {
+				color={ 220 15 20 }
+				color2={ 255 255 255 }
+				
+				norse = Burgundaholmr
+			
+				b_ronne = {
+				}
+				b_knudsker = {
+				}
+				b_hammershus = {
+				}
+				b_nexo = {
+					swedish = "Nexö"
+					norse = "Nexö"
+				}
+				b_aakirkeby = {
+				}
+				b_hasle = {
+				}
+				b_svaneke = {
+				}
+				b_gudhjem = {
+				}
+			}
+			c_blekinge = {
+				color={ 220 30 20 }
+				color2={ 255 255 255 }
+			
+				b_solvesborg_slott = {
+					danish = "Sølvesborg Slott"
+					norwegian = "Sølvesborg Slott"
+				}
+				b_solvesborg = {
+					danish = "Sølvesborg"
+					norwegian = "Sølvesborg"
+				}
+				b_avaskar = {
+					danish = "Avaskær"
+					norwegian = "Avaskær"
+				}
+				b_elleholm = {
+				}
+				b_lycka = {
+				}
+				b_ronneby = {
+				}
+				b_lyckeby = {
+				}
+				b_lister = {
+				}
+			}
+		}
+		d_sjaelland = {
+			color={ 206 57 57 }
+			color2={ 255 255 255 }
+			capital = 266 # Sjaelland
+			
+			dignity = 8
+			
+			swedish = Själland
+			english = Zealand
+			norse = Sjælland
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 7
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			c_sjaelland = {
+				color={ 216 50 50 }
+				color2={ 255 255 255 }
+				
+				swedish = Själland
+				norse = Sjælland
+				english = Zealand
+
+				holy_site = norse_pagan
+				holy_site = norse_pagan_reformed
+				
+				b_kobenhavn = {
+					swedish = Köpenhamn
+					norse = Hafn
+				}
+				b_roskilde = {
+				}
+				b_helsingor = {
+					swedish = Helsingör
+					norse = Helsingör
+				}
+				b_kalundborg = {
+				}
+				b_naestved = {
+					swedish = Nästved
+					norse = Næstved
+				}
+				b_slagelse = {
+				}
+				b_vordingborg = {
+				}
+				b_ringsted = {
+				}
+				b_lejre = {
+					norse = Hleiðra
+				}
+			}
+			c_lolland = {
+				color={ 216 60 60 }
+				color2={ 255 255 255 }
+
+				b_lolland = {}				
+				b_nacascogh = {}
+				b_maribo = {}
+				b_saxakopingh = {}
+				b_ruthby = {}
+				b_nykobing = {}
+				b_bandholm = {}
+			}
+			c_fyn = {
+				color={ 216 55 55 }
+				color2={ 255 255 255 }
+				
+				b_svendborg = {
+				}
+				b_odense = {
+				}
+				b_faaborg = {
+				}
+				b_assens = {
+				}
+				b_middelfart = {
+				}
+				b_nyborg = {
+				}
+				b_kerteminde = {
+				}
+				b_bogense = {
+				}
+			}
+		}
+		d_slesvig = { # Jylland
+			color={ 224 74 74 }
+			color2={ 255 255 255 }
+			
+			capital = 1684 # Åbosyssel
+						
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 0
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+
+			c_jylland = {
+				color={ 225 84 84 }
+				color2={ 255 255 255 }
+			
+				b_hjorring = {}
+				b_skagen = {}
+				b_thystadth = {}
+				b_hvet = {}
+				b_burlun = {}
+				b_jarlslef = {}
+				b_horns = {}
+			}
+
+			c_hardsyssel = {
+				color={ 255 60 60 }
+				color2={ 255 255 255 }
+
+				b_holstebro = {}
+				b_varde = {}
+				b_skive = {
+				}
+				b_ringkobing = {
+					swedish = "Ringköping"
+					norse = Ringköping
+				}				
+				b_skjern = {}
+				b_lemvig = {}
+				b_struer = {}
+				b_ulburg = {}
+			}
+			c_abosyssel = {
+				color={ 255 45 45 }
+				color2={ 255 255 255 }
+
+				swedish = "Århus"
+				norse = "Årus"
+
+				b_aarhus = {
+					swedish = "Århus"
+					norse = "Årus"
+				}
+				b_jelling = {}
+				b_randers = {}
+				b_horsens = {
+					norse = "Horsnæs"
+				}
+				b_lisbjerg = {}
+				b_vejle = {}
+				b_skanderborg = {}
+			}
+			c_himmersyssel = {
+				color={ 255 30 30 }
+				color2={ 255 255 255 }
+
+				b_aalborg = {}
+				b_viborg = {}
+				b_hadesundt = {}
+				b_aar = {}
+				b_hornum = {}
+				b_gislum = {}
+				b_rins = {}
+			}
+		}
+		
+		d_holstein = {
+			color={ 172 112 112 }
+			color2={ 255 255 255 }
+		
+			capital = 263 #Holstein
+
+			old_saxon = Albingia
+		
+			c_slesvig = {
+				color={ 225 78 78 }
+				color2={ 255 255 255 }
+				
+				german = "Schleswig"
+			
+				b_flensborg = {
+					german = "Flensburg"
+				}
+				b_ribe = {
+				}
+				b_slesvig = {
+				}
+				b_sonderborg = {
+					swedish = "Sönderborg"
+					german = "Sonderburg"
+				}
+				b_tonder = {
+				}
+				b_aabenraa = {
+					swedish = "Åbenrå"
+					german = "Apenrade"
+				}
+				b_haderslev = {
+					german = "Hadersleben"
+				}
+				b_kolding = {
+				}
+				b_hedeby = {
+					norse = Heiðabyr
+				}
+			}
+
+			c_holstein = {
+				color={ 219 219 219 }
+				color2={ 255 255 255 }
+				
+				danish = "Holsten"
+				swedish = "Holsten"
+				norwegian = "Holsten"
+
+				old_saxon = Albingia
+
+				b_kiel = {
+				}
+				b_gottorp = {
+				}
+				b_reinholdsburg = {
+				}
+				b_gluckstadt = {
+					danish = "Lykstad"
+					swedish = "Lyckstad"
+					norwegian = "Lykstad"
+					norse = "Lykstad"
+				}
+				b_lauenburg = {
+					danish = "Lauenborg"
+					swedish = "Lauenborg"
+					norwegian = "Lauenborg"
+					norse = "Lauenborg"
+				}
+				b_segeberg = {
+				}
+				b_oldenburg_holstein = {}
+			}
+
+			c_dithmarschen = {
+				color={ 240 180 200 }
+				color2={ 255 255 255 }
+
+				old_saxon = "Thietmaresca"
+
+				b_heide = {}
+				b_itzehoe = {}
+				b_meldorf = {}
+				b_elmshorn = {}
+				b_wacken = {}
+				b_busum = {}
+				b_ulstrup = {}
+			}
+		}
+	}
+	
+	k_norway = {
+		color={ 170 170 210 }
+		color2={ 220 220 220 }
+		
+		culture = norwegian
+		
+		capital = 274 # Bergenshus
+		
+		norse_pagan_reformed = 350 # Crusade target weight
+		catholic = 100 # Crusade target weight
+		finnish_pagan_reformed = 50
+		
+		norse = Noregr
+		#danish = Norge
+		#swedish = Norge
+		#norwegian = Norge
+		
+		d_iceland = {
+			color={ 195 190 255 }
+			color2={ 220 220 220 }
+			
+			capital = 1 # Vestisland
+			
+			norse = Island
+			danish = Island
+			swedish = Island
+			norwegian = Island
+			
+			c_vestisland = {
+				color={ 190 230 250 }
+				color2={ 220 220 220 }
+				
+				swedish = "Västisland"
+				
+				b_hvamm = {
+				}
+				b_vatnafjordur = {
+				}
+				b_alftafjordur = {
+				}
+				b_borg = {
+				}
+				b_reykholar = {
+				}
+				b_isafjordur = {
+				}
+				b_sudureyri = {
+				}
+			}
+			
+			c_austisland = {
+				color={ 185 195 255 }
+				color2={ 220 220 220 }
+				
+				swedish = "Östisland"
+				
+				b_valpjotstadur = {
+				}
+				b_kirkjubaer = {
+				}
+				b_reydarfjall = {
+				}
+				b_hoffel = {
+				}
+				b_reydarfjordur = {
+				}
+				b_eskilfjordur = {
+				}
+				b_egilsstadir = {
+				}
+				
+			}
+			
+			c_nordlendingafjordungur = {
+				color={185 195 255}
+				color2={220 220 220}
+				
+				swedish = "Nordisland"
+				
+				b_husavik = {
+				}
+				b_nattfaravik = {
+				}
+				b_hrisey = {
+				}
+				b_holar = {
+				}
+				b_glaumbaer = {
+				}
+				b_akureyri = {
+				}
+				b_goddalir = {
+				}
+			}
+			
+			c_sunnlendingafjordungur = {
+				color={185 195 255}
+				color2={220 220 220}
+				
+				swedish = "Sydisland"
+				
+				b_reykjavik = {
+					irish = "Papar"
+				}
+				b_alftanes = {
+					swedish = "Alftanäs"
+				}
+				b_skalholt = {
+				}
+				b_kjalarnes = {
+				}
+				b_pingvellir = {
+				}
+				b_hlidarendi = {
+				}
+				b_olfusa = {
+				}
+			}
+		}
+		d_orkney = {
+			color={ 106 140 225 }
+			color2={ 255 255 255 }
+			
+			capital = 36 # Orkney
+			
+			norse = "Norðreyjar"
+			pictish = "Insee Galeth"
+			welsh = "Ynysoedd Gogledd"
+			irish = "Innse Tuath"
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 5
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			c_faereyar = {
+				color={ 116 145 239 }
+				color2={ 255 255 255 }
+				
+				swedish = "Färöarna"
+				pictish = "Caliu"
+				welsh = "Ynysoedd Ceiliau"
+				irish = "Innse Caora"
+				
+				b_skansin = {
+					pictish = "Lam"
+					welsh = "Llam"
+					irish = "Leum"
+				}
+				b_torshavn = {
+					pictish = "Pirth Taran"
+					welsh = "Porth Taran"
+					irish = "Port Turenn"
+				}
+				b_kirkjubour = {
+					pictish = "Tathinauu"
+					welsh = "Tyddynaueglwys"
+					irish = "Tuathanaseaglais"
+				}
+				b_funningur = {
+					pictish = "Uenaeth"
+					welsh = "Gwynaidd"
+					irish = "Fionnach"
+				}
+				b_kvivik = {
+					pictish = "Culbachuu"
+					welsh = "Culbachwy"
+					irish = "Caolbati"
+				}
+				b_sandur = {
+					pictish = "Insee Tret"
+					welsh = "Ynys Traeth"
+					irish = "Eilean Tràigh"
+				}
+				b_klaksvik = {
+					pictish = "Insee Uun"
+					welsh = "Ynys Edn"
+					irish = "Innis Eun"
+				}
+				b_hov = {
+					pictish = "Icluasc"
+					welsh = "Eglwys"
+					irish = "Eaglais"
+				}
+			}
+			c_shetland = {
+				color={ 96 130 220 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Hjaltland"
+				danish = "Hjaltland"
+				swedish = "Hjaltland"
+				norse = "Hjaltland"
+				pictish = "Insee Cait"
+				welsh = "Ynysoedd Cait"
+				irish = "Innse Catt"
+				
+				b_scalloway = {
+					pictish = "Bachuuon Maurt"
+					welsh = "Bachwyon Mawrty"
+					irish = "Batin Môrtaigh"
+				}
+				b_muness = {
+					pictish = "Muunis"
+					welsh = "Mwynis"
+					irish = "Mùnis"
+				}
+				b_tingwall = {
+					pictish = "Camanfalioth"
+					welsh = "Cymanfalleoedd"
+					irish = "Coinneamhionad"
+				}
+				b_cunningsburgh = {
+					norwegian = "Konungsborg"
+					danish = "Konungsborg"
+					swedish = "Konungsborg"
+					norse = "Konungsborg"
+					pictish = "Caer Rui"
+					welsh = "Caer Rhi"
+					irish = "Rìghdùn"
+				}
+				b_sumburgh = {
+					pictish = "Taranupin"
+					welsh = "Taranupenn"
+					irish = "Tàirneanachceann"
+				}
+				b_northmavine = {
+					pictish = "Goglethculder"
+					welsh = "Gogleddculdir"
+					irish = "Tuathcuing"
+				}
+				b_sound = {
+					pictish = "Cliaubae"
+					welsh = "Cleiaubae"
+					irish = "Crèadhbati"
+				}
+				b_yell = {
+					pictish = "Insee Uuan"
+					welsh = "Ynys Gwyn"
+					irish = "Innis Fionn"
+				}
+			}
+			c_orkney = {
+				color={ 106 140 235 }
+				color2={ 255 255 255 }
+				
+				swedish = "Orknö"
+				danish = "Orknø"
+				norse = "Orknö"
+				pictish = "Insee Orc"
+				welsh = "Ynysoedd Orc"
+				irish = "Innse Orc"
+				
+				b_kirkwall = {
+					norwegian = "Kirkuvåg"
+					danish = "Kyrkovik"
+					swedish = "Kyrkovik"
+					norse = "Kyrkovik"
+					pictish = "Icluasctreh"
+					welsh = "Eglwystref"
+					irish = "Baile na h-Eaglais"
+				}
+				b_birsay = {
+					norwegian = "Birgishærad"
+					danish = "Birgishærad"
+					swedish = "Birgishärad"
+					norse = "Birgishærad"
+					pictish = "Brideclauet"
+					welsh = "Ffraidclywed"
+					irish = "Brìghdechuala"
+				}
+				b_orphir = {
+					pictish = "Aerfur"
+					welsh = "Aerfwr"
+					irish = "Ayrfir"
+				}
+				b_westray = {
+					pictish = "Driduana"
+					welsh = "Driduana"
+					irish = "Triduana"
+				}
+				b_wyre = {
+					pictish = "Insee Ware"
+					welsh = "Ynys Wyre"
+					irish = "Innis Weir"
+				}
+				b_egilsay = {
+					pictish = "Insee Icluasc"
+					welsh = "Ynys Eglwys"
+					irish = "Innis Eaglais"
+				}
+				b_sanday = {
+					pictish = "Insee Tiuod"
+					welsh = "Ynys Tywod"
+					irish = "Innis Tràigh"
+				}
+				b_ronaldsay = {
+					pictish = "Insee Ninian"
+					welsh = "Ynys Ninian"
+					irish = "Innis Ronan"
+				}
+			}
+		}
+		d_agder = {
+			color = { 140 100 200 }
+			color2 = { 255 255 255 }
+
+			capital = 268
+
+			norse = "Egðafylki"
+
+			c_agder = {
+				color={ 40 85 255 }
+				color2={ 255 255 255 }
+				
+				norse = "Agdir"
+			
+				b_iveland = {
+				} 
+				b_flekkefjord = {
+				}
+				b_hylestad = {
+				}
+				b_grimstad = {
+				}
+				b_visedal = {
+				}
+				b_horga = {
+				}
+				b_holt = {
+				}
+				b_sirdal = {
+				}
+			}
+			c_rogaland = {
+				color={ 10 110 255 }
+				color2={ 255 255 255 }
+				
+				norse = "Rygjafylki"
+				
+				b_eikundarsund = {
+				}
+				b_stavanger = {
+				}
+				b_roldal = {
+				} 
+				b_naerbo = {
+				}
+				b_klepp = {
+				}
+				b_bygdeborg = {
+				}
+				b_hesby  = {
+				}
+				b_jonegarden = {
+				}
+			}
+			c_telemark = {
+				color={ 45 160 255 }
+				color2={ 255 255 255 }
+				
+				norse = "Þelamark"
+				
+				b_skien = {
+				}
+				b_eidsborg = {
+				}
+				b_fredriksten = {
+				}
+				b_hitterdals = {
+				}
+				b_seljord = {
+				}
+				b_fyresdal = {
+				}
+				b_grenland = {
+				}
+				b_gimsoy = {
+				}
+			}
+		}
+		d_vestlandet = {
+			color={ 120 160 245 }
+			color2={ 255 255 255 }
+			
+			capital = 274 # Bergenhus
+			
+			c_romsdal = {
+				color = { 20 20 240 }
+				color2= { 255 255 255 }
+
+				norse = "Raumsdalr"
+
+				b_veoy = {
+				}
+				b_molde = {
+				}
+				b_helland = {
+				}
+				b_rodven = {
+				}
+				b_hustad = {
+				}
+				b_voll = {
+				}
+				b_sund_romsdal = {
+				}
+			}
+			c_sogn = {
+				color = { 30 30 180 }
+				color2 = { 255 255 255 }
+
+				norse = "Sygnafylki"
+
+				b_leikanger = {
+				}
+				b_sogndal = {
+				}
+				b_kaupanger = {
+				}
+				b_fortun = {
+				}
+				b_aurland = {
+				}
+				b_kvamsoy = {
+				}
+				b_vik = {
+				}
+			}
+			c_forde = {
+				color = { 10 40 150 }
+				color2 = { 255 255 255 }
+
+				norse = "Firdafylki"
+
+				b_forde = {
+					norse = "Filðir"
+				}
+				b_kinn = {
+				}
+				b_audunborg = {
+				}
+				b_dale = {
+				}
+				b_luster = {
+				}
+				b_bygstad = {
+				}
+				b_flora = {
+				}
+			}
+			c_sunnmore = {
+				color = { 20 80 120 }
+				color2 = { 255 255 255 }
+
+				norse = "Sunnmære"
+
+				b_borgund = {
+				}
+				b_borgundkaupangen = {
+				}
+				b_giske = {
+				}
+				b_steinvag = {
+				}
+				b_valldal = {
+				}
+				b_aheim = {
+				}
+				b_haram = {
+				}
+			}
+			c_bergenshus = {
+				color={ 60 157 209 }
+				color2={ 255 255 255 }
+				
+				norse = Hordaland
+				
+				b_bergenhus = {
+				}
+				b_kinsarvik = {
+				}
+				b_bergen = {
+					norse = Bjorgvin
+				}
+				b_hove = {
+				}
+				b_fedje = {
+				}
+				b_lyse = {
+				}
+				b_strandvik = {
+				}
+			}
+		}
+
+		d_oppland = {
+			color={ 100 125 220 }
+			color2={ 255 255 255 }
+
+			capital = 273
+
+			c_oppland = {
+				color={ 94 120 215 }
+				color2={ 255 255 255 }
+
+				norse = Heidmark
+								
+				b_lillehammer = {
+				}
+				b_favang = {
+				}
+				b_oyer = {
+				}
+				b_slidre = {
+				}
+				b_flesberg = {
+				}
+				b_birid = {
+				}
+				b_redalr = {
+				}
+			}
+			c_hedmark = {
+				color={ 110 140 235 }
+				color2={ 255 255 255 }
+				
+				norse = Eystridal
+
+				b_hamarhus = {
+				}
+				b_elverum = {
+				}
+				b_hamar = {
+				}
+				b_kongsvinger = {
+				}
+				b_vang = {
+				}
+				b_loten = {
+				}
+				b_stange = {
+				}
+				b_eidskog = {
+				}
+			}
+			c_gudbrandsdal = {
+				color={ 120 120 225 }
+				color2={ 255 255 255 }
+				
+				b_dovre = {
+				}
+				b_lom = {
+				}
+				b_garmo = {
+				}
+				b_gausdal = {
+				}
+				b_lesja = {
+				}
+				b_vaga = {
+				}
+				b_heidal = {
+				}
+			}
+
+			c_romerike = {
+				color={ 80 40 200 }
+				color2 = { 255 255 255 }
+
+				b_eidsvoll = {
+				}
+				b_jessheim = {
+				}
+				b_sorumsand = {
+				}
+				b_nannestad = {
+				}
+				b_ask_romerike = {
+				}
+				b_hurdal = {
+				}
+				b_solheim = {
+				}
+				b_fetsund = {
+				}
+			}
+		}
+
+		d_ostlandet = {
+			color={ 80 120 215 }
+			color2={ 255 255 255 }
+			
+			capital = 272 # Akershus
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 6
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+
+			c_vestfold = {
+				color={ 89 100 195 }
+				color2={ 255 255 255 }
+				
+				b_kaupang = {
+				}
+				b_skiringssal = {
+				}
+				b_uvdal = {
+				}
+				b_nore = {
+				}
+				b_tonsberg = {
+				}
+				b_arendall = {
+				}
+				b_re = {
+				}
+				b_horten = {
+				}
+			}
+			c_akershus = {
+				color={ 120 158 235 }
+				color2={ 255 255 255 }
+				
+				norse = Vingulsmark
+				
+				b_akershus = {
+				}
+				b_oslo = {
+				}
+				b_bergheim = {
+				}
+				b_nes = {
+				}
+				b_isegran = {
+				}
+				b_baerum = {
+				}
+				b_moss = {
+				}
+			}
+			c_viken = {
+				color={ 25 175 255 }
+				color2={ 255 255 255 }
+				
+				norse = Alfheimr
+				
+				b_bagahus = {
+				}
+				b_kungahalla = {
+					norwegian = "Kungahælla"
+					danish = "Kungahælla"
+				}
+				b_svarteborg = {
+				}
+				b_svenneby = {
+				}
+				b_ockero = {
+					norwegian = "Øckerø"
+					danish = "Øckerø"
+				}
+				b_hede = {
+				}
+				b_marstrand = {
+				}
+				b_kungsviken = {
+				}
+			}
+		}
+		d_trondelag = {
+			#color={ 144 130 205 }
+			color={ 40 160 255 }
+			color2={ 255 255 255 }
+			
+			capital = 275 # Trondelag
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 9
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			c_trondelag = {
+				color={ 20 155 255 }
+				color2={ 255 255 255 }
+				
+				holy_site = norse_pagan
+				holy_site = norse_pagan_reformed
+
+				b_nidaros = {
+				}
+				b_maere = {
+				}
+				b_trondheim = {
+				}
+				b_steinvikholm = {
+				}
+				b_sverresborg = {
+				}
+				b_austratt = {
+				}
+				b_haltalen = {
+				}
+				b_ora = {
+				}
+			}
+			c_naumadal = {
+				color={ 25 205 240 }
+				color2={ 255 255 255 }
+				
+				b_tinghaugen = {
+				}
+				b_lade = {
+				}
+				b_logtun = {
+				}
+				b_levanger = {
+				}
+				b_hegra = {
+				}
+				b_leksvik = {
+				}
+				b_halsstein = {
+				}
+			}
+			c_halogaland = {
+				color={ 10 195 255 }
+				color2={ 255 255 255 }
+				
+				b_somna = {
+				}
+				b_bindal = {
+				}
+				b_veiga = {
+				}
+				b_brunnoy = {
+				}
+				b_hattfjelldalen = {
+				}
+				b_lein = {
+				}
+				b_mosjoen = {
+				}
+				b_alstahaug = {
+				}
+			}
+		}
+		d_jamtland = {
+			color={ 45 85 245 }
+			color2={ 255 255 255 }
+			
+			capital = 282 # Jamtland
+			
+			norwegian = "Jemtland"
+			danish = "Jemtland"
+			norse = "Jamtaland"
+			
+			c_jamtland = {
+				color={ 45 85 255 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Jemtland"
+				danish = "Jemtland"
+				norse = "Jamtaland"
+				
+				b_mjalleborgen = {
+				}
+				b_husan = {
+				}
+				b_vasterhus = {			
+				}
+				b_gene = { #Fictional, for prosperity		
+				}
+				b_brunflo = {	#Fictional, for prosperity		
+				}
+				b_borgvattnet = {	#Fictional, for prosperity		
+				}
+				b_offerdal = {	#Fictional, for prosperity		
+				}
+			}
+			c_herjedalen = {
+				color={ 40 76 225 }
+				color2={ 255 255 255 }
+				
+				swedish = "Härjedalen"
+				norse = "Herjadal"
+				
+				b_sveg = {
+				}
+				b_hogvalen = {
+				}
+				b_tannas = {
+				}
+				b_ulvkalla = { #Fictional, for prosperity
+				}
+				b_vemdalen = { #Fictional, for prosperity
+				}
+				b_ljusnedal = { #Fictional, for prosperity
+				}
+				b_lillhardal = { #Fictional, for prosperity
+				}
+			}
+		}
+	}
+	
+	k_finland = {
+		color = { 130 73 20 }
+		color2={ 255 255 255 }
+		
+		capital = 382 # Finland
+		
+		culture = finnish
+		
+		finnish_pagan_reformed = 500 # Crusade target weight
+		baltic_pagan_reformed = 100
+		slavic_pagan_reformed = 50
+		catholic = 40
+		norse_pagan_reformed = 100 # Crusade target weight
+		
+		finnish = Suomi
+		lappish = Suomi
+		ugricbaltic = Suomi
+		komi = Suomi
+		samoyed = Suomi
+		mordvin = Suomi
+		meshchera = Suomi
+		
+		# Creation/usurpation trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = north_germanic
+					culture_group = finno_ugric
+					culture_group = east_slavic
+				}
+			}
+		}
+		d_karelia = {
+			color={ 155 135 45 }
+			color2={ 255 255 255 }
+			
+			capital = 388 # Karjala
+			
+			swedish = "Karelen"
+			danish = "Karelen"
+			norse = "Karelen"
+			norwegian = "Karelen"
+			russian = "Kareliya"
+			
+			c_onega = {
+				color={ 165 45 45 }
+				color2={ 255 255 255 }
+
+				pommeranian = "Olonets"
+				polish = "Olonets"
+				bohemian = "Olonets"
+				russian = "Olonets"
+				prussian = "Olonets"
+				lithuanian = "Olonets"
+				lettigallish = "Olonets"
+				swedish = "Olonets"
+				norse = "Olonets"
+				norwegian = "Olonets"
+				danish = "Olonets"
+			
+				b_ust-onega = {
+				}
+				b_aunus = {
+					pommeranian = "Olonets"
+					polish = "Olonets"
+					bohemian = "Olonets"
+					russian = "Olonets"
+					prussian = "Olonets"
+					lithuanian = "Olonets"
+					lettigallish = "Olonets"
+					swedish = "Olonets"
+					norse = "Olonets"
+					norwegian = "Olonets"
+					danish = "Olonets"
+				}
+				b_kondopoga = {
+				}
+				b_pudoga = {
+				}
+				b_petrozavodsk = {
+				}
+				b_medvezhyegorsk = {
+				}
+				b_pryazha = {
+				}
+			}
+			c_karelen = {
+				color={ 135 25 25 }
+				color2={ 255 255 255 }
+				
+				finnish = "Viena"
+				lappish = "Viena"
+				ugricbaltic = "Viena"
+				komi = "Viena"
+				samoyed = "Viena"
+				mordvin = "Viena"
+				meshchera = "Viena"
+			
+				b_kem = {
+				}
+				b_sordavala = {
+				}
+				b_kalevala = {
+				}
+				b_loukhi = {
+				}
+				b_kostomuksha = {
+				}
+				b_muezersky = {
+				}
+				b_pitkyaranta = {
+				}
+			}
+			c_kexholm = {
+				color={ 185 70 70 }
+				color2={ 255 255 255 }
+				
+				swedish = "Kexholm"
+				norse = "Kexholm"
+				norwegian = "Kexholm"
+				danish = "Kexholm"
+
+				holy_site = finnish_pagan
+				holy_site = finnish_pagan_reformed
+				
+				b_antrea = {
+					swedish = "St Andree"
+					norse = "St Andree"
+					norwegian = "St Andree"
+					danish = "St Andree"
+				}
+				b_raivola = {
+				}
+				b_kakisalmi = {
+					swedish = "Kexholm"
+					norse = "Kexholm"
+					norwegian = "Kexholm"
+					danish = "Kexholm"
+					russian = "Korela"
+				}
+				b_jekaborg = {
+				}
+				b_koivisto={
+				} 
+				b_toksovo = {
+				}
+				b_terijoki = {
+				}
+				b_taipale = {
+				}
+			}
+			c_east_karelia = {		#new with HF
+				color={ 145 35 35 }
+				color2={ 255 255 255 }
+			
+				b_soroka = {
+				}
+				b_sekee = {
+					swedish = "Segezja"
+					norse = "Segezja"
+					danish = "Segezja"
+					norwegian = "Segezja"
+					russian = "Segezha"
+				}
+				b_vyg = {			#river & lake
+				}
+				b_segozero = {		#based on lake
+				}
+				b_ondo = {			#based on lake
+				}
+				b_yelm = {			#based on lake
+				}
+				b_masl = {			#based on lake
+				}
+			}
+			c_sortavala = {		#new with HF
+				color={ 192 76 76 }
+				color2={ 255 255 255 }
+				
+				swedish = "Sordavala "
+				norse = "Sordavala "
+				norwegian = "Sordavala "
+				danish = "Sordavala "
+				
+				b_sortavala = {
+					swedish = "Sordavala"
+					norse = "Sordavala"
+					norwegian = "Sordavala"
+					danish = "Sordavala"
+				}
+				b_kitee = {
+					swedish = "Kides"
+					norse = "Sordavala"
+				}
+				b_lappeenranta = {
+					swedish = "Villmanstrand"
+					norse = "Villmanstrand"
+					norwegian = "Villmanstrand"
+					danish = "Villmanstrand"
+				}
+				b_lakhdenpokhia = {
+					swedish = "Lahdenpohja"
+					norse = "Lahdenpohja"
+					norwegian = "Lahdenpohja"
+					danish = "Lahdenpohja"
+				} 
+				b_ruskeala = {
+				}
+				b_yanis = {		#lake name
+				}
+				b_karmalan = {	#karmalan
+				}
+			}
+		}
+		d_finland = {
+			color={ 131 108 26 }
+			color2={ 255 255 255 }
+			
+			capital = 382 # Suomi
+			
+			finnish = Suomi
+			lappish = Suomi
+			ugricbaltic = Suomi
+			komi = Suomi
+			samoyed = Suomi
+			mordvin = Suomi
+			meshchera = Suomi
+
+			c_nyland = {
+				color={ 185 65 65 }
+				color2={ 255 255 255 }
+				
+				swedish = "Nyland"
+				norse = "Nyland"
+				norwegian = "Nyland"
+				danish = "Nyland"
+			
+				b_porvoo = {
+					swedish = "Borgå"
+					norse = "Borgå"
+					norwegian = "Borgå"
+					danish = "Borgå"
+				}
+				b_loviisa = {
+					swedish = "Lovisa"
+					norse = "Lovisa"
+					norwegian = "Lovisa"
+					danish = "Lovisa"
+				}
+				b_espoo = {
+					swedish = "Esbo"
+					norse = "Esbo"
+					norwegian = "Esbo"
+					danish = "Esbo"
+				}
+				b_hamina = {
+					swedish = "Fredrikshamn"
+					norse = "Fredrikshamn"
+					norwegian = "Fredrikshamn"
+					danish = "Fredrikshamn"
+				}
+				b_svartholm = {
+				}
+				b_hanko = {
+					swedish = "Hangö"
+					norse = "Hangö"
+					norwegian = "Hangø"
+					danish = "Hangø"
+				}
+				b_kotka = {
+				}
+			}
+			c_finland = {
+				color={ 125 15 15 }
+				color2={ 255 255 255 }
+				
+				swedish = "Finland"
+				norwegian = "Finland"
+				norse = "Finland"
+				danish = "Finland"
+			
+				b_turku  = {		#Moved as first holding with HF
+					swedish = "Åbo"
+					norse = "Åbo"
+					norwegian = "Åbo"
+					danish = "Åbo"
+				}
+				b_kuusisto  = {
+					swedish = "Kustö"
+					norse = "Kustö"
+					norwegian = "Kustø"
+					danish = "Kustø"
+				}
+				b_naantali = {
+					swedish = "Nådendal"
+					norse = "Nådendal"
+					norwegian = "Nådendal"
+					danish = "Nådendal"
+				}
+				b_rikala  = {
+				}
+				b_rauma  = {
+					swedish = "Raumo"
+					norse = "Raumo"
+				}
+				b_jukarsborg  = {
+				}
+				b_lieto  = {
+					swedish = "Lundo"
+					norse = "Lundo"
+				}
+				b_stenberga  = {
+				}
+			}
+			c_tavasts = {
+				color={ 130 20 20 }
+				color2={ 255 255 255 }
+				
+				swedish = "Tavastehus"
+				norwegian = "Tavastehus"
+				danish = "Tavastehus"
+				norse = "Tavastehus"
+				finnish = Häme
+				lappish = Häme
+				ugricbaltic = Häme
+			
+				b_hameenlinna = {
+					swedish = "Tavastehus"
+					norwegian = "Tavastehus"
+					danish = "Tavastehus"
+					norse = "Tavastehus"
+				}
+				b_lahti = {
+				}
+				b_vanaja = {
+				}
+				b_mattila = {
+				}
+				b_harviala = {
+				}
+				b_vesilahti = {
+				}
+				b_hattula = {
+				}
+				b_haikonen = {
+				}
+			}
+			c_satakunta = {
+				color={ 116 46 46 }
+				color2={ 255 255 255 }
+				
+				swedish = "Satakunda"
+				norse = "Satakunda"
+			
+				b_ulvila = {
+				}
+				b_liinmaa = {
+					swedish = "Vredenborg"
+					norse = "Vredenborg"
+					norwegian = "Vredenborg"
+					danish = "Vredenborg"
+					german = "Vreghdenborch"
+				}
+				b_kiukainen = {
+				}
+				b_pori = {
+				}
+				b_telja = {
+				}
+				b_hahlo = {
+				}
+				b_kankaanpaa = {
+				}
+				b_hiittenharju = {
+				}
+			}
+			c_siuntio = {		#New with HF
+				color={ 188 73 78 }
+				color2={ 255 255 255 }
+				
+					swedish = "Sjundeå"
+					norse = "Sjundeå"
+					norwegian = "Sjundeå"
+					danish = "Sjundeå"
+			
+				b_siuntio = {
+					swedish = "Sjundeå"
+					norse = "Sjundeå"
+					norwegian = "Sjundeå"
+					danish = "Sjundeå"
+				}
+				b_lohja = {
+					swedish = "Lojo"
+					norse = "Lojo"
+					norwegian = "Lojo"
+					danish = "Lojo"
+				}
+				b_helsinki = {
+					swedish = "Helsingfors"
+					norse = "Helsingfors"
+					norwegian = "Helsingfors"
+					danish = "Helsingfors"
+				} 
+				b_raseborg = {
+					swedish = "Raseborg"
+					norse = "Raseborg"
+					norwegian = "Raseborg"
+					danish = "Raseborg"
+				}
+				b_vantaa = {
+					swedish = "Vanda"
+					norse = "Vanda"
+					norwegian = "Vanda"
+					danish = "Vanda"
+				}
+				b_kerava = {
+					swedish = "Kervo"
+					norse = "Kervo"
+					norwegian = "Kervo"
+					danish = "Kervo"
+				}
+				b_bodom = {			#lake
+				}
+			}
+		}
+		
+		d_ostrobothnia = {		#New with HF
+			color={ 145 58 58 }
+			color2={ 255 255 255 }
+			
+			capital = 385 # Osterbotten
+			
+			swedish = "Österbotten"
+			norwegian = "Østerbotten"
+			danish = "Østerbotten"
+			norse = "Austerbotn"
+			finnish = Pohjanmaa
+			lappish = Pohjanmaa
+			ugricbaltic = Pohjanmaa
+
+			c_osterbotten = {	#moved here in HF
+				color={ 152 66 66 }
+				color2={ 255 255 255 }
+				
+				swedish = "Österbotten"
+				norwegian = "Østerbotten"
+				danish = "Østerbotten"
+				norse = "Austerbotn"
+				finnish = Pohjanmaa
+				lappish = Pohjanmaa
+				ugricbaltic = Pohjanmaa
+			
+				b_vaasa = {
+					swedish = "Vasa"
+					norse = "Vasa"
+					norwegian = "Vasa"
+					danish = "Vasa"
+				}
+				b_kristinestad = {
+					swedish = "Kristinestad"
+					norse = "Kristinestad"
+					norwegian = "Kristinestad"
+					danish = "Kristinestad"
+				} 
+				b_korsholm = {
+				}
+				b_liminka = {
+				}
+				b_kalajoki = {
+				}
+				b_kaskinen = {
+					swedish = "Kaskö"
+					norse = "Kaskö"
+					norwegian = "Kaskö"
+					danish = "Kaskö"
+				}
+				b_veteli = {
+				}
+			}
+			
+			c_oulu = {		#New with HF
+				color={ 152 76 76 }
+				color2={ 255 255 255 }
+			
+					swedish = "Uleåborg"
+					norse = "Uleåborg"
+					norwegian = "Uleåborg"
+					danish = "Uleåborg"
+				
+				b_oulu = {		#NOT NEW
+					swedish = "Uleåborg"
+					norse = "Uleåborg"
+					norwegian = "Uleåborg"
+					danish = "Uleåborg"
+				}
+				b_kokkola = {
+					swedish = "Karleby"
+					norse = "Karleby"
+					norwegian = "Karleby"
+					danish = "Karleby"
+				} 
+				b_nykarleby = {
+					swedish = "Nykarleby"
+					norse = "Nykarleby"
+					norwegian = "Nykarleby"
+					danish = "Nykarleby"
+				}
+				b_raahe = {
+					swedish = "Brahestad"
+					norse = "Brahestad"
+					norwegian = "Brahestad"
+					danish = "Brahestad"
+				}
+				b_jakobstad = {
+					swedish = "Brahestad"
+					norse = "Brahestad"
+					norwegian = "Brahestad"
+					danish = "Brahestad"
+				}
+				b_lapuan = {		#river base
+				}
+				b_siuruan = {		#river base
+				}
+				b_kiiminki = {		#river base
+				}
+			}
+			
+			c_kajaani = {		#New with HF
+				color={ 152 86 86 }
+				color2={ 255 255 255 }
+			
+				b_kajaani = {
+					swedish = "Kajana"
+					norse = "Kajana"
+					norwegian = "Kajana"
+					danish = "Kajana"
+				}
+				b_kainuu = {		#lake's nickname
+				} 
+				b_kiehiman = {		#river base
+				}
+				b_paltamo = {		#town
+				}
+				b_nyflax = {		#name on old map
+				}
+				b_sarismaki = {		#name on old map
+				}
+				b_haslam = {		#name on old map
+				}
+			}
+		}
+		
+		d_savonia = {		#New with HF
+			color={ 110 5 5 }
+			color2={ 255 255 255 }
+			
+			capital = 390 # Savolaks
+			
+			c_savolaks = {
+				color={ 120 10 10 }
+				color2={ 255 255 255 }
+				
+				swedish = "Savolax"
+				norse = "Savolax"
+				norwegian = "Savolax"
+				danish = "Savolax"
+			
+				b_olavinlinna = {
+					swedish = "Olofsborg"
+					norse = "Olofsborg"
+					norwegian = "Olavsborg"
+					danish = "Olavsborg"
+				}
+				b_mikkeli = {
+					swedish = "St Michel"
+					norse = "St Michel"
+					norwegian = "St Michel"
+					danish = "St Michel"
+				}
+				b_savonlinna = {
+					swedish = "Nyslott"
+					norse = "Nyslott"
+					norwegian = "Nyslott"
+					danish = "Nyslott"
+				}
+				b_savitaipale = {
+				}
+				b_brahelinna = {
+					swedish = "Brahehus"
+					norse = "Brahehus"
+					norwegian = "Brahehus"
+					danish = "Brahehus"
+				}
+				b_sysma = {
+				}
+				b_puula = {		#lake name
+				}
+			}
+			c_laukaa = {		#New with HF
+				color={ 130 10 10 }
+				color2={ 255 255 255 }
+				
+				swedish = "Laukas"
+				norse = "Laukas"
+				danish = "Laukas"
+				norwegian = "Laukas"
+				russian = "Laukas"
+			
+				b_jyvaskyla = {
+				}
+				b_keuruu = {
+					swedish = "Keuru"
+					norse = "Keuru"
+					danish = "Keuru"
+					norwegian = "Keuru"
+				}
+				b_hankasalmi = {
+				}
+				b_suolahti = {
+				}
+				b_kuusvesi = {		#lake name
+				}
+				b_saraavesi = {		#lake name
+				}
+				b_peurunka = {		#lake name
+				}
+			}
+			c_joensuu = {		#New with HF
+				color={ 140 10 10 }
+				color2={ 255 255 255 }
+			
+				b_joensuu = {
+				}
+				b_iisalmi = {
+					swedish = "Idensalmi"
+					norse = "Idensalmi"
+					norwegian = "Idensalmi"
+					danish = "Idensalmi"
+				}
+				b_eno = {
+				}
+				b_liperi = {
+					swedish = "Libelits"
+					norse = "Libelits"
+					norwegian = "Libelits"
+					danish = "Libelits"
+				}
+				b_kontiolahti = {
+					swedish = "Kontiolax"
+					norse = "Kontiolax"
+					norwegian = "Kontiolax"
+					danish = "Kontiolax"
+				}
+				b_ilomantsi = {
+					swedish = "Ilomants"
+					norse = "Ilomants"
+					norwegian = "Ilomants"
+					danish = "Ilomants"
+				}
+				b_pyhaselka = {
+				}
+			}
+			c_kuopio = {		#New with HF
+				color={ 150 10 10 }
+				color2={ 255 255 255 }
+			
+				b_kuopio = {
+				}
+				b_vaajasalo = {
+				}
+				b_kotasaari = {
+				}
+				b_kallavesi = {		#lake name
+				}
+				b_juurusvesu = {		#lake name
+				}
+				b_kukkarinselka = {		#lake name
+				}
+				b_ruokovesi = {		#lake name
+				}
+			}
+		}
+	}
+	
+	k_sapmi = {
+		color = { 255 125 69 }
+		color2={ 255 255 255 }
+		
+		capital = 279 # Sápmi
+		
+		culture = lappish
+		
+		finnish_pagan_reformed = 350 # Crusade target weight
+		baltic_pagan_reformed = 50
+		slavic_pagan_reformed = 25
+		catholic = 25
+		norse_pagan_reformed = 50 # Crusade target weight
+		
+		norse = Norðrríki
+		swedish = Nordarike
+		norwegian = Nordarike
+		danish = Nordarike
+		finnish = Lappi
+		lappish = Sápmi
+		
+		# Creation/usurpation trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = finno_ugric
+				}
+			}
+		}
+		
+		d_sapmi = {
+			color={ 231 64 32 }
+			color2={ 255 255 255 }
+			
+			capital = 280 # Västerbotten
+			
+			norse = Norrland
+			norwegian = Norrland
+			swedish = Norrland
+			danish = Norrland
+			finnish=Lappi
+			lappish=Sápmi
+
+			c_lappland = {
+				color={ 255 70 70 }
+				color2={ 255 255 255 }
+				
+				finnish=Lappi
+				lappish=Sápmi
+				
+				b_lycksele = {
+				}
+				b_asele = {
+				}
+				b_sorsele = {
+				}
+				b_arvidsjaur = {
+				}
+				b_bergvattnet = {
+				}
+				b_arjeplog = {
+				}
+				b_gallivare = {
+					norwegian = "Gellivare"
+					danish = "Gellivare"
+				}
+				b_kiruna = {
+				}
+			}
+			c_vasterbotten = {
+				color={ 240 95 95 }
+				color2={ 255 255 255 }
+				
+				swedish = "Västerbotten"
+				norwegian = "Vesterbotten"
+				danish = "Vesterbotten"
+				norse = "Vesterbotn"
+				finnish=Länsipohja
+				lappish=Länsipohja
+				
+				b_umea = {
+					finnish=Uumaja
+					lappish=Ume
+				}
+				b_bygdea = {
+				}
+				b_skelleftea = {
+				}
+				b_lovanger = {
+					norwegian = "Løvånger"
+					danish = "Løvånger"
+				}
+				b_pitea = {
+				}
+				b_lulea = {
+				}
+				b_kalix = {
+				}
+				b_tornea = {
+				}
+			}
+		}
+		
+		d_finnmark = {
+			color={ 200 80 30 }
+			color2={ 255 255 255 }
+			
+			capital = 391 # Nordland
+			
+			lappish=Finnmárku
+			
+			c_finnmark = {
+				color={ 190 45 45 }
+				color2={ 255 255 255 }
+				
+				lappish=Finnmárku
+				
+				b_varghoeya = {
+				}
+				b_vardohus = {
+				}
+				b_ostervagen = {
+				}
+				b_malangen = {
+				}
+				b_hammerfest = {
+				}
+				b_karsloy = {
+				}
+				b_piselvnes = {
+				}
+				b_tromso = {
+				}
+			}
+			c_nordland = {
+				color={ 190 95 95 }
+				color2={ 255 255 255 }
+				
+				b_rost = {
+				}
+				b_kabelvag = {
+				}
+				b_bodo = {
+				}
+				b_narvik = {
+				}
+				b_rodoy = {
+				}
+				b_andenes = {
+				}
+				b_beiarn = {
+				}
+				b_harstad = {
+				}
+			}
+		}
+		
+		d_kola = {
+			color={ 230 70 15 }
+
+			capital = 386 # Kemi
+	
+			culture = lappish
+			title = "HIGH_CHIEF"
+			foa = "HIGH_CHIEF_FOA"
+	
+			c_kola = {
+				color={ 230 60 35 }
+				color2={ 255 255 255 }
+			
+				b_kola = {
+				}
+				b_mafelskoi = {
+				}
+				b_pechenga = {
+				}
+				b_waranger = {
+				}
+				b_tre = {
+				}
+				b_lovozero = {
+				}
+				b_molovskoi = {
+				}
+				b_jekanskoi = {
+				}
+			}
+			c_kandalax = {
+				color={ 230 100 35 }
+				color2={ 255 255 255 }
+				
+				swedish = "Kandalax"
+				norse = "Kandalax"
+				norwegian = "Kandalax"
+				danish = "Kandalax"
+			
+				b_kantalahti = {
+					swedish = "Kandalax"
+					norse = "Kandalax"
+					norwegian = "Kandalax"
+					danish = "Kandalax"
+				}
+				b_umba = {
+				}
+				b_varzuga = {
+				}
+				b_lekastrom = {
+				}
+				b_sarapo = {
+				}
+				b_kolsky = {
+				}
+				b_ponoy = {
+				}
+				b_pyaozero = {
+				}
+			}
+			c_kemi = {
+				color={ 230 80 15 }
+				color2={ 255 255 255 }
+			
+				b_kemi = {
+				}
+				b_neiden = {
+				}
+				b_inari = {
+				}
+				b_tornio = {
+				}
+				b_kemijarvi = {
+				}
+				b_utsjoki = {
+				}
+				b_savukoski = {
+				}
+			}
+			
+			c_rovaniemi = {
+				color={ 235 85 22 }
+				color2={ 255 255 255 }
+			
+				b_rovaniemi = {
+				}
+				b_ounas = {			#river base
+				}
+				b_nakkala = {		#river base
+				}
+				b_raudan = {		#river base
+				}
+				b_kitinen = {		#river base
+				}
+				b_luiro = {			#river base
+				}
+				b_jeesio = {		#river base
+				}
+			}
+		}
+	}
+
+	k_estonia = {			#new with HF
+		color={ 125 75 75 }
+        color2={ 255 255 255 }
+        
+        culture = ugricbaltic
+        
+        capital = 378 # Kalevan
+        
+        catholic = 50 # Crusade target weight
+        finnish_pagan_reformed = 300 # Crusade target weight
+        baltic_pagan_reformed = 250 # Crusade target weight
+		
+		d_esthonia = {
+			color={ 150 75 75 }
+			color2={ 255 255 255 }
+			
+			capital = 378 # Kalevan
+			
+			culture = ugricbaltic
+		
+			c_reval = {
+				color={ 160 85 85 }
+				color2={ 255 255 255 }
+				
+				swedish = "Reval"
+				danish = "Reval"
+				norwegian = "Reval"
+				german = "Reval"
+				norse = "Reval"
+			
+				b_reval = { # Kalevan
+					swedish = "Reval"
+					danish = "Reval"
+					norwegian = "Reval"
+					german = "Reval"
+					norse = "Reval"
+				}
+				b_hapsal = { # Haapsalu
+					swedish = "Hapsal"
+					danish = "Hapsal"
+					norwegian = "Hapsal"
+					german = "Hapsal"
+					norse = "Hapsal"
+				}
+				b_toompea = {
+					swedish = "Domberg"
+					danish = "Domberg"
+					norwegian = "Domberg"
+					german = "Domberg"
+					norse = "Domberg"
+				}
+				b_leal = { # Lihula
+					swedish = "Lehal"
+					danish = "Lehal"
+					norwegian = "Lehal"
+					german = "Leal"
+					norse = "Leal"
+				}
+				b_borpeal = {
+				}
+				b_laane = {
+				}
+				b_pades = {
+				}
+				b_parnaw = {
+				}
+			}
+			c_narva = {
+				color={ 175 55 55 }
+				color2={ 255 255 255 }
+			
+				b_narva = {
+				}
+				b_agelinde = {
+				}
+				b_wesenberg = {
+				}
+				b_telsborg = {
+				}
+				b_pudiviru = {
+				}
+				b_askala = {
+				}
+				b_repel = {
+				}
+				b_alentagh = {
+				}
+			}
+			c_livs = {
+				color={ 170 50 50 }
+				color2={ 255 255 255 }
+				
+				swedish = Lääne
+				danish = Lääne
+				
+				b_livs = {		#placeholder
+				}
+				b_haapsalu = {
+				}
+				b_lihula = {
+					german = Leal
+				}
+				b_parnu = {
+					ugricbaltic = Pärnu
+					german = Pernau
+					polish = Parnawa
+					lithuanian = Pernu
+				}
+				b_martna = {
+				}
+				b_kullamaa = {
+				}
+				b_karuse = {
+				}
+				b_pooravere = {
+				}
+				b_piirsalu = {
+				}
+			}
+
+			c_osel = {
+				color={ 101 48 48 }
+				color2={ 255 255 255 }
+				
+				swedish = "Ösel"
+				norse = "Ösel"
+				danish = "Øsel"
+				norwegian = "Øsel"
+				german = "Ösel"
+
+				holy_site = finnish_pagan
+				holy_site = finnish_pagan_reformed
+				
+				b_kuressare = {
+					swedish = "Arensborg"
+					norse = "Arensborg"
+					danish = "Arensborg"
+					norwegian = "Arensborg"
+					german = "Arensburg"
+				}
+				b_hiiumaa = {
+					swedish = "Dagö"
+					norse = "Dagö"
+					danish = "Dagø"
+					norwegian = "Dagø"
+					german = "Dagö"
+				}
+				b_muhu = {
+					swedish = "Moon"
+					norse = "Moon"
+					danish = "Moon"
+					norwegian = "Moon"
+					german = "Mohn"
+				}
+				b_valjala = {
+				}
+				b_poide = {
+				}
+				b_leisi = {
+				}
+				b_orisaare = {
+				}
+				b_kaarma = {
+				}
+			}
+		}
+		
+		d_sakala = {		#New with HF
+			color={ 140 60 60 }
+			color2={ 255 255 255 }
+			
+			capital = 375 # Lettigaliens = Liivimaa
+			
+			culture = ugricbaltic
+		
+			c_lettigalians = {
+				color={ 125 50 50 }
+				color2={ 255 255 255 }
+				
+				swedish = "Livland"
+				norse = "Livland"
+				danish = "Livland"
+				norwegian = "Livland"
+				german = "Livland"
+
+				b_gaujiena = {
+					ugricbaltic = Atsela
+					german = Adsel
+					lithuanian = Atzeles
+				}
+				b_kokenois = {
+					ugricbaltic = Koknese
+					german = Kokenhusen
+					polish = Koknese
+					lithuanian = Koknese
+				}
+				b_uxkull = { # Ikskila
+					swedish = "Yxkull"
+					norse = "Yxkull"
+					danish = "Yxkull"
+					norwegian = "Yxkull"
+					german = "Üxküll"
+					ugricbaltic = Ikškila
+					polish = Ikškile
+					lithuanian = Ikškile
+				}
+				b_wenden = {
+					ugricbaltic = Võnnu
+					polish = Kies
+					lithuanian = Cesys
+				}
+				b_wolmer = {
+					ugricbaltic = Valmiera
+					german = Wolmar
+					polish = Valmiera
+					lithuanian = Valmiera
+				}
+				b_lemisele = {
+					swedish = "Lemsal"
+					norse = "Lemsal"
+					danish = "Lemsal"
+					norwegian = "Lemsal"
+					ugricbaltic = Lemsalu
+					german = Lemsal
+					polish = Limbaži
+					lithuanian = Limbažiai
+				}
+				b_seswegen = {
+					ugricbaltic = Cesvaine
+					german = Sesswegen
+					polish = Cesvaine
+					lithuanian = Cesvaine
+				}
+			}
+			c_dorpat = {		#Moved here with HF
+				color={ 115 5 5 }
+				color2={ 255 255 255 }
+				
+				swedish = "Dorpat"
+				norse = "Dorpat"
+				danish = "Dorpat"
+				norwegian = "Dorpat"
+				german = "Dorpat"
+			
+				b_tartu = {
+					swedish = "Dorpat"
+					norse = "Dorpat"
+					danish = "Dorpat"
+					norwegian = "Dorpat"
+					german = "Dorpat"
+				}
+				b_jarva = {
+				}
+				b_fellin = {
+				}
+				b_odenpah = {
+				}
+				b_lais = {
+				}
+				b_vastseliina = {
+				}
+				b_kirrumpa = {
+				}
+				b_vanakastre = {
+				}
+			}
+			c_jarva = {
+				color={ 98 40 40 }
+				color2={ 255 255 255 }
+				
+				swedish = "Järvamaa"
+				danish = "Järvamaa"
+				
+				b_viljandi = {
+				}
+				b_alempois = {
+				}
+				b_vaiga = {
+				}
+				b_mohu = {
+				}
+				b_nurmekund = {
+				}
+				b_jogentagana = {
+				}
+				b_sackal = {
+				}
+			}
+		}
+	}
+}
+
+e_wendish_empire = {
+	color={ 130 20 50 }
+	color2={ 200 0 0 }
+	
+	capital = 527 # Krakowskie
+		
+	culture = polish
+	
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = west_slavic
+				culture_group = baltic
+			}
+		}
+	}
+	
+	short_name = yes
+
+	k_moravia = {
+		color={ 158 102 36 }
+		color2={ 200 0 0 }
+
+		capital = 441 # Brno
+
+		culture = bohemian
+		
+		slavic_pagan_reformed = 100 # Crusade target weight
+		
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_moravia = {
+						is_titular = yes
+					}
+				}
+				k_moravia = {
+					is_titular = no
+				}
+			}
+			hidden_tooltip = {
+				ai = no
+			}
+		}
+	}
+
+	k_poland = {
+		color={ 150 23 23 }
+		color2={ 200 0 0 }
+		
+		capital = 527 # Krakowskie
+		
+		culture = polish
+		
+		catholic = 100 # Crusade target weight
+		slavic_pagan_reformed = 500 # Crusade target weight
+		baltic_pagan_reformed = 100 # Crusade target weight
+		
+		d_mazovia = {
+			color={ 125 46 36 }
+			color2={ 255 255 255 }
+			
+			capital = 529 # Plock
+			
+			c_plock = {
+				color={ 127 30 2 }
+				color2={ 255 255 255 }
+
+				holy_site = slavic_pagan
+				holy_site = slavic_pagan_reformed
+				
+				b_plock = {
+				}
+				b_wyszogrod = {
+				}
+				b_plonsk = {
+				}
+				b_zacroczym = {
+				}
+				b_ciechanow = {
+				}
+				b_rozan = {
+				}
+				b_szrensk = {
+				}
+			}
+			c_czersk = {			#Since HF, is now basically Liw
+				color={ 127 6 50 }
+				color2={ 255 255 255 }
+				
+				b_liw = {
+				}
+				b_brodno = {
+				}
+				b_radzymin = {
+				}
+				b_wegrow = {
+				}
+				b_liw_nowy = {
+				}
+				b_lochow = {
+				}
+				b_tluszoz = {
+				}
+			}
+			c_lomzynska = {			#New with HF
+				color={ 127 0 70 }
+				color2={ 255 255 255 }
+				
+				b_lomza = {
+				}
+				b_ostroleka = {
+				}
+				b_wizna = {
+				}
+				b_kolno = {
+				}
+				b_swieck = {
+				}
+				b_nur = {
+				}
+				b_radzilow = {
+				}
+			}
+			c_sieradzko-leczyckie = {	#Since HF, is now basically Czersk & Warsaw
+				color={ 160 40 40 }
+				color2={ 255 255 255 }
+			
+				b_gostynin = {
+				}
+				b_lowicz = {
+				}
+				b_warszawa = {
+				}
+				b_czersk = {
+				}
+				b_sochaczew = {
+				}
+				b_grojec = {
+				}
+				b_rawska = {
+				}
+			}
+		}
+
+		d_greater_poland = { 
+			color={ 140 13 13 }
+			color2={ 255 255 255 }
+			
+			capital = 431 # Poznanskie
+		
+			c_lubusz = {
+				color={ 135 30 30 }
+				color2={ 255 255 255 }
+				
+				german = Lebus
+				swedish = Lebus
+				norse = Lebus
+				norwegian = Lebus
+				danish = Lebus
+			
+				b_lubusz = {
+					german = Lebus
+					swedish = Lebus
+					norse = Lebus
+					norwegian = Lebus
+					danish = Lebus
+				}
+				b_mysliborz = {
+				}
+				b_kostrzyn = {
+				}
+				b_cedynia = {
+				}
+				b_pryzyce = {
+				}
+				b_sulecin = {
+				}
+				b_sulecia = {		#fictional
+				}
+				b_nadodra = {		#fictional
+				}
+			}
+			c_gnieznienskie = {			#Since HF, is now Naklo
+				color={ 125 6 2 }
+				color2={ 255 255 255 }
+			
+				b_naklo = {
+				}
+				b_kamien = {
+				}
+				b_kcynia = {
+				}
+				b_pila = {
+				}
+				b_lubiewo = {		#modern
+				}
+				b_podgaje = {		#modern
+				}
+				b_bialaziema = {	#fictional
+				}
+			}
+			c_poznanskie = {
+				color={ 145 6 2 }
+				color2={ 255 255 255 }
+				
+				german = Posen
+				swedish = Posen
+				norse = Posen
+				norwegian = Posen
+				danish = Posen
+			
+				b_poznan = {
+					german = Posen
+					swedish = Posen
+					norse = Posen
+					norwegian = Posen
+					danish = Posen
+				}
+				b_oborniki = {
+				}
+				b_czarnkow = {
+				}
+				b_koscian = {
+				}
+				b_miedzyrzecz = {
+				}
+				b_walcz = {
+				}
+				b_wschowa = {
+				}
+			}
+			c_kaliskie = {
+				color={ 155 6 20}
+				color2={ 255 255 255 }
+			
+				b_gniezno = {		#Moved here with HF
+					german = Gnesen
+					swedish = Gnesen
+					norse = Gnesen
+					norwegian = Gnesen
+					danish = Gnesen
+				}
+				b_kalisz = {
+				}
+				b_konin = {
+				}
+				b_sroda = {
+				}
+				b_pyzdry = {
+				}
+				b_kolo = {
+				}
+				b_kozmin = {
+				}
+			}
+		}
+		d_silesia = {
+			color={ 169 35 75 }
+			color2={ 255 255 255 }
+			
+			capital = 435 # Upper Silesia
+		
+			c_lower_silesia = {
+				color={ 170 30 30 }
+				color2={ 255 255 255 }
+			
+				b_glogow = {
+					german = Glogau
+					swedish = Glogau
+					norse = Glogau
+					norwegian = Glogau
+					danish = Glogau
+				}
+				b_zielonagora = {
+				}
+				b_krosno = {
+					german = Krossen
+					swedish = Krossen
+					norse = Krossen
+					norwegian = Krossen
+					danish = Krossen
+				}
+				b_nowogrod = {
+				}
+				b_swiebozin = {
+				}
+				b_bytomodrz = {
+				}
+				b_zagan = {
+					german = Sagan
+					swedish = Sagan
+					norse = Sagan
+					norwegian = Sagan
+					danish = Sagan
+				}
+			}
+			c_upper_silesia = {			#With HF, this is renamed to "Wroclaw"
+				color={ 200 50 70 }
+				color2={ 255 255 255 }
+			
+				german = Breslau
+				swedish = Breslau
+				norse = Breslau
+				norwegian = Breslau
+				danish = Breslau
+			
+				b_wroclaw = {
+					german = Breslau
+					swedish = Breslau
+					norse = Breslau
+					norwegian = Breslau
+					danish = Breslau
+				}
+				b_legnica = {
+					german = Liegnitz
+					swedish = Liegnitz
+					norse = Liegnitz
+					norwegian = Liegnitz
+					danish = Liegnitz
+				}
+				b_brzeg = {
+					german = Brieg
+					swedish = Brieg
+					norse = Brieg
+					norwegian = Brieg
+					danish = Brieg
+				}
+				b_boleslawiec = {
+				}
+				b_olesnica= {
+				}
+				b_niemcza = {
+				}
+				b_henrykow = {
+					german = Heinrichau
+					swedish = Heinrichau
+					norse = Heinrichau
+					norwegian = Heinrichau
+					danish = Heinrichau
+				}
+			}
+			c_opole = {					#With HF, this is renamed to "Upper Silesia"
+				color={ 218 37 15 }
+				color2={ 255 255 255 }
+			
+				b_opole = {
+					german = Uppeln
+					swedish = Uppeln
+					norse = Uppeln
+					norwegian = Uppeln
+					danish = Uppeln
+				}
+				b_lubliniec = {
+				} 
+				b_kozle = {
+				}
+				b_strzelce = {
+				}
+				b_rybnik = {
+				}
+				b_siewerz = {
+				}
+				b_raciborz = {
+				}
+			}
+			c_cieszyn = {
+				color={ 127 6 2 }
+				color2={ 255 255 255 }
+				
+				german = Teschen
+				swedish = Teschen
+				norse = Teschen
+				norwegian = Teschen
+				danish = Teschen
+			
+				b_cieszyn = {
+					german = Teschen
+					swedish = Teschen
+					norse = Teschen
+					norwegian = Teschen
+					danish = Teschen
+				}
+				b_oswiecim = {
+				}
+				b_zywiec = {
+				}
+				b_bielsko = {
+				}
+				b_pszczyna = {
+				}
+				b_zator = {
+				}
+				b_skoczow = {
+				}
+			}
+		}
+		d_lesser_poland = { 
+			color={ 245 163 176 }
+			color2={ 255 255 255 }
+			
+			capital = 527 # Krakowskie
+
+			c_krakowskie = {
+				color={ 137 6 20 }
+				color2={ 255 255 255 }
+				
+				german = Krakau
+				swedish = Krakau
+				norse = Krakau
+				norwegian = Krakau
+				danish = Krakau
+			
+				b_krakow = {
+					german = Krakau
+					swedish = Krakau
+					norse = Krakau
+					norwegian = Krakau
+					danish = Krakau
+				}
+				b_jedrzejow = {
+				}
+				b_wieliczka = {
+				}
+				b_bochnia = {
+				}
+				b_olsztyn = {
+				}
+				b_zakopane = {
+				}
+				b_czestochowa = {
+				}
+			}
+			c_sacz = {
+				color={ 117 6 2 }
+				color2={ 255 255 255 }
+				
+				german = Sandez
+				swedish = Sandez
+				norse = Sandez
+				norwegian = Sandez
+				danish = Sandez
+			
+				b_nowysacz = {
+					german = "Neu Sandez"
+					swedish = Nysand
+					norse = Nysand
+					norwegian = Nysand
+					danish = Nysand
+				}
+				b_gorlice = {
+				}
+				b_szczyrzycz = {
+				}
+				b_tarnow = {
+				}
+				b_pilzno = {
+				}
+				b_mielec = {
+				}
+				b_biecz = {
+				}
+			}
+			c_sandomierskie = {
+				color={ 147 16 2 }
+				color2={ 255 255 255 }
+			
+				b_sandomierz = {
+				}
+				b_radom = {
+				}
+				b_kielce = {
+				}
+				b_olescnica = {
+				}
+				b_wislica = {
+				}
+				b_opoczno = {
+				}
+				b_opatow = {
+				}
+			}
+			c_lubelska = {			#New with HF
+				color={ 147 40 2 }
+				color2={ 255 255 255 }
+			
+				b_lublin = {
+				}
+				b_parczew = {
+				}
+				b_urzedow = {
+				}
+				b_goraj = {
+				}
+				b_zamosc = {		#modern
+				}
+				b_podwieprza = {	#fictional
+				}
+				b_nadwisla = {		#fictional
+				}
+			}
+			c_stezycka = {			#New with HF
+				color={ 127 30 2 }
+				color2={ 255 255 255 }
+			
+				b_stezyca = {
+				}
+				b_lukow = {
+				}
+				b_kock = {
+				}
+				b_ryki = {				#modern
+				}
+				b_deblin = {			#modern
+				}
+				b_radzyn = {			#modern
+				}
+				b_stoczeklukowski = {	#modern
+				}
+			}
+		}
+		d_kuyavia = { 
+			color={ 115 30 50 }		
+			color2={ 255 255 255 }
+			
+			capital = 428 # Kujawy
+		
+			c_kujawy = {			#In HF moved to more geographically accurate location
+				color={ 210 50 10 }
+				color2={ 255 255 255 }
+			
+				b_bygdoszcz = {
+				}
+				b_leczyca = {
+				}
+				b_kruszwica = {
+				}
+				b_brzesckujawskie = {
+				}
+				b_klodawa = {
+				}
+				b_nieszawa = {
+				}
+				b_inowroclaw = {
+				}
+			}
+			c_dobrzynska = {		#New with HF
+				color={ 200 60 20 }
+				color2={ 255 255 255 }
+			
+				b_dobrzyn = {
+				}
+				b_wloclawek = {
+				}
+				b_lipno = {
+				}
+				b_rypin = {
+				}
+				b_skepe = {
+				}
+				b_michalowo = {
+				}
+				b_kikot = {
+				}
+			}
+			c_wielunska = {				#new with HF
+				color={ 180 60 25 }
+				color2={ 255 255 255 }
+			
+				b_wielun = {
+				}
+				b_grabow = {
+				}
+				b_ostrzeszow = {
+				}
+				b_wierzchlas = {
+				}
+				b_osjakow = {
+				}
+				b_ostrowek = {
+				}
+				b_czarnozyly = {
+				}
+			}
+			c_sieradzka = {				#new with HF
+				color={ 210 75 10 }
+				color2={ 255 255 255 }
+				
+				german = Schieratz
+				swedish = Schieratz
+				norse = Schieratz
+				norwegian = Schieratz
+				danish = Schieratz
+			
+				b_sieradz = {
+					german = Schieratz
+					swedish = Schieratz
+					norse = Schieratz
+					norwegian = Schieratz
+					danish = Schieratz
+				}
+				b_piotrkow = {
+				}
+				b_przedborz = {
+				}
+				b_szadek = {
+				}
+				b_radomsko = {
+				}
+				b_turek = {
+				}
+				b_rozprza = {
+				}
+			}
+		}
+	}
+	
+	k_pomerania = {
+		color={ 145 130 40 }
+		color2={ 220 220 20 }
+		
+		culture = pommeranian
+		
+		capital = 366 #Stettin
+		
+		catholic = 400 # Crusade target weight
+		slavic_pagan_reformed = 500 # Crusade target weight
+		norse_pagan_reformed = 100 # Crusade target weight
+		baltic_pagan_reformed = 100 # Crusade target weight
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = pagan_group
+				}
+			}
+		}
+		
+		d_lausitz = {
+			color={ 160 135 145 }
+			color2={ 220 220 20 }
+
+			capital = 364 # Lausitz
+
+			c_lausitz = {
+				color={ 174 174 174 }
+				color2={ 255 255 255 }
+
+				pommeranian = Luzycka
+				
+				b_lebusa = {
+				}
+				b_dobrilugk = {
+				} 
+				b_lebus = {
+					pommeranian = Lubiazu
+				}
+				b_cottbus = {
+					pommeranian = Chosebuz
+				}
+				b_rothenburg = {
+				}
+				b_forst = {
+				}
+				b_zittau = {
+					pommeranian = Zitawa
+				}
+				b_luckau = {
+					pommeranian = Luckawa
+				}
+			}
+			c_anhalt = {
+				color={ 184 184 184 }
+				color2={ 255 255 255 }
+
+				pommeranian = Zirwisti
+				
+				b_zerbst = {	
+					pommeranian = Zirwisti
+				}
+				b_dessau = {
+				}
+				b_lindau_zeist = {}
+				b_walter-nienburg = {}
+				b_dornburg_zeist = {}
+				b_coswig = {}
+				b_wittenberg_zeist = {}
+			}
+			c_plauen = {
+				color={ 180 180 180 }
+				color2={ 255 255 255 }
+
+				pommeranian = Mjezybor
+				bohemian = Mezibor
+				
+				b_plauen = {
+					pommeranian = Ploni
+				}
+				b_leipzig = {
+					pommeranian = Lipsk
+				}
+				b_merseburg = {
+					pommeranian = Mjezybor
+					bohemian = Mezibor
+				}
+				b_halle = {
+					pommeranian = Dobrebora
+				}
+				b_knobelsdorf = {
+				}
+				b_zeitz = {
+					pommeranian = Cici
+				}
+				b_zwickau = {
+					pommeranian = Swikawa
+				}
+				b_naumburg = {
+				}
+			}
+		}
+		d_mecklemburg = {
+			color={ 162 160 110 }
+			color2={ 255 255 255 }
+			
+			capital = 260 #mecklemburg
+			
+			pommeranian = Obotritia
+
+			c_mecklemburg = {
+				color={ 207 207 207 }
+				color2={ 255 255 255 }
+
+				pommeranian = Weligrad
+				
+				b_mecklemburg = {
+					pommeranian = Weligrad
+				}
+				b_wismar = {
+					pommeranian = Vesimer
+				}
+				b_gevezin = {
+					pommeranian = Radgosc			
+				}
+				b_schwerin = {
+					pommeranian = Zuarina
+				}
+				b_lutzow = {
+				}
+				b_grevesmuhlen = {
+				}
+				b_parchim = {
+				}
+				b_hagenow = {
+				}
+			}
+
+			c_hamburg = {
+				color={ 225 225 225 }
+				color2={ 255 255 255 }
+				
+				danish = "Hamborg"
+				swedish = "Hamborg"
+				norwegian = "Hamborg"
+				norse = "Hamborg"
+				old_saxon = "Sturmaria"
+			
+				b_hamburg = {
+					danish = "Hamborg"
+					swedish = "Hamborg"
+					norwegian = "Hamborg"
+					norse = "Hamborg"
+				}
+				b_altona = {
+				}
+				b_harburg = {
+					danish = "Harborg"
+					swedish = "Harborg"
+					norwegian = "Harborg"
+					norse = "Harborg"
+				}
+				b_brunsbuttel = {
+				}
+				b_buxtehude = {
+				}
+				b_niendorf = {
+				}
+				b_lokstedt = {
+				}
+			}
+			c_lubeck = {
+				color={ 142 142 142 }
+				color2={ 255 255 255 }
+				
+				danish = "Lybæk"
+				swedish = "Lybäck"
+				norwegian = "Lybæk"
+				norse = "Lybæck"
+				pommeranian = "Liubice"
+				polish = "Liubice"
+				bohemian = "Liubice"
+				prussian = "Liubice"
+				old_saxon = "Liubice"
+				
+				b_lubeck = {
+					danish = "Lybæk"
+					swedish = "Lybäck"
+					norwegian = "Lybæk"
+					norse = "Lybæck"
+					pommeranian = "Liubice"
+					polish = "Liubice"
+					bohemian = "Liubice"
+					prussian = "Liubice"
+					old_saxon = "Liubice"
+				}
+				b_ratzeburg = {
+					danish = "Ratseborg"
+					swedish = "Ratseborg"
+					norse = "Ratseborg"
+					norwegian = "Ratseborg"
+				}
+				b_travemunde = {
+				}
+				b_wulfsdorf = {
+				}
+				b_schlutup = {
+				}
+				b_starigard = {
+				}
+				b_weslo = {
+				}
+				b_bucu = {
+				}
+			}
+		}
+		d_rugen = {
+			color= { 100 120 82 }
+			color2= { 255 255 255 }
+
+			capital = 304 #Rugen
+
+			pommeranian = Rana
+			danish = Rugia
+
+			c_rostock = {
+				color={ 204 204 204 }
+				color2={ 255 255 255 }
+
+				pommeranian = Rastokú
+				
+				b_rostock = {
+					pommeranian = Rastokú
+				}
+				b_penzlin = {	
+					pommeranian = Pentzelin	
+				}
+				b_gustrow = {	
+					pommeranian = Guscerov				
+				}
+				b_malchin = {
+				}
+				b_damgarten = {
+				}
+				b_strelitz = {
+					pommeranian = Streltza
+				}
+				#b_stargard = {		#Outcommented from here in HF as it should be instead a barony in c_stettin
+				#}
+				b_ahrensberg = {
+				}
+			}
+			c_werle = {
+				color={ 202 202 202 }
+				color2={ 255 255 255 }
+
+				pommeranian = Dymin
+				
+				b_waren = {
+				}
+				b_greifswald = {
+					pommeranian = Gripscogh
+				}
+				b_stralsund = {
+
+					pommeranian = Stralow
+				}
+				b_tribsees = {
+				}
+				b_demmin = {
+				}
+				b_treptow = {
+				}
+				b_friedland = {
+					pommeranian = Mirów
+				}
+				b_templin = {
+				}
+			}
+			c_rugen = {
+				color={ 201 201 201 }
+				color2={ 255 255 255 }
+
+				pommeranian = Rana
+
+				holy_site = slavic_pagan
+				holy_site = slavic_pagan_reformed
+				holy_site = baltic_pagan
+				holy_site = baltic_pagan_reformed
+				
+				b_charenza = {
+				}
+				b_arkona = {
+				}
+				b_rugard = {
+				}
+				b_putbus = {
+				}
+				b_barth = {
+				}
+				b_ralswiek = {
+				}
+				b_hiddensee = {
+				}
+				b_tribuzin = {
+				}
+			}
+		}
+		d_pommerania = {
+			color={ 111 143 51 }
+			color2={ 255 255 255 }
+			
+			capital = 366 # Stettin
+		
+			c_wolgast = {
+				color={ 121 163 58 }
+				color2={ 255 255 255 }
+
+				pommeranian = Wologoszcz
+			
+				b_wolgast = {
+					pommeranian = Wologoszcz
+				}
+				b_usedom = {
+					pommeranian = Uznjöm
+				}
+				b_anklam = {	
+					pommeranian = Taglim			
+				}
+				b_ueckermunde = {
+				}
+				b_zinnowitz = {
+				}
+				b_zussow = {
+				}
+				b_kemnitz = {
+				}
+				b_eggesin = {
+				}
+			}
+			c_stettin = {
+				color={ 91 163 48 }
+				color2={ 255 255 255 }
+				
+				pommeranian = Szczecin
+			
+				b_soldin = {
+				}
+				b_stettin = {
+
+					pommeranian = Szczecin
+				}
+				b_wollin = {
+				} 
+				b_stargard = {
+				}
+				b_kammin = {
+				}
+				b_kolbatz = {
+				}
+				b_cedene = {
+				}
+				b_pyritz = {
+				}
+			}
+			c_neumark = {
+				color={ 91 143 40}
+				color2={ 255 255 255 }
+				
+				pommeranian = "Santok"
+				polish = "Santok"
+			
+				b_santok = {
+				}
+				b_driesen = {
+				} 
+				b_bernstein = {
+				}
+				b_dramburg = {
+				}
+				b_tempelburg = {
+				}
+				b_schivelbein = {
+				}
+				b_drawa = {
+				}
+			}
+		}
+		d_pomeralia = {
+			color={ 95 135 77 }
+			color2={ 255 255 255 }
+			
+			capital = 368 # Danzig
+		
+			c_danzig = {
+				color={ 115 139 70 }
+				color2={ 255 255 255 }
+				
+				pommeranian = "Gdansk"
+				polish = "Gdansk"
+				bohemian = "Gdansk"
+				russian = "Gdansk"
+				prussian = "Gdansk"
+				lithuanian = "Gdansk"
+				lettigallish = "Gdansk"
+				swedish = "Danzig"
+				norse = "Danzig"
+				norwegian = "Danzig"
+				danish = "Danzig"
+			
+				b_puck = {
+				}
+				b_danzig = {
+					pommeranian = "Gdansk"
+					polish = "Gdansk"
+					bohemian = "Gdansk"
+					russian = "Gdansk"
+					prussian = "Gdansk"
+					lithuanian = "Gdansk"
+					lettigallish = "Gdansk"
+					swedish = "Danzig"
+					norse = "Danzig"
+					norwegian = "Danzig"
+					danish = "Danzig"
+				}
+				b_oliva = {
+				}
+				b_tuchel = {
+				}
+				b_schwetz = {
+				}
+				b_danlauenburg = {
+				}
+				b_mewe = {
+				}
+				b_schlochau = {
+				}
+			}
+			c_bytow = {
+				color={ 5 133 25 }
+				color2={ 255 255 255 }
+				
+				b_bytow = {
+				}
+				b_lebork = {
+				}
+				b_lupawa = {
+				}
+				b_lebe = {
+				}
+				b_carbero = {
+				}
+				b_swolow = {
+				}
+				b_parchowy = {
+				}
+			}
+			c_slupsk = {
+				color={ 6 155 25 }
+				color2={ 255 255 255 }
+				
+				german = "Stolp"
+				swedish = "Stolp"
+				norwegian = "Stolp"
+				danish = "Stolp"
+				norse = "Stolp"
+			
+				b_rugenwalde = {
+				}
+				b_slupsk = {
+					german = "Stolp"
+					swedish = "Stolp"
+					norwegian = "Stolp"
+					danish = "Stolp"
+					norse = "Stolp"
+				}
+				b_colberg = {
+				}
+				b_schlawe = {
+				}
+				b_corlin = {
+				}
+				b_gerwin = {
+				}
+				b_ustka = {
+				}
+				b_belgard = {
+				}
+			}
+		}
+		d_brandenburg = {
+			color={ 121 121 121 }
+			color2={ 255 255 255 }
+			
+			capital = 365 #Brandenburg
+
+			pommeranian = "Sorbia" # Brennaburg
+			
+			c_brandenburg = {
+				color={ 186 186 186 }
+				color2={ 255 255 255 }
+
+				pommeranian = Brennaburg
+				
+				b_brandenburg = {
+					pommeranian = Brennaburg	
+				}
+				b_berlin = {
+				}
+				b_juterborg = {
+					pommeranian = Jutriboc
+				}
+				b_belzig = {
+				}
+				b_ruppin = {
+				}
+				b_oranienburg = {
+					pommeranian = Bochzowe
+				}
+				b_muncheberg = {
+				}
+			}
+			c_havelberg = {
+				color={ 186 186 160 }
+				color2={ 255 255 255 }
+
+				pommeranian = "Lenzen"
+
+				b_lenzen = {}
+				b_havelberg = {
+					pommeranian = "Brisanen"
+				}
+				b_wittstock = {
+					pommeranian = "Vysoka"
+				}
+				b_plattenburg = {
+					pommeranian = "Prignitz"
+				}
+				b_wilsnack = {}
+				b_jerichow = {}
+				b_schonhausen = {}
+			}
+		}
+		d_meissen = {
+			color={ 182 188 181 }
+			color2={ 255 255 255 }
+			
+			capital = 312 #Meissen
+
+			pommeranian = Nisani
+		
+			c_meissen = {
+				color={ 177 177 177 }
+				color2={ 255 255 255 }
+
+				pommeranian = Nisani
+				
+				b_dresden = {
+					pommeranian = Drezdany
+				}
+				b_meissen = {
+					pommeranian = Misni
+				}
+				b_dohna = {
+				}
+				b_belgern = { # Called Altenburg
+				}
+				b_strehla = {
+				}
+				b_rabenau = {
+				}
+				b_wettin = {
+				}
+				b_radeburg = {
+				}
+			}
+			c_gorlitz = {
+				color={ 164 164 164 }
+				color2={ 255 255 255 }
+				
+				polish = "Zgorzelice"
+				pommeranian = "Zgorzelice"
+				bohemian = "Zhorelec"
+				
+				b_gorlitz = {
+					pommeranian = Zhorjelc
+				}
+				b_bautzen = {
+					pommeranian = Budysin
+				} 
+				b_herrhut = {
+				}
+				b_spremberg = {
+				}
+				b_ylustiaberg = {
+				}
+				b_priebus = {
+				}
+				b_bischolow = {
+				}
+			}
+		}
+	}
+
+	k_lithuania = {
+		color={ 90 10 0 }
+		color2={ 255 255 255 }
+		
+		capital = 420 # Aukshayts
+		
+		culture = lithuanian
+		
+		prussian = "Prussia"
+		
+		catholic = 50 # Crusade target weight
+		slavic_pagan_reformed = 100 # Crusade target weight
+		baltic_pagan_reformed = 500
+		finnish_pagan_reformed = 100
+		
+		d_prussia = {
+			color={ 200 100 100 }
+			color2={ 255 255 255 }
+			
+			capital = 370 # Marienburg
+			
+			prussian = "Pruthenia"
+			lithuanian = "Pruthenia"
+			lettigallish = "Pruthenia"
+			
+			c_marienburg = {
+				color={ 185 90 90 }
+				color2={ 255 255 255 }
+					
+				b_marienburg = {
+				}
+				b_braunsberg = {
+				}
+				b_elbing = {
+				}
+				b_christburg = {
+				}
+				b_heilsberg = {
+				}
+				b_bartenstein = {
+				}
+				b_marienwerder = {
+				}
+				b_balga = {
+				}
+			}
+			c_galindia = {
+				color={ 185 90 90 }
+				color2={ 255 255 255 }
+					
+				b_angerburg = {
+				}
+				b_osterode = {
+				}
+				b_nikelshagen = {
+				}
+				b_gilgenburg = {
+				}
+				b_treuburg = {
+				}
+				b_hohenstein = {
+				}
+				b_neidenburg = {
+				}
+				b_wielbark = {
+				}
+			}
+			c_sambia = {
+				color={ 190 80 80 }
+				color2={ 255 255 255 }
+				
+				lithuanian = "Semba"
+				lettigallish = "Semba"
+				german = "Samland"
+				swedish = "Samland"
+				norse = "Samland"
+				danish = "Samland"
+				norwegian = "Samland"
+					
+				b_konigsberg = {
+					polish = "Krolewiec"
+					prussian = "Krolewiec"
+					pommeranian = "Krolewiec"
+					lithuanian = "Krolewiec"
+					lettigallish = "Krolewiec"
+					bohemian = "Krolewiec"
+				}
+				b_fischhausen = {
+					prussian = "Romowe"
+					pommeranian = "Romowe"
+					lithuanian = "Romowe"
+					lettigallish = "Romowe"	
+				}
+				b_sambrandenburg = {
+					polish = "Bramborska"
+					prussian = "Bramborska"
+					pommeranian = "Bramborska"
+				}
+				b_tapiau = {
+				}
+				b_labiau = {
+				}
+				b_frombork = {
+				}
+				b_wiskiauten = {
+				}
+				b_cranz = {
+				}
+			}
+			
+			c_chelminskie = {
+				color={ 170 70 70 }
+				color2={ 255 255 255 }
+				
+				german = "Kulm"
+				swedish = "Kulm"
+				norwegian = "Kulm"
+				danish = "Kulm"
+				norse = "Kulm"
+
+				holy_site = baltic_pagan
+				holy_site = baltic_pagan_reformed
+				
+				b_chelmno = {
+					german = "Kulm"
+					swedish = "Kulm"
+					norse = "Kulm"
+					norwegian = "Kulm"
+					danish = "Kulm"
+				}
+				b_kulm = {
+				}
+				b_thorn = {
+				}
+				b_niedenburg = {
+				}
+				b_rehden = {
+				}
+				b_lobau = {
+				}
+				b_eylau = {
+				}
+				b_briesen = {
+				}
+			}
+		}
+		d_lithuanians = {
+			color={ 81 0 0 }
+			color2={ 255 255 255 }
+			
+			capital = 420 # Aukshayts
+			
+			c_aukshayts = {				#Vilnius
+				color={ 146 17 17 }
+				color2={ 255 255 255 }
+			
+				polish = "Wilno"
+				german = "Wilna"
+			
+				b_vilnius = {
+					polish = "Wilno"
+					german = "Wilna"
+				}
+				b_trakai = {
+				}
+				b_kreva = {
+				}
+				b_alsenai = {
+				}
+				b_asmena = {
+				}
+				b_eliskes = {
+				}
+				b_medininkai = {
+				}
+			}
+			
+			c_yatvyagi = {			 #Kaunas
+				color={ 127 69 20 }
+				color2={ 255 255 255 }
+				
+				polish = "Kowno"
+				
+				b_kaunas = {
+					polish = "Kowno"
+				}
+				b_darsuniskis = {
+				}
+				b_alytus = {
+				}
+				b_birstonas = {
+				}
+				b_vilkaviskis = {
+				}
+				b_raiziai = {
+				}
+				b_gailen = {
+				}
+			}
+			
+			c_nalsia = {		
+				color={ 135 22 22 }
+				color2={ 255 255 255 }
+			
+				b_utena = {
+				}
+				b_svencionys = {
+				}
+				b_kernave = {
+				}
+				b_nemencine = {
+				}
+				b_ukmerge = {
+				}
+				b_anyksciai = {
+				}
+				b_nerisia	= {		#fictional, based on the bordering river Neris
+				}
+			}
+			
+			c_deltuva = {		
+				color={ 135 30 30 }
+				color2={ 255 255 255 }
+			
+				b_deltuva = {
+				}
+				b_upyte = {
+				}
+				b_ariogala = {
+				}
+				b_betygala = {
+				}
+				b_junigeda = {
+				}
+				b_velluona = {
+				}
+				b_siauliai = {
+				}
+			}
+			
+			c_zhmud = { # Samogitia		#moved here with HF, as they are Lithuanians Lowlanders
+				color={ 166 81 81 }
+				color2={ 255 255 255 }
+				
+				german = "Sameiten"
+				prussian = "Zhmud"
+				lithuanian = "Zemaitija"
+				polish = "Zhmudz"
+				russian = "Zhmud"
+				pommeranian = "Zhmud"
+				bohemian = "Zhmud"
+				lettigallish = "Zemaiteje"
+				
+				dignity = 1		#Just so that in early history, it defaults to this instead of Deltuva as main
+				
+				b_jurbarkas = {
+					german = "Georgenburg"
+					swedish = "Georgsborg"
+					norse = "Georgsborg"
+					danish = "Georgsborg"
+					norwegian = "Georgsborg"
+				}
+				b_raseiniai = {
+					german = "Raseinen"
+					swedish = "Raseinen"
+					norse = "Raseinen"
+					danish = "Raseinen"
+					norwegian = "Raseinen"
+				}
+				b_zarenai = {
+				}
+				b_tverai = {
+				}
+				b_kraziai = {
+				}
+				b_knituva = {
+				}
+				b_siautuna = {
+				}
+			}
+		}
+		d_courland = { 
+			color={ 182 16 16 }
+			color2={ 255 255 255 }
+			
+			capital = 373 # Kurzeme
+			
+			german = "Kurland"
+			swedish = "Kurland"
+			norse = "Kurland"
+			danish = "Kurland"
+			norwegian = "Kurland"
+			lettigallish = Curonia
+			lithuanian = Curonia
+			prussian = Curonia
+			
+			c_kurs = {
+				color={ 182 24 24 }
+				color2={ 255 255 255 }
+				
+				german = "Kurland"
+				swedish = "Kurland"
+				norse = "Kurland"
+				danish = "Kurland"
+				norwegian = "Kurland"
+				
+				b_grobin = {
+				}
+				b_medze = {
+				}
+				b_vartaja = {
+				}
+				b_kuldiga = {
+				}
+				b_aizpute = {
+				}
+				b_apule = {
+				}
+				b_impilte = {
+				}
+			}
+			c_vanema = {
+				color={ 182 40 40 }
+				color2={ 255 255 255 }
+				
+				b_vanema = {
+				}
+				b_matkule = {
+				}
+				b_lagzdene = {
+				}
+				b_piltyn = {
+				}
+				b_rumen = {
+				}
+				b_talsen = {
+				}
+				b_ventspils = {
+				}
+			}
+		}
+		d_samogitia = {
+			color={ 150 70 70 }
+			color2={ 255 255 255 }
+			
+			capital = 421 # Samogitia
+			
+			german = "Sclavonia"
+			prussian = "Sclavonia"
+			lithuanian = "Skalva"
+			polish = "Skalowia"
+			russian = "Skalovia"
+			pommeranian = "Skalowia"
+			bohemian = "Skalowia "
+			lettigallish = "Skalva"
+			
+			c_scalovia = {
+				color={ 190 85 85 }
+				color2={ 255 255 255 }
+					
+				b_ragnit = {
+					pommeranian = "Ragneta"
+					polish = "Ragneta"
+					bohemian = "Ragneta"
+					russian = "Ragneta"
+					prussian = "Ragnita"
+					lithuanian = "Ragaine"
+					lettigallish = "Ragaine"
+				}
+				b_russ = {
+				}
+				b_jurgaiten = {
+				}
+				b_jomsberg = {
+				}
+				b_tilgit = {
+				} 
+				b_splitter = {
+				}
+				b_strewa = {
+				}
+				b_skomanten = {
+				}
+			}
+			c_memel = {
+				color={ 166 85 85 }
+				color2={ 255 255 255 }
+				
+				b_memel = {
+				}
+				b_kretingale = {
+				}
+				b_gargzdai = {
+					german = "Garsden"
+					swedish = "Garsden"
+					norse = "Garsden"
+					danish = "Garsden"
+					norwegian = "Garsden"
+					polish = "Gorzdy"
+					russian = "Gorzhdy"
+				}
+				b_kaup = {
+				}
+				b_juodkrante = {
+				}
+				b_nida = {
+					german = "Nidden"
+				}
+				b_dreverna = {
+				}
+				b_palanga = {
+				}
+			}
+		}
+		
+		d_latgale = {					#New with HF
+		
+			color={ 165 70 45 }
+			color2={ 255 255 255 }
+			
+			capital = 1594 # Jersika
+			
+			c_west_dvina = {			#Moved here from Polock
+				color={ 125 18 18 }
+				color2={ 255 255 255 }
+				
+				swedish = "Lettgallen"
+				norse = "Lettgallen"
+				danish = "Lettgallen"
+				norwegian = "Lettgallen"
+				german = "Lettgallen"
+			
+				b_erle = {
+				}
+				b_kreuzburg = {
+					ugricbaltic = Krustpilsi
+					polish = Krzyzbork
+					lithuanian = Krustpils
+				}
+				b_daugavpils = {
+					german = "Dünaburg"
+					swedish = "Dynaborg"
+					norse = "Dynaborg"
+					danish = "Dynaborg"
+					norwegian = "Dynaborg"
+					finnish = "Väinänlinna"
+					russian = "Dvinsk"
+					ugricbaltic = Väinalinn
+					polish = Dyneburg
+					lithuanian = Daugpilis
+				}
+				b_balvi = {
+					lithuanian = Balvai
+				}
+				b_rezekne = {
+					polish = Rzezyca
+				}
+				b_kraslava = {
+					polish = Kraslaw
+				}
+				b_vilaka = {
+					lithuanian = Viliaka
+				}
+				b_varakjani = {
+					ugricbaltic = Varaklani
+					german = Varaklani
+				}
+				b_ludza = {
+					polish = Lucyn
+				}
+			}
+			c_jersika = {
+				color={ 125 36 12 }
+				color2={ 255 255 255 }
+			
+				german = Gerzika
+			
+				b_jersika = {
+					german = Gerzika
+				}
+				b_koknese = {
+					german = Kokenhusen
+				}
+				b_alene = {
+				}
+				b_marciena = {
+				}
+				b_negeste = {
+				}
+				b_asote = {
+				}
+				b_autine = {
+				}
+			}
+			c_talava = {
+				color={ 125 60 12 }
+				color2={ 255 255 255 }
+			
+				b_satekle = {
+				}
+				b_metsene = {
+				}
+				b_trikata = {
+				}
+				b_gulbene = {
+				}
+				b_aluksne = {
+				}
+				b_imera = {
+				}
+				b_vijciems = {
+				}
+			}
+			c_selija = {		#Placed here in HF as they're not big enough to warrant their own duchy more than the titular one
+				color={ 180 30 30 }
+				color2={ 255 255 255 }
+
+				b_selpils = {
+				}
+				b_dignaja = {
+				}
+				b_dubenou = {
+				}
+				b_rackiska = {
+				}
+				b_lichsta = {
+				}
+				b_rurezeme = {
+				}
+				b_ozikel = {
+				}
+				b_varviai = {
+				}
+			}
+		}
+		d_livonia = {
+			color={ 110 50 50 }
+			color2={ 255 255 255 }
+			
+			capital = 375 # Liivimaa
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 2
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			c_riga = {
+				color={ 100 50 50 }
+				color2={ 255 255 255 }
+				
+				holy_site = baltic_pagan
+				holy_site = baltic_pagan_reformed
+				
+				b_riga = {
+				}
+				b_ledurga = {
+				}
+				b_salaspils = {
+				}
+				b_sigulda = {
+				}
+				b_ikskile = {
+				}
+				b_turaida = {
+				}
+				b_ropazi = {
+				}
+			}
+			c_tukums = {
+				color={ 100 50 75 }
+				color2={ 255 255 255 }
+				
+				b_tukums = {
+				}
+				b_dundaga = {
+					swedish = "Dondangen"
+					norse = "Dondangen"
+					danish = "Dondangen"
+					norwegian = "Dondangen"
+					german = "Dondangen"
+				}
+				b_kandava = {
+					swedish = "Candaw"
+					norse = "Candaw"
+					danish = "Candaw"
+					norwegian = "Candaw"
+					german = "Candaw"
+				}
+				b_sabile = {
+					swedish = "Sebel"
+					norse = "Sebel"
+					danish = "Sebel"
+					norwegian = "Sebel"
+					german = "Sebel"
+				}
+				b_talsi = {
+					swedish = "Talsen"
+					norse = "Talsen"
+					danish = "Talsen"
+					norwegian = "Talsen"
+					german = "Talsen"
+				}
+				b_kayeva = {
+					swedish = "Cayeven"
+					norse = "Cayeven"
+					danish = "Cayeven"
+					norwegian = "Cayeven"
+					german = "Cayeven"
+				}
+				b_bulla = {
+					swedish = "Bullen"
+					norse = "Bullen"
+					danish = "Bullen"
+					norwegian = "Bullen"
+					german = "Bullen"
+				}
+			}
+			
+			c_zemigalians = {		#moved here with HF. Not big enough to get their own duchy, more than the titular duchy, so attached to the Livonian sphere of Influence
+				color={ 182 20 20 }
+				color2={ 255 255 255 }
+				
+				b_mezotne = {
+				}
+				b_tervete = {
+				}
+				b_dobele = {
+				}
+				b_jelgawa = {
+				}
+				b_sparnene = {
+				}
+				b_dobe = {
+				}
+				b_rakte = {
+				}
+			}
+		}
+		d_yatviags = {
+			color={ 149 97 97 }
+			color2={ 255 255 255 }
+			
+			capital = 424 # Grodno
+			
+			c_jacwiez = { # Grodno
+				color={ 141 32 30 }
+				color2={ 255 255 255 }
+			
+				b_jacwiez = {
+				}
+				b_novogrudok = {
+				}
+				b_grodno = {
+				}
+				b_iuje = {
+				}
+				b_skidziel = {
+				}
+				b_mir = {
+				}
+				b_niasvizh = {
+				}
+				b_zirmuny = {
+				}
+			}
+			c_sudovia = {			#Sudovia // moved there with HF
+				color={ 146 21 21 }
+				color2={ 255 255 255 }
+			
+				b_merkine = {
+				}
+				b_rudamina = {
+				}
+				b_liskiava = {
+				}
+				b_hrodna = {
+				}
+				b_suvalkai = {
+				}
+				b_augustavas = {
+				}
+				b_seiniai = {
+				}
+			}
+		}
+	}
+	
+	k_bohemia = {
+        color={ 176 110 32 }
+        color2={ 255 255 255 }
+        
+        culture = bohemian
+        
+        capital = 437 # Praha
+        
+        catholic = 400 # Crusade target weight
+        slavic_pagan_reformed = 100 # Crusade target weight
+        baltic_pagan_reformed = 50 # Crusade target weight
+        
+		allow = {
+			k_moravia = { has_holder = no }
+		}
+
+        d_bohemia = {
+           		color={ 195 110 11 }
+           		color2={ 255 255 255 }
+           
+           		capital = 437 # Praha
+           
+           		c_domazlice = {
+               		color={ 197 112 13 }
+               		color2={ 255 255 255 }
+					
+               		bohemian = "Jižní Cechy"
+               		pommeranian = "Jizni Cechy"
+               		polish = "Jizni Cechy"
+               		croatian = "Jizni Cechy"
+               		serbian = "Jizni Cechy"
+               		bulgarian = "Jizni Cechy"
+					bosnian = "Jizni Cechy"
+                	russian = "Jizni Cechy"
+                	ilmenian = "Jizni Cechy"
+                	severian = "Jizni Cechy"
+                	volhynian = "Jizni Cechy"
+                	german = "Sudböhmen"
+                	norse = "Sudböhmen"
+                	swedish = "Sudböhmen"
+                	danish = "Sudböhmen"
+                	norwegian = "Sudböhmen"
+                	old_frankish = "Sudböhmen"
+                	old_saxon = "Sudböhmen"
+                	saxon = "Sudböhmen"
+                	suebi = "Sudböhmen"
+					slovieni = "Jižní Cechy"
+                
+                	b_prachen = {
+                	}
+                	b_doudleby = {
+                	}
+                	b_chynov = {
+                	}
+                	b_hohenfurth = {
+						bohemian = "Vyšší Brod"
+						slovieni = "Vyšší Brod"
+                	}
+                	b_rosenberg = {
+						bohemian = "Rožmberk"
+						slovieni = "Rožmberk"
+                	}
+                	b_budejovice = {
+						german = "Budweis"
+                	}
+                	b_pisek = {
+                	}
+                	b_krumlov = {
+						german = "Krumau"
+                	}
+                	b_goldenkron = {
+						bohemian = "Zlatá Koruna"
+						slovieni = "Zlatá Koruna"
+                	}
+                	b_resenberg = {}
+            		}
+            	c_praha = {
+                color={ 199 114 15 }
+                color2={ 255 255 255 }
+				
+					norse = Prag
+					swedish = Prag
+					danish = Prag
+					norwegian = Prag
+					german = Prag
+					lombard = Prag
+					old_frankish = Prag
+					suebi = Prag
+					saxon = Prag
+					old_saxon = Prag
+					pommeranian = Praha
+					bohemian = Praha
+					slovieni = Praha
+					polish = Praha
+					croatian = Praha
+					serbian = Praha
+					bulgarian = Praha
+					bosnian = "Praha"
+					russian = Praga
+					ilmenian = Praha
+					severian = Praha
+					volhynian = Praha
+                
+					b_praha = {
+						norse = Prag
+						swedish = Prag
+						danish = Prag
+						norwegian = Prag
+						german = Prag
+						lombard = Prag
+						old_frankish = Prag
+						suebi = Prag
+						saxon = Prag
+						old_saxon = Prag
+						pommeranian = Praha
+						bohemian = Praha
+						slovieni = Praha
+						polish = Praha
+						croatian = Praha
+						serbian = Praha
+						bulgarian = Praha
+						bosnian = "Praha"
+						russian = Praha
+						ilmenian = Praha
+						severian = Praha
+						volhynian = Praha
+					}
+                	b_brevnov = {
+                	}
+                	b_kuttenberg = {
+						german = Kuttenberg
+						norse = Kuttenberg
+						swedish = Kuttenberg
+						danish = Kuttenberg
+						saxon = Kuttenberg
+						old_saxon = Kuttenberg
+						bohemian = "Kutna Hora"
+						slovieni = "Kutná Hora"
+                	}
+                	b_vysehrad = {
+                	}
+                	b_kourim = {
+                	}
+                	b_kolin = {
+                	}
+                	b_stare_mesto = {
+                	}
+                	b_zbraslav = {
+                	}
+                	b_sazava = {
+						german = "Sassau"
+                	}
+				}
+            	c_litomerice = {
+              		color={ 203 118 19 }
+              		color2={ 255 255 255 }
+
+              		german = "Leitmeritz"
+					swedish = "Leitmeritz"
+					norse = "Leitmeritz"
+					danish = "Leitmeritz"
+					norwegian = "Leitmeritz"
+              
+              		b_litomerice = {
+						german = "Leitmeritz"
+						swedish = "Leitmeritz"
+						norse = "Leitmeritz"
+						danish = "Leitmeritz"
+						norwegian = "Leitmeritz"
+             		}
+					b_melnik_bohemia = {}
+					b_mnichovo_hradiste = {}
+					b_zitava = {}
+					b_duba_litomerice = {}
+					b_decin = {}
+					b_ceskalipa = {}
+					b_boleslav = {}
+					b_nymburk = {}
+				}
+				c_hradec = {
+                	color={ 200 104 38 }
+            		color2={ 255 255 255 }
+				
+					german = "Grätz"
+                
+                	b_hradeckralove = {
+						german = "Grätz"
+                	}
+					b_kladsko = {
+						german = "Glatz"
+						polish = "Klodzko"
+					}
+					b_zleby = {
+               		}
+					b_chrudim = {
+					}
+					b_caslav = {
+                	}
+					b_jaromer = {
+                	}
+                	b_litomysl = {
+                	}
+				}
+				c_plzen = {
+                	color={ 205 120 21 }
+                	color2={ 255 255 255 }
+                
+                	german = Pilsen
+					swedish = Pilsen
+					norse = Pilsen
+					danish = Pilsen
+					norwegian = Pilsen
+                
+                	b_plzen = {
+                		german = Pilsen
+						swedish = Pilsen
+						norse = Pilsen
+						danish = Pilsen
+						norwegian = Pilsen
+                	}
+                	b_plasy = {
+                	}
+               		b_stribo = {
+                	}
+                	b_klatovy = {
+                	}
+                	b_kladruby = {
+                	}
+                	b_primda = {
+                	}
+                	b_domazlice = {
+                	}
+            	}
+				c_zatec = {
+                	color={ 155 105 30 }
+                	color2={ 255 255 255 }
+				
+					german = "Saaz"
+                
+                	b_zatec = {
+						german = "Saaz"
+                	}
+					b_osek = {
+					}
+					b_louny = {
+                	}
+					b_bilina = {
+					}
+					b_kadan = {
+                	}
+					b_teplice = {
+                	}
+                	b_chomutov = {
+                	}
+            	}
+        }
+        d_moravia = {
+            color={ 157 101 35 }
+            color2={ 255 255 255 }
+            
+            capital = 440 # Olomouc
+            
+			c_znojmo = {
+				color={ 51 51 51 }
+				color2={ 255 255 255 }
+			
+				german = "Znaim"
+		
+				b_znojmo = {
+					german = "Znaim"
+				}
+				b_mikulov = {
+				}
+				b_trebic = {
+				}
+				b_pohansko = {
+				}
+				b_jihlava = {
+					german = "Iglau"
+				}
+				b_bitov = {
+				}
+				b_vranov = {
+				}
+				b_telc = {
+				}
+				b_louka = {
+				}
+				b_eibenshitz = {
+					bohemian = "Ivancice"
+					slovieni = "Ivancice"
+				}
+			}
+            c_olomouc = {
+                color={ 163 107 41 }
+               	color2={ 255 255 255 }
+                
+				german = "Olmütz"
+				polish = Olomuniec
+				
+                b_olomouc = {
+					german = "Olmütz"
+					polish = Olomuniec
+                }
+                b_velehrad = {
+                }
+                b_hradiste = {
+                }
+                b_svaty_kopecek = {
+                }
+                b_prerov = {
+                }
+                b_vyskov = {
+                }
+                b_unicov = {
+                }
+                b_zabreh = {
+                }
+            }
+            c_brno = {
+               	color={ 166 110 44 }
+            	color2={ 255 255 255 }
+               	
+				german = "Brünn"
+				
+                b_veligrad = {
+					slovieni = Velehrad
+                }
+                b_brno = {
+					german = "Brünn"
+				}
+                b_mikulcice = {
+                }
+                b_zdar = {
+                }
+                b_svitavy = {
+                }
+                b_rajhrad = {
+                }
+                b_pernstejn = {
+                }
+                b_hodonin = {
+                }
+                b_boskovice = {
+                }
+            }
+           	c_opava = {
+                color={ 163 110 44 }
+                color2={ 255 255 255 }
+				
+				german = "Troppau"
+				polish = "Opawa"
+                
+                b_opava = {
+					german = "Troppau"
+					polish = "Opawa"
+                }
+                b_krnov = {
+                }
+                b_bruntal = {
+                }
+                b_hradec_nad_moravici = {
+                }
+                b_hlubcice = {
+                }
+                b_holasovice = {
+                }
+                b_oldrisov = {
+                }
+            }
+        }
+	}
+}
+
+e_russia = {
+	color={ 147 164 104 }
+	color2={ 255 255 255 }
+	
+	capital = 547 # Kiev
+	
+	culture = russian
+	short_name = yes
+	
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = north_germanic
+				culture_group = east_slavic
+				culture_group = finno_ugric
+			}
+		}
+	}
+	
+	finnish = Suomi
+	lappish = Suomi
+	ugricbaltic = Suomi
+	komi = Suomi
+	samoyed = Suomi
+	mordvin = Suomi
+	meshchera = Suomi
+	
+	k_galicia-volhynia = {
+		color={ 50 150 130 }
+		color2={ 255 255 255 }
+		
+		capital = 535 # Vladimir Volynsky
+		
+		culture = russian
+		
+		slavic_pagan_reformed = 200 # Crusade target weight
+		baltic_pagan_reformed = 50 # Crusade target weight
+		tengri_pagan_reformed = 50
+		finnish_pagan_reformed = 50
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = north_germanic
+					culture_group = east_slavic 
+				}
+			}
+		}
+		
+		d_volhynia = {
+			color={ 204 155 121 }
+			color2={ 255 255 255 }
+			
+			capital = 535 # Vladimir Volynsky
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 3
+					texture_internal = 7
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "slavic_pagan"
+			}
+			
+			c_vladimir_volynsky = {
+				color={ 204 155 121 }
+				color2={ 255 255 255 }
+				
+				polish = "Wlodzimierz Wolynski"
+	
+				b_vladimirvolynsky = {
+					polish = "Wlodzimierz Wolynski"
+				}
+				b_luboml = {
+				}
+				b_kovel = {
+				}
+				b_lukiv = {
+				}
+				b_lityn = {
+				}
+				b_mochalky = {
+				}
+				b_okhotnyky = {
+				}
+			}
+			c_beresty = {
+				color={ 204 175 111 }
+				color2={ 255 255 255 }
+				
+				polish = "Brzesc"
+	
+				b_beresty = {
+				}
+				b_bielsk = {
+				}
+				b_kobryn = {
+				} 
+				b_kamyanyets = {
+				}
+				b_mielnik = {
+				}
+				b_koden = {
+				}
+				b_wlodawa = {
+				}
+				b_parwa = {			#fictional
+				}
+			}
+			c_lutsk = {
+				color={ 184 165 101 }
+				color2={ 255 255 255 }
+				
+				polish = "Luck"
+				
+				b_lutsk = {
+				}
+				b_dubno = {
+				}
+				b_jytomyr = {
+				}
+				b_peresopnytsia = {
+				}
+				b_shumsk = {
+				}
+				b_rivne = {
+				}
+				b_pochaiv = {
+				}
+			}
+			c_podlasie = {
+				color={ 214 145 111 }
+				color2={ 255 255 255 }
+
+				holy_site = baltic_pagan
+				holy_site = baltic_pagan_reformed
+				
+				b_drohiczyn = {
+				}
+				b_goniadz = {
+				}
+				b_sejny = {
+				}
+				b_rajgrod = {
+				}
+				b_tykocin = {
+				}
+				b_zambrow = {
+				}
+				b_lapy = {
+				}
+				b_krynki = {
+				}
+			}
+		}
+		d_galich = {
+			color={ 224 112 130 }
+			color2={ 255 255 255 }
+			
+			capital = 536 # Galich
+			
+			c_galich = {
+				color={ 224 112 130 }
+				color2={ 255 255 255 }
+				
+				polish = "Halicz"
+				
+				b_galich = {
+				}
+				b_bykovna = {
+				}
+				b_kolomyia = {
+				}
+				b_vasyliv = {
+				}
+				b_rohatin = {
+				}
+				b_tysmenytsia = {
+				}
+				b_tovmach = {
+				}
+			}
+			c_terebovl = {
+				color={ 224 132 120 }
+				color2={ 255 255 255 }
+				
+				polish = "Trembowla"
+	
+				b_terebovl = {
+				}
+				b_mykulyn = {
+				}
+				b_onut = {
+				}
+				b_kuchelemyn = {
+				}
+				b_bakota = {
+				}
+				b_moklekov = {
+				}
+				b_dolyna = {
+				}
+			}
+			c_zvenyhorod = {
+				color={ 220 100 115 }
+				color2={ 255 255 255 }
+				
+				polish = "Dzwinogrod"
+				
+				b_zvenyhorod = {
+				}
+				b_lvov = {
+				}
+				b_butsk = {
+				}
+				b_sambir = {
+				}
+				b_udech = {
+				}
+				b_horodok = {
+				}
+				b_rogozhyn = {
+				}
+			}
+			c_zaslav = {
+				color={ 225 115 120 }
+				color2={ 255 255 255 }
+				
+				polish = "Zaslaw"
+				
+				b_zaslav = {
+				}
+				b_kremyanets = {
+				}
+				b_plisnesk = {
+				}
+				b_buzhesk = {
+				}
+				b_ostroh = {
+				}
+				b_chepetivka = {
+				}
+				b_slavuta = {
+				}
+			}
+			c_ushytsia = {
+				color={ 200 100 110 }
+				color2={ 255 255 255 }
+				
+				polish = "Uszyca"
+				
+				b_ushytsia = {
+				}
+				b_kamianets = {
+				}
+				b_litnivtsi = {
+				}
+				b_dunaivtsi = {
+				}
+				b_murovani = {
+				}
+				b_velykyi_zhvanchyk = {
+				}
+				b_ushiyin = {
+				}
+			}
+		}
+		d_cherven_cities = {
+			color={ 224 70 70 }
+			color2={ 255 255 255 }
+			
+			capital = 1635 # Cherven
+			
+			c_cherven = {
+				color={ 224 70 70 }
+				color2={ 255 255 255 }
+				
+				b_cherven = {
+					polish = "Czerwien"
+				}
+				b_volyn = {
+					polish = "Wolyn"
+				}
+				b_hrubeshiv = {
+					polish = "Hrubieszow"
+				}
+				b_saciaska = {
+				}
+				b_kholm_ch = {
+					polish = "Chelm"
+				}
+				b_krasnystaw = {
+				}
+				b_suteysk = {
+				}
+			}
+			c_belz = {
+				color={ 234 90 90 }
+				color2={ 255 255 255 }
+				
+				b_belz = {
+				}
+				b_horodlo = {
+				}
+				b_lopatyn = {
+				}
+				b_sokal = {
+				}
+				b_grabowiec = {
+				}
+				b_mycow = {
+				}
+				b_tchernogrov = {
+				}
+			}
+			c_peremyshl = {
+				color={ 244 110 110 }
+				color2={ 255 255 255 }
+	
+				polish = "Przemysl"
+	
+				b_peremyshl = {
+					polish = "Przemysl"
+				}
+				b_sanok = {
+				}
+				b_jaroslav = {
+					polish = "Jaroslaw"
+				}
+				b_rasiv = {
+					polish = "Rzeszow"
+				}
+				b_liubachiv = {
+					polish = "Lubaczow"
+				}
+				b_lezhaisk = {
+					polish = "Lezajsk"
+				}
+				b_ustryky_dolishni = {
+				}
+			}
+		}
+	}
+	k_ruthenia = {		#Kiev
+		color={ 70 150 90 }
+		color2={ 255 255 255 }
+		
+		capital = 547 # Kiev
+		
+		culture = russian
+		
+		slavic_pagan_reformed = 500 # Crusade target weight
+		baltic_pagan_reformed = 100 # Crusade target weight
+		tengri_pagan_reformed = 100
+		finnish_pagan_reformed = 100
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = north_germanic
+					culture_group = east_slavic 
+				}
+			}
+		}
+		
+		norse = Könugarðr
+		swedish = Könugård
+		norwegian = Kønugård
+		danish = Kønugård
+		
+		d_kiev = {
+			color={ 129 187 125 }
+			color2={ 255 255 255 }
+			
+			dignity = 10 # Counted as having 10 more counties than it does
+			capital = 547 # Kiev
+			
+			norse = Könugarðr
+			swedish = Könugård
+			norwegian = Kønugård
+			danish = Kønugård
+					
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 1
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			#pagan_coa = {
+			#	template = 0
+			#	layer = {
+			#		texture = 3
+			#		texture_internal = 4
+			#		emblem = 0
+			#		color = 0
+			#		color = 0
+			#		color = 0
+			#	}
+			#	religion = "slavic_pagan"
+			#}
+	
+			c_kiev = {
+				color={ 106 106 26 }
+				color2={ 255 255 255 }
+				
+				norse = Könugarðr
+				swedish = Könugård
+				norwegian = Kønugård
+				danish = Kønugård
+
+				holy_site = slavic_pagan
+				holy_site = slavic_pagan_reformed
+				
+				b_kiev = {
+					norse = Könugarðr
+					swedish = Könugård
+					norwegian = Kønugård
+					danish = Kønugård
+				}
+				b_zhytomyr = {
+				}
+				b_vyshhorod = {
+				}
+				b_vasykliv = {
+				}
+				b_yuriev = {
+				}
+				b_kaniv = {
+				}
+				b_fastiv = {
+				}
+			}
+			c_korosten = {
+				color={ 111 111 31 }
+				color2={ 255 255 255 }
+				
+				b_korosten = {
+				}
+				b_olevsk = {
+				}
+				b_ovruch = {
+				}
+				b_malyn = {
+				}
+				b_chernobyl = {
+				}
+				b_narodytchi = {
+				}
+				b_louhyny = {
+				}
+			}
+			c_vozviahel = {
+				color={ 116 116 36 }
+				color2={ 255 255 255 }
+				
+				b_vozvyahel = {
+				}
+				b_korets = {
+				}
+				b_horodnytsia = {
+				}
+				b_berdytchiv = {
+				}
+				b_baranivka = {
+				}
+				b_yemilchyne = {
+				}
+				b_hrud = {
+				}
+			}
+			c_medjybij = {
+				color={ 101 101 21 }
+				color2={ 255 255 255 }
+				
+				b_medjybij = {
+				}
+				b_hubyn = {
+				}
+				b_khmilnyk = {
+				}
+				b_letychiv = {
+				}
+				b_berdychiv = {
+				}
+				b_liubar = {
+				}
+				b_chudniv = {
+				}
+			}
+		}
+		d_turov = {
+			color={ 132 160 94 }
+			color2={ 255 255 255 }
+			
+			capital = 552 # Turov
+			
+			ilmenian = "Dregovichia"
+			
+			c_turov = {
+				color={ 135 160 100 }
+				color2={ 255 255 255 }
+				
+				b_turov = {
+				}
+				b_davyd-haradok = {
+				}
+				b_stolin = {
+				}
+				b_alsany = {
+				}
+				b_stachava = {
+				}
+				b_fiadory = {
+				}
+				b_sarny = {
+				}
+			}
+			c_pinsk = {
+				color={ 120 155 80 }
+				color2={ 255 255 255 }
+				
+				b_pinsk = {
+				}
+				b_ivanava = {
+				}
+				b_luninets = {
+				}
+				b_drahichyn = {
+				}
+				b_biaroza = {
+				}
+				b_hantsavichy = {
+				}
+				b_motal = {
+				}
+			}
+			c_slutsk = {
+				color={ 130 165 70 }
+				color2={ 255 255 255 }
+				
+				b_slutsk = {
+				}
+				b_gomel = {
+				}
+				b_mazyr = {
+				}
+				b_rechytsa = {
+				}
+				b_zhytkavichy = {
+				}
+				b_loyew = {
+				}
+				b_kazlovichy = {
+				}
+			}
+			c_volkovysk = {
+				color={ 110 145 70 }
+				color2={ 255 255 255 }
+				
+				b_volkovysk = {
+				}
+				b_klotsk = {
+				}
+				b_ouslonim = {
+				}
+				b_studzieniki = {
+				}
+				b_ruzhany = {
+				}
+				b_zyrovichy = {
+				}
+				b_lyakhavichy = {
+				}
+			}
+		}
+		
+		d_minsk = {
+			color={ 110 110 45 }
+			color2={ 255 255 255 }
+			
+			capital = 550 # Minsk
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 3
+					texture_internal = 5
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "slavic_pagan"
+			}
+			
+			c_minsk = {
+				color={ 60 105 2 }
+				color2={ 255 255 255 }
+				
+				b_minsk = {
+				}
+				b_zaslawye = {
+				}
+				b_lahoysk = {
+				}
+				b_barysaw = {
+				}
+				b_koidanova = {
+				}
+				b_maryina_horka = {
+				}
+				b_nyasvizh = {
+				}
+			}
+			c_drutsk = {
+				color={ 70 130 5 }
+				color2={ 255 255 255 }
+				
+				b_drutsk = {
+				}
+				b_bialocerkev = {
+				}
+				b_rahachow = {
+				}
+				b_mogilev = {
+				}
+				b_zhlobin = {
+				}
+				b_babruysk = {
+				}
+				b_dashkovka = {
+				}
+			}
+			c_novogrodek = {
+				color={ 70 95 2 }
+				color2={ 255 255 255 }
+				
+				b_novogrodek = {
+				}
+				b_slonim = {
+				}
+				b_lida = {
+				}
+				b_karelichy = {
+				}
+				b_shchuchyn = {
+				}
+				b_iwie = {
+				}
+				b_dziatlava = {
+				}
+			}
+		}
+		
+		d_polotsk = {
+			color = { 128 133 104 }
+			color2={ 255 255 255 }
+			
+			capital = 419 # Polotsk
+			
+			severian = "Krivichia"
+			ilmenian = "Krivichia"	
+			
+			c_polotsk = {
+				color={ 125 14 14 }
+				color2={ 255 255 255 }
+				
+				swedish = "Pallteskja"
+				norse = "Pallteskja"
+				danish = "Pallteskja"
+				norwegian = "Pallteskja"
+			
+				b_polotsk = {
+					swedish = "Pallteskja"
+					norse = "Pallteskja"
+					danish = "Pallteskja"
+					norwegian = "Pallteskja"
+				}
+				b_haradok = {
+				}
+				b_rassony = {
+				}
+				b_obol = {
+				}
+				b_douza = {
+				}
+				b_sirotino = {
+				}
+				b_leskovichi = {
+				}
+			}
+			c_lepiel = {
+				color={ 125 24 24 }
+				color2={ 255 255 255 }
+
+				b_lukoml = {
+				}
+				b_dokshytsy = {
+				}
+				b_lepiel = {
+				}
+				b_novalukoml = {
+				}
+				b_ushachy = {
+				}
+				b_hlybokaye = {
+				}
+				b_sharkawshchyna = {
+				}
+			}
+			c_orsha = {
+				color={ 79 135 16 }
+				color2={ 255 255 255 }
+				
+				b_orsha = {
+				}
+				b_talachyn = {
+				}
+				b_dubrowna = {
+				}
+				b_baran_orsha = {
+				}
+				b_shklow = {
+				} 
+				b_krugale = {
+				}
+				b_zheleznyaki = {
+				}
+			}
+			c_vitebsk = {
+				color={ 75 125 6 }
+				color2={ 255 255 255 }
+				
+				b_vitebsk = {
+				}
+				b_sianno = {
+				}
+				b_beshankovichy = {
+				}
+				b_liozna = {
+				}
+				b_boguchevsk = {
+				}
+				b_ruba = {
+				}
+				b_bilieva = {
+				}
+			}
+		}
+		
+		d_smolensk = {
+			color={ 226 241 182 }
+			color2={ 255 255 255 }
+			
+			capital = 568 # Smolensk
+			
+			severian = "Radimichia"
+			ilmenian = "Radimichia"
+			
+			c_smolensk = {
+				color={ 229 244 185 }
+				color2={ 255 255 255 }
+				
+				swedish = "Smaleskja"
+				norse = "Smaleskja"
+				danish = "Smaleskja"
+				norwegian = "Smaleskja"
+					
+				b_smolensk = {
+					swedish = "Smaleskja"
+					norse = "Smaleskja"
+					danish = "Smaleskja"
+					norwegian = "Smaleskja"
+				}
+				b_gnyozdovo = {
+				}
+				b_krasny = {
+				}
+				b_velizh = {
+				}
+				b_yartsevo = {
+				}
+				b_netrizovo = {
+				}
+				b_ray = {
+				}
+			}
+			c_roslavl = {
+				color={ 239 242 185 }
+				color2={ 255 255 255 }
+					
+				b_roslavl = {
+				}
+				b_pochinok = {
+				}
+				b_chocimsk = {
+				}
+				b_aleksandr = { #Fictional, for prosperity
+				}
+				b_vugimsk = { #Fictional, for prosperity
+				}
+				b_imaslavl = { #Fictional, for prosperity
+				}
+				b_kankol = { #Fictional, for prosperity
+				}
+			}
+			c_mstislavl = {
+				color={ 232 247 188 }
+				color2={ 255 255 255 }
+					
+				b_mstitslavl = {
+				}
+				b_krychaw = {
+				}
+				b_propoysk = {
+				}
+				b_rahacou = {
+				}
+				b_chachersk = {
+				}
+				b_horki = {
+				}
+				b_drybin = {
+				}
+			}
+			c_vyazma = {
+				color={ 175 189 131 }
+				color2={ 255 255 255 }
+					
+				b_vyazma = {
+				}
+				b_yelnya = {
+				}
+				b_dorogobyzh = {
+				}
+				b_ignatkovo = {
+				}
+				b_tesnoye = {
+				}
+				b_safonovo = {
+				}
+				b_mokhnatka = {
+				}
+			}
+			c_toropets = {
+				color={ 157 173 113 }
+				color2={ 255 255 255 }
+				
+				b_toropets = {
+				}
+				b_demyansk = {
+				}
+				b_andreapol = {
+				}
+				b_zhizhitsa = {
+				}
+				b_chistoye = {
+				}
+				b_ploskosh = {
+				}
+				b_okhvat = {
+				}
+			}
+		}
+		d_pereyaslavl = {
+			color={ 60 120 65 }
+			color2={ 255 255 255 }
+			
+			capital = 555 # Pereyaslavl
+		
+			c_pereyaslavl = {
+				color={ 235 205 118 }
+				color2={ 255 255 255 }
+				
+				b_pereyaslavl = {
+				}
+				b_boryspil = {
+				}
+				b_kozelets = {
+				}
+				b_baryshivka = {
+				}
+				b_yahotyn = {
+				}
+				b_velyka_dymerka = {
+				}
+				b_berezan = {
+				}
+			}
+			c_voin = {
+				color={ 230 200 110 }
+				color2={ 255 255 255 }
+				
+				b_voin = {
+				}
+				b_zolotonosha = {
+				}
+				b_drabiv = {
+				}
+				b_chornobai = {
+				}
+				b_irkliiv = {
+				}
+				b_bohodukhivka = {
+				}
+				b_pishchane = {
+				}
+			}
+			c_hradyzk = {
+				color={ 225 195 105 }
+				color2={ 255 255 255 }
+				
+				b_hradyzk = {
+				}
+				b_poltava = {
+				}
+				b_khorol = {
+				}
+				b_lubny = {
+				}
+				b_kremenchuk = {
+				}
+				b_myrhorod = {
+				}
+				b_kobeliaky = {
+				}
+			}
+			c_priluk = {
+				color={ 221 191 101}
+				color2={ 255 255 255 }
+				
+				b_priluk = {
+				}
+				b_romny = {
+				}
+				b_bobrovytsia = {
+				}
+				b_varva = {
+				}
+				b_nizhyn = {
+				}
+				b_nosivka = {
+				}
+				b_ichina = {
+				}
+			}
+		}
+	}
+	k_chernigov = {
+		color={ 147 164 104 }
+		color2={ 255 255 255 }
+		
+		capital = 554 # Chernigov
+		
+		culture = russian
+		
+		slavic_pagan_reformed = 150 # Crusade target weight
+		baltic_pagan_reformed = 50 # Crusade target weight
+		tengri_pagan_reformed = 50
+		finnish_pagan_reformed = 50
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = north_germanic
+					culture_group = east_slavic 
+				}
+			}
+		}
+		
+		d_chernigov = {
+			color={ 150 235 91 }
+			color2={ 255 255 255 }
+			
+			capital = 554 # Chernigov
+			
+			severian = "Severia"
+			ilmenian = "Severia"
+			mordvin = "Severia"
+			meshchera = "Severia"
+			
+			c_lyubech = {
+				color={ 238 253 194 }
+				color2={ 255 255 255 }
+		
+				b_lyubech = {
+				}
+				b_dobrouch = {
+				}
+				b_cierachouka = {
+				}
+				b_dobryanka = {
+				}
+				b_lysyye = {
+				}
+				b_skytok = {
+				}
+				b_perepys = {
+				}
+			}
+			c_chernigov = {
+				color={ 242 255 197 }
+				color2={ 255 255 255 }
+		
+				b_chernigov = {
+				}
+				b_snov = {
+				}
+				b_korop = {
+				}
+				b_sosnytsia = {
+				}
+				b_mena = {
+				}
+				b_horodina = {
+				}
+				b_ripky = {
+				}
+			}
+			c_starodub = {
+				color={ 230 255 190 }
+				color2={ 255 255 255 }
+				
+				b_starodub = {
+				}
+				b_vyshenky = {
+				}
+				b_obolonnya = {
+				}
+				b_ponornytsya = {
+				}
+				b_zelena_polyana = {
+				}
+				b_avdiika = {
+				}
+				b_desnianske = {
+				}
+			}
+			c_novgorod_seversky = {
+				color = { 140 165 40 }
+				color2 = { 255 255 255 }
+	
+				b_novgorodseversky = {
+				}
+				b_glukhov = {
+				}
+				b_batouryn = {
+				}
+				b_konotop = {
+				}
+				b_bakhmatch = {
+				}
+				b_altynivka = {
+				}
+				b_atyshua = {
+				}
+			}
+		}
+			
+		d_novgorod-seversk = { # Called Bryansk in-game
+			color = { 120 155 40 }
+			color2={ 255 255 255 }
+			
+			capital = 576 # Bryansk   
+	
+			c_bryansk = {
+				color = { 160 175 40 }
+				color2={ 255 255 255 }
+
+				holy_site = baltic_pagan
+				holy_site = baltic_pagan_reformed
+				
+				b_bryansk = {
+				}
+				b_pochep = {
+				}
+				b_trubetsk = {
+				}
+				b_suponevo = {
+				}
+				b_kokino = {
+				}
+				b_vygonichi = {
+				}
+				b_bezichi = {
+				}
+			}
+			c_kromy = {
+				color={ 164 179 49 }
+				color2={ 255 255 255 }
+				
+				b_kromy = {
+				}
+				b_sevsk = {
+				}
+				b_dmitrievka = {
+				}
+				b_navlya = {
+				}
+				b_lokot = {
+				}
+				b_nechayeva = {
+				}
+				b_sakovnina = {
+				}
+			}
+			c_rylsk = {
+				color={ 145 170 45 }
+				color2={ 255 255 255 }
+				
+				b_rylsk = {
+				}
+				b_vyr = {
+				}
+				b_krupets = {
+				}
+				b_kapystichi = {
+				}
+				b_ivanovskoye = {
+				}
+				b_korenovo = {
+				}
+				b_glushkvo = {
+				}
+			}
+			c_kursk = {
+				color={ 150 180 55 }
+				color2={ 255 255 255 }
+				
+				b_kursk = {
+				}
+				b_olgov = {
+				}
+				b_sukovo = {
+				}
+				b_fatej = {
+				}
+				b_pryamitsyno = {
+				}
+				b_kourchatov = {
+				}
+				b_zolotukhino = {
+				}
+			}
+		}
+		
+		d_ryazan = {
+			color={ 90 95 25 }
+			color2={ 255 255 255 }
+			
+			capital = 580 # Ryazan
+			
+			mordvin = Meshchera
+			meshchera = Meshchera
+
+			c_pronsk = {
+				color={ 101 110 45 }
+				color2={ 255 255 255 }
+	
+				b_pronsk = {
+				}
+				b_skopin = {
+				}
+				b_likharevskoye_gorodishch = {
+				}
+				b_mikhaylov = {
+				}
+				b_pavelets = {
+				}
+				b_oktyabrsky = {
+				}
+				b_gryaznoye = {
+				}
+			}	
+			c_ryazan = {
+				color={ 121 140 50 }
+				color2={ 255 255 255 }
+
+				holy_site = finnish_pagan
+				holy_site = finnish_pagan_reformed
+				
+				b_ryazan = {
+				}
+				b_pereyaslavl_ryazanski = {
+				}
+				b_krasnoye = {
+				}
+				b_lukhovitsy = {
+				}
+				b_rybnoye = {
+				}
+				b_novoselki = {
+				}
+				b_turlatovo = {
+				}
+			}
+			c_kolomna = {
+				color={ 131 149 54 }
+				color2={ 255 255 255 }
+				
+				b_tula = {
+				}
+				b_rostislavl = {
+				}
+				b_veniov = {
+				}
+				b_kochira = {
+				}
+				b_laptevo = {
+				}
+				b_ozherelye = {
+				}
+				b_konchinka = {
+				}
+			}
+			c_yelets = {
+				color={ 111 120 55 }
+				color2={ 255 255 255 }
+				
+				b_yelets = {
+				}
+				b_voronej = {
+				}
+				b_zadonsk = {
+				}
+				b_semiuki = {
+				}
+				b_khlevnoye = {
+				}
+				b_dolgorukovo = {
+				}
+				b_terbuny = {
+				}
+			}
+		}
+		d_murom = {
+			color={ 100 130 50 }
+			color2={ 255 255 255 }
+			
+			capital = 581 # Murom
+			
+			c_murom = {
+				color={ 101 130 50 }
+				color2={ 255 255 255 }
+				
+				swedish = "Moramar"
+				norse = "Moramar"
+				danish = "Moramar"
+				norwegian = "Moramar"
+				
+				b_murom = {
+					swedish = "Moramar"
+					norse = "Moramar"
+					danish = "Moramar"
+					norwegian = "Moramar"
+				}
+				b_kasimov = {
+				}
+				b_vyksa = {
+				}
+				b_melenki = {
+				}
+				b_yelatma = {
+				}
+				b_ulanovka = {
+				}
+				b_arkhangel = {
+				}
+			}
+			c_orekhovo-zouievo = {
+				color={ 125 130 40 }
+				color2={ 255 255 255 }
+				
+				b_orekhovo-zouievo = {
+				}
+				b_yegoryevsk = {
+				}
+				b_tuma = {
+				}
+				b_murmino = {
+				}
+				b_degtyanoye = {
+				}
+				b_malakhovo = {
+				}
+				b_gorki = {
+				}
+			}
+		}
+		d_karachev = {
+			color={ 165 180 65 }
+			color2={ 255 255 255 }
+			
+			capital = 1666 # Karachev
+		
+			c_karachev = {
+				color={ 165 180 65 }
+				color2={ 255 255 255 }
+				
+				b_karachev = {
+				}
+				b_orel = {
+				}
+				b_bolkhov = {
+				}
+				b_naryshkino = {
+				}
+				b_krasnaya = {
+				}
+				b_khotynets = {
+				}
+				b_ryabinovka = {
+				}
+			}
+			c_kozelsk = {
+				color={ 175 190 75 }
+				color2={ 255 255 255 }
+				
+				b_kozelsk = {
+				}
+				b_mosalsk = {
+				}
+				b_belev = {
+				}
+				b_mezetsk = {
+				}
+				b_serpeisk = {
+				}
+				b_sosensky = {
+				}
+				b_sukhinichi = {
+				}
+			}
+		}
+		d_novosil = {
+			color={ 115 130 15 }
+			color2={ 255 255 255 }
+			
+			capital = 1634 # Novosil		
+		
+			c_novosil = {
+				color={ 115 130 15 }
+				color2={ 255 255 255 }
+				
+				b_novosil = {
+				}
+				b_kolpna = {
+				}
+				b_strakhovka = {
+				}
+				b_verkhovye = {
+				}
+				b_khomutovo = {
+				}
+				b_pokrovskoye = {
+				}
+				b_livny = {
+				}
+			}
+			c_serpukhov = {
+				color={ 141 159 64 }
+				color2={ 255 255 255 }
+				
+				b_serpukhov = {
+				}
+				b_dugna = {
+				}
+				b_bogucharovo = {
+				}
+				b_novogurovsky = {
+				}
+				b_zaokskiy = {
+				}
+				b_nenashevo = {
+				}
+				b_kolyupanovo = {
+				}
+			}
+			c_vorotynsk = {
+				color={ 125 145 50 }
+				color2={ 255 255 255 }
+				
+				b_vorotynsk = {
+				}
+				b_mchensk = {
+				}
+				b_odoyev = {
+				}
+				b_suvorova = {
+				}
+				b_plavsk = {
+				}
+				b_chern = {
+				}
+				b_somovo = {
+				}
+			}
+		}
+	}
+	k_rus = {		#Novgorod
+		color={ 137 194 100 }
+		color2={ 255 255 255 }
+		
+		capital = 414 # Novgorod
+		
+		slavic_pagan_reformed = 500 # Crusade target weight
+		finnish_pagan_reformed = 300 # Crusade target weight
+		baltic_pagan_reformed = 100 # Crusade target weight
+		
+		#mordvin = Mordvinia
+		norse = Garðariki
+		
+		culture = russian
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = north_germanic
+					culture_group = east_slavic
+					culture_group = finno_ugric
+				}
+			}
+		}
+		
+		d_beloozero = {		#Veps
+			color={ 120 155 80 }
+			color2={ 255 255 255 }
+			
+			capital = 412 # Torzhok
+			
+			c_zaozerye = {
+				color={ 134 150 90 }
+				color2={ 255 255 255 }
+					
+				b_zarechnaya = {
+				}
+				b_vytegra = {
+				}
+				b_kedra = {
+				}
+				b_oshta = {
+				}
+				b_gornyy_ruchey = {
+				}
+				b_rodionovo = {
+				}
+				b_devyatiny = {
+				}
+			}
+			c_chlisselbourg = {
+				color={ 144 160 110 }
+				color2={ 255 255 255 }
+				
+				b_chlisselbourg = {
+				}
+				b_mokrishvitsa = {
+				}
+				b_lodeynoye_pole = {
+				}
+				b_volkhov = {
+				}
+				b_storozhno = {
+				}
+				b_nossok = {
+				}
+				b_nevdubstroy = {
+				}
+			}
+			c_tikhvine = {
+				color={ 125 140 85 }
+				color2={ 255 255 255 }
+				
+				b_tikhvine = {
+				}
+				b_babayevo = {
+				}
+				b_pestovo = {
+				}
+				b_pikalyovo = {
+				}
+				b_chagoda = {
+				}
+				b_boksiti = {
+				}
+				b_khvoynaya = {
+				}
+			}
+			c_torzhok = {
+				color={ 134 161 111 }
+				color2={ 255 255 255 }
+			
+				b_torzhok = {
+				}
+				b_ostashkov = {
+				}
+				b_vyshny_volochyok = {
+				}
+				b_kamenka = {
+				}
+				b_firovo = {
+				}
+				b_rashkino = {
+				}
+				b_zizino = {
+				}
+			}
+			c_bezichy = {
+				color={ 160 180 120 }
+				color2={ 255 255 255 }
+				
+				b_bezichy = {
+				}
+				b_maksatikha = {
+				}
+				b_rameshki = {
+				}
+				b_tolmachi = {
+				}
+				b_torby = {
+				}
+				b_knyazhikha = {
+				}
+				b_klyuchevaya = {
+				}
+			}			
+		}
+		d_novgorod = {
+			color={ 107 164 64 }
+			color2={ 255 255 255 }
+			
+			dignity = 10
+			
+			capital = 414 # Novgorod
+			
+			swedish = "Holmgård"
+			norse = "Holmgarðr"
+			danish = "Holmgård"
+			norwegian = "Holmgård"
+			ilmenian = "Ilmenia"
+			severian = "Ilmenia"
+			mordvin = "Ilmenia"
+			meshchera = "Ilmenia"
+			samoyed = "Ilmenia"
+			finnish = "Ilmenia"
+			lappish = "Ilmenia"
+			ugricbaltic = "Ilmenia"
+			komi = "Ilmenia"
+			khanty = "Ilmenia"
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 4
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			c_bezhetsky_verh = { # Ladoga
+				color={ 144 161 101 }
+				color2={ 255 255 255 }
+				
+				finnish = "Laatokka"
+					
+				b_ladoga = {
+				}
+				b_lyuban = {
+				}
+				b_tosno = {
+				}
+				b_vyritsa = {
+				}
+				b_kirovsk = {
+				}
+				b_naziya = {
+				}
+				b_novinka = {
+				}
+			}	
+			c_novgorod = {
+				color={ 149 166 106 }
+				color2={ 255 255 255 }
+				
+				swedish = "Holmgård"
+				norse = "Holmgarðr"
+				danish = "Holmgård"
+				norwegian = "Holmgård"
+						
+				holy_site = slavic_pagan
+				holy_site = slavic_pagan_reformed
+				holy_site = finnish_pagan
+				holy_site = finnish_pagan_reformed								
+
+				b_novgorod = {
+					swedish = "Holmgård"
+					norse = "Holmgarðr"
+					danish = "Holmgård"
+					norwegian = "Holmgård"
+				}
+				b_soltsy = {
+				}
+				b_pankovka = {
+				}
+				b_chudovo = {
+				}
+				b_luga = {
+				}
+				b_batetsky = {
+				}
+				b_shimsk = {
+				}
+			}
+			c_rusa = {
+				color={ 139 156 96 }
+				color2={ 255 255 255 }
+				
+				b_rusa = {
+				}
+				b_poddorye = {
+				}
+				b_ramushevo = {
+				}
+				b_lyublino = {
+				}
+				b_peregino = {
+				}
+				b_belebelka = {
+				}
+				b_korchevka = {
+				}
+			}
+			c_kholm = {
+				color={ 140 170 120 }
+				color2={ 255 255 255 }
+				
+				b_kholm = {
+				}
+				b_molvotitsy = {
+				}
+				b_lychkovo = {
+				}
+				b_nevskaya = {
+				}
+				b_suchki = {
+				}
+				b_yazhelbitsy = {
+				}
+				b_fishovo = {
+				}
+			}
+			c_borovichi = {
+				color={ 120 135 80 }
+				color2={ 255 255 255 }
+				
+				b_borovichi = {
+				}
+				b_kirichi = {
+				}
+				b_khoromy = {
+				}
+				b_okulovka = {
+				}
+				b_lyubytino = {
+				}
+				b_pchevzha = {
+				}
+				b_vodogon = {
+				}
+			}
+		}
+		d_pskov = {
+			color={ 140 130 62 }
+			color2={ 255 255 255 }
+			
+			capital = 413 # Pskov
+			
+			german = "Pleskau"
+
+			c_pskov = {
+				color={ 151 167 107 }
+				color2={ 255 255 255 }
+				
+				german = "Pleskau"
+						
+				b_pskov = {
+				}
+				b_ostrov = {
+				}
+				b_golubovo = {
+				}
+				b_porkhov = {
+				}
+				b_khilovo = {
+				}
+				b_dedovichi = {
+				}
+				b_goristo = {
+				}
+			}
+			c_velikiye_luki = {
+				color={ 154 170 110 }
+				color2={ 255 255 255 }
+						
+				b_velikiyeluki = {
+				}
+				b_sebezh = {
+				}
+				b_nevel = {
+				}
+				b_bely = {
+				}
+				b_usvyaty = {
+				}
+				b_loknya = {
+				}
+				b_staryatoropa = {
+				}
+			}
+			c_vodi = {
+				color={ 113 0 0 }
+				color2={ 255 255 255 }
+				
+				finnish = "Inkeri"
+				russian = "Ingriya"
+				ilmenian = "Ingriya"
+				severian = "Ingriya"
+				swedish = "Ingermanland"
+			
+				b_nyen = {
+					finnish = "Nevanlinna"
+				}
+				b_noteborg = {
+					swedish = "Nöteborg"
+					norse = "Nöteborg"
+					norwegian = "Nøteborg"
+					danish = "Nøteborg"
+					german = "Schlüsselburg"
+					russian = "Oreshek"
+				}
+				b_kingisepp = {
+					finnish = "Jaama"
+				}
+				b_jogopera = {
+				}
+				b_ivanovskaya = { # Teusina
+					swedish = "Teusina"
+					norwegian = "Teusina"
+					norse = "Teusina"
+					danish = "Teusina"
+					russian = "Tyavzino"
+				}
+				b_nosok = {
+				}
+				b_liivtsula = {
+				}
+				b_khotchino = {
+					finnish = "Hatsina"
+					swedish = "Hatsina"
+					norse = "Hatsina"
+				}
+			}
+			c_gdov = {
+				color={ 160 177 117 }
+				color2={ 255 255 255 }
+				
+				b_gdov = {
+				}
+				b_mda = {
+				}
+				b_vyazki = {
+				}
+				b_kolydukha = {
+				}
+				b_plyussa = {
+				}
+				b_strizhki = {
+				}
+				b_zakhodsy = {
+				}
+			}
+			c_izborsk = {
+				color={ 160 180 120 }
+				color2={ 255 255 255 }
+				
+				b_izborsk = {
+				}
+				b_pechory = {
+				}
+				b_khokhly = {
+				}
+				b_rodovoye = {
+				}
+				b_tupy = {
+				}
+				b_kamno = {
+				}
+				b_poleny = {
+				}
+			}
+		}
+	}
+	k_vladimir = {
+		color={ 87 144 50 }
+		color2={ 255 255 255 }
+		
+		capital = 582 # Vladimir
+		
+		slavic_pagan_reformed = 100 # Crusade target weight
+		finnish_pagan_reformed = 250 # Crusade target weight
+		baltic_pagan_reformed = 100 # Crusade target weight
+		
+		culture = russian
+		
+		pagan_coa = {
+			template = 0
+			layer = {
+				texture = 3
+				texture_internal = 6
+				emblem = 0
+				color = 0
+				color = 0
+				color = 0
+			}
+			religion = "slavic_pagan"
+		}
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = north_germanic
+					culture_group = east_slavic
+					culture_group = finno_ugric
+				}
+			}
+		}
+	
+		d_vladimir = {
+			color={ 180 200 90 }
+			color2={ 255 255 255 }
+			
+			capital = 582 # Vladimir
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 3
+					texture_internal = 6
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "slavic_pagan"
+			}
+	
+			c_gorodez = {
+				color={ 193 207 149 }
+				color2={ 255 255 255 }
+						
+				b_gorodez = {
+				}
+				b_kitezh = {
+				}
+				b_bor = {
+				}
+				b_puchishche = {
+				}
+				b_tarasikha = {
+				}
+				b_chistoye_pole = {
+				}
+				b_spasskoye = {
+				}
+			}
+			c_nizhny_novgorod = {
+				color={ 196 210 152 }
+				color2={ 255 255 255 }
+				
+				komi="Obran Osh"
+				mordvin="Obran Osh"
+				samoyed="Obran Osh"
+				finnish="Obran Osh"
+				lappish="Obran Osh"
+				cuman="Obran Osh"
+				pecheneg="Obran Osh"
+				mongol="Obran Osh"
+				turkish="Obran Osh"
+				avar="Obran Osh"
+						
+				b_nizhnynovgorod = {
+					komi="Obran Osh"
+					mordvin="Obran Osh"
+					samoyed="Obran Osh"
+					finnish="Obran Osh"
+					lappish="Obran Osh"
+					cuman="Obran Osh"
+					pecheneg="Obran Osh"
+					mongol="Obran Osh"
+					turkish="Obran Osh"
+					avar="Obran Osh"
+				}
+				b_lyskovo = {
+				}
+				b_balakhna = {
+				}
+				b_kstovo = {
+				}
+				b_pavlovo = {
+				}
+				b_bogorodsk = {
+				}
+				b_knyaginino = {
+				}
+			}
+			c_vladimir = {
+				color={ 202 216 158 }
+				color2={ 255 255 255 }
+						
+				b_vladimir = {
+				}
+				b_starodub_vladimirsky = {
+				}
+				b_bogolyubovo = {
+				}
+				b_rochdestvenskoye = {
+				}
+				b_gorokhovets = {
+				}
+				b_viazniki = {
+				}
+				b_nikologory = {
+				}
+				b_kovrov = {
+				}
+			}
+			c_suzdal = {
+				color={ 199 213 155 }
+				color2={ 255 255 255 }
+				
+				swedish = "Sursdalar"
+				norse = "Sursdalar"
+				danish = "Sursdalar"
+				norwegian = "Sursdalar"
+						
+				b_suzdal = {
+					swedish = "Sursdalar"
+					norse = "Sursdalar"
+					danish = "Sursdalar"
+					norwegian = "Sursdalar"
+				}
+				b_sudalyvka = {
+				}
+				b_shuya = {
+				}
+				b_kineshma = {
+				}
+				b_vichuga = {
+				}
+				b_ivanovo = {
+				}
+				b_sereda = {
+				}
+			}
+			c_yuryev = {
+				color={ 173 189 129 }
+				color2={ 255 255 255 }
+				
+				b_yuryev = {
+				}
+				b_godenovo = {
+				}
+				b_gavrilov_posad = {
+				}
+				b_kolchugino = {
+				}
+				b_varvarino = {
+				}
+				b_bavleny = {
+				}
+				b_berezhok = {
+				}
+			}
+			c_pereyaslavl_zalessky = {
+				color={ 163 179 119 }
+				color2={ 255 255 255 }
+						
+				b_pereyaslavlzalessky = {
+				}
+				b_sergiyevposad = {
+				}
+				b_aleksandrov = {
+				}
+				b_strunino = {
+				}
+				b_karabanovo = {
+				}
+				b_kupanskoye = {
+				}
+				b_khmelniki = {
+				}
+			}
+		}
+		d_moskva = {
+			color={ 207 222 123 }
+			color2={ 255 255 255 }
+			
+			capital = 575 # Moskva
+			
+			mordvin = Mochkava
+			meshchera = Mochkava
+			
+			c_moskva = {
+				color={ 220 235 176 }
+				color2={ 255 255 255 }
+				
+				mordvin = Mochkava
+				meshchera = Mochkava
+				
+				b_moskva = {
+					mordvin = Mochkava
+					meshchera = Mochkava
+				}
+				b_mytishchi = {
+				}
+				b_podolsk = {
+				}
+				b_istra = {
+				}
+				b_lyubertsy = {
+				}
+				b_khimki = {
+				}
+				b_krasnoya = {
+				}
+			}
+			c_naro-fominsk = {
+				color={ 210 225 166 }
+				color2={ 255 255 255 }
+				
+				b_naro-fominsk = {
+				}
+				b_lopasnya = {
+				}
+				b_klimovka = {
+				}
+				b_voronovo = {
+				}
+				b_kubinka = {
+				}
+				b_troitsk = {
+				}
+				b_chukovo = {
+				}
+			}
+		}
+		d_yaroslavl = {		#Vologda
+			color={ 178 192 134 }
+			color2={ 255 255 255 }
+			
+			capital = 572 # Yaroslavl
+			
+			c_kostroma = {
+				color={ 181 195 137 }
+				color2={ 255 255 255 }
+						
+				b_kostroma = {
+				}
+				b_sudislavl = {
+				}
+				b_plyos = {
+				}
+				b_nerektha = {
+				}
+				b_apraksino = {
+				}
+				b_kosmynino = {
+				}
+				b_zavolzhsk = {
+				}
+				b_nekrasoskoye = {
+				}
+			}
+			c_vologda = {
+				color={ 141 158 98 }
+				color2={ 255 255 255 }
+					
+				b_vologda = {
+				}
+				b_kadnikovskaya = {
+				}
+				b_sokol = {
+				}
+				b_uste = {
+				}
+				b_bolshayamurga = {
+				}
+				b_dvinitsa = {
+				}
+				b_motyn = {
+				}
+				b_staroye = {
+				}
+			}
+			c_chud = {
+				color={ 138 154 94 }
+				color2={ 255 255 255 }
+					
+				b_totma = {
+				}
+				b_krbor = {
+				}
+				b_kamchuga = {
+				}
+				b_chunlovka = {
+				}
+				b_zalese = {
+				}
+				b_krutayaosyp = {
+				}
+				b_veldvor = {
+				}
+				b_zaytsevo = {
+				}
+			}
+		}
+		d_rostov = {
+			color={ 124 137 89 }
+			color2={ 255 255 255 }
+			
+			capital = 574 # Rostov
+			
+			finnish = Merya
+			lappish = Merya
+			ugricbaltic = Merya
+			komi = Merya
+			samoyed = Merya
+			mordvin = Merya
+			meshchera = Merya
+			
+			c_rostov = {
+				color={ 166 180 122 }
+				color2={ 255 255 255 }
+				
+				swedish = "Radstofa"
+				norse = "Radstofa"
+				danish = "Radstofa"
+				norwegian = "Radstofa"
+				komi=Merya
+				mordvin=Merya
+				samoyed=Merya
+				finnish=Merya
+				lappish=Merya
+					
+				b_sarskoyegorodishche = {
+					komi=Merya
+					mordvin=Merya
+					samoyed=Merya
+					finnish=Merya
+					lappish=Merya
+				}
+				b_rostov = {
+					swedish = "Radstofa"
+					norse = "Radstofa"
+					danish = "Radstofa"
+					norwegian = "Radstofa"
+				}
+				b_spasoyakovlevsky = {			
+				}
+				b_lvy = {
+				}
+				b_yepikharka = {
+				}
+				b_rezanka = {
+				}
+				b_kondakovo = {
+				}
+			}
+			c_uglich = {
+				color={ 169 183 125 }
+				color2={ 255 255 255 }
+					
+				b_uglich = {
+				}
+				b_ustyuzhna = {
+				}
+				b_ugliche_pole = {
+				}
+				b_mologa = {
+				}
+				b_krasny_kholm = {
+				}
+				b_koprino = {
+				}
+				b_breytovo = {
+				}
+			}
+			c_yaroslavl = {
+				color={ 184 198 140 }
+				color2={ 255 255 255 }
+				
+				b_timerevo = {
+				}
+				b_yaroslavl = {
+				}
+				b_rybinsk = {
+				}
+				b_petropavlovsky = {
+				}
+				b_spaso-preobrazhensky = {
+				}
+				b_romanov = {
+				}
+				b_borisoglebsky = {
+				}
+			}
+			c_beloozero = {
+				color={ 133 148 90 }
+				color2={ 255 255 255 }
+				
+				b_belozersk = {
+				}
+				b_fedosyevo = {
+				}
+				b_cherepovets = {
+				}
+				b_kirillobelozersky = {
+				}
+				b_ferapontov = {
+				}
+				b_baryevychi = {
+				}
+				b_kinilov = {
+				}
+			}
+		}
+		d_tver = {
+			color={ 169 183 125 }
+			color2={ 255 255 255 }
+			
+			capital = 570 # Tver
+			
+			ilmenian = "Vyatichia"
+			severian = "Vyatichia"
+			
+			c_tver = {
+				color={ 172 186 128 }
+				color2={ 255 255 255 }
+					
+				b_tver = {
+				}
+				b_klin = {
+				}
+				b_lotoshino = {
+				}
+				b_puchka = {
+				}
+				b_rodnya = {
+				}
+				b_turayevo = {
+				}
+				b_burashevo = {
+				}
+			}
+			c_rzheva = {
+				color={ 170 180 130 }
+				color2={ 255 255 255 }
+				
+				b_rzheva = {
+				}
+				b_gorodok = {
+				}
+				b_vysokoye = {
+				}
+				b_mednoye = {
+				}
+				b_pleshki = {
+				}
+				b_deshevki = {
+				}
+				b_zelenyy = {
+				}
+			}
+			c_zoubtsov = {
+				color={ 220 240 180 }
+				color2={ 255 255 255 }
+				
+				b_zoubtsov = {
+				}
+				b_yesinka = {
+				}
+				b_verigino = {
+				}
+				b_batakovo = {
+				}
+				b_papino = {
+				}
+				b_vysokino = {
+				}
+				b_ulyankovo = {
+				}
+			}
+			c_kashin = {
+				color={ 165 179 121 }
+				color2={ 255 255 255 }
+				
+				b_kashin = {
+				}
+				b_kaliazin = {
+				}
+				b_kimry = {
+				}
+				b_likhoslavl = {
+				}
+				b_kesova_gora = {
+				}
+				b_goritsy = {
+				}
+				b_ustinovo = {
+				}
+			}
+			c_mozhaysk = {
+				color={ 200 225 156 }
+				color2={ 255 255 255 }
+			
+				b_volgamozhaysk = {
+				}
+				b_shakhunya = {
+				}
+				b_yaransk = {
+				}
+				b_vakhtan = {
+				}
+				b_varnavino = {
+				}
+				b_kiknur = {
+				}
+				b_tonshaevo = {
+				}
+				b_uren = {
+				}
+			}
+		}
+	}
+}
+
+e_pontic_steppe = {
+	color = { 125 80 18 }
+	color2={ 255 255 255 }
+	
+	culture = cuman
+	
+	capital = 619 #	Saray
+	
+	short_name = yes
+	
+	# Creation/Usurp Trigger
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = altaic
+				culture = alan
+				culture = hungarian
+			}
+		}
+	}
+	
+	k_magyar = {
+		color={ 187 70 70 }
+		culture = hungarian
+	
+		allow = {
+			ai = no
+		}
+	}
+	k_khazaria = {
+		color={ 250 184 31 }
+		color2={ 255 255 255 }
+		
+		capital = 620 #	Itil
+		
+		culture = khazar
+		
+		# Creation/Usurp Trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture = khazar
+					religion_group = jewish_group
+				}
+			}
+		}
+		
+		d_aqtobe = {
+			color={ 140 140 40 }
+			color2={ 255 255 255 }
+			capital = 896 # Aqtobe
+
+			c_inder = {
+				color={ 171 138 50 }
+				color2={ 255 255 255 }
+			
+				b_orsk = { # Inderbor
+				}
+				b_karatogay = {
+				}
+				b_bogunbay = {
+				}
+				b_kaumetey = {
+				}
+				b_chausay = {
+				}
+				b_kemer = {
+				}
+				b_ebita = {
+				}
+				b_dzhanatalap = {
+				}
+			}
+			c_aqtobe = {
+				color={ 232 174 18 }
+				color2={ 255 255 255 }
+			
+				b_aqtobe = {
+				}
+				b_burta = {
+				} 
+				b_sibiryak = {
+				}
+				b_kunsay = {
+				}
+				b_zharlysay = {
+				}
+				b_shilikta = {
+				}
+				b_aulkutyrtas = {
+				}
+			}
+			c_utva = {
+				color={ 180 130 14 }
+				color2={ 255 255 255 }
+
+				b_utva = {}
+				b_ashchesay = {}
+				b_kirovo = {}
+				b_aktau = {}
+				b_araltobe = {}
+				b_saryumir = {}
+				b_ersary = {}
+			}
+			c_mughalzhar = {
+				color={ 170 120 11 }
+				color2={ 255 255 255 }
+
+				b_mughalzhar = {}
+				b_temir = {}
+				b_uil = {}
+				b_kopa = {}
+				b_bolgarka = {}
+				b_kandyagash = {}
+				b_kenzhaly = {}
+			}
+		}
+
+		d_sakmara = {
+			color={ 130 120 50 }
+			color2={ 255 255 255 }
+
+			capital = 1848 # Sakmara 
+
+			c_sakmara = {
+				color={ 200 150 20 }
+				color2={ 255 255 255 }
+
+				b_sakmara = {}
+				b_orenburg = {}
+				b_kushkul = {}
+				b_prudy = {}
+				b_iskra = {}
+				b_bulanovo = {}
+				b_zerklo = {}
+			}
+			c_irtek = {
+				color={ 190 140 17 }
+				color2={ 255 255 255 }
+
+				b_irtek = {}
+				b_kirsanovo = {}
+				b_khamino = {}
+				b_qanai = {}
+				b_borili = {}
+				b_chirovo = {}
+				b_teploye = {}
+			}
+		}
+
+		d_itil = {
+			color={ 151 118 30 }
+			color2={ 255 255 255 }
+			
+			capital = 620 # Itil
+
+			c_itil = {
+				color={ 155 122 34 }
+				color2={ 255 255 255 }
+
+				holy_site = tengri_pagan
+				holy_site = tengri_pagan_reformed
+				
+				b_itil = {
+				}
+				b_khaganbaligh = {
+				}
+				b_kamyzyak = {
+				}
+				b_kharabali = {
+				}
+				b_xacitarxan = {
+				} 
+				b_alga = {
+				}
+				b_tumak = {
+				}
+			}
+			c_uzens = {
+				color={ 163 130 42 }
+				color2={ 255 255 255 }
+			
+				b_kaztal = {
+				}
+				b_krykuru = {
+				}
+				b_kyzylasker = {
+				}
+				b_khasan = {
+				}
+				b_akkus = {
+				}
+				b_kosoba = {
+				}
+				b_ushkuduk = {
+				}
+				b_aytbay = {
+				}
+			}
+			c_saray = {
+				color={ 175 142 54 }
+				color2={ 255 255 255 }
+			
+				b_akhtuba = {
+				}
+				b_saray = {
+				}
+				b_tsaganaman = {
+				}
+				b_uspenka = {
+				}
+				b_pokrovka = {
+				}
+				b_dzhelga = {
+				}
+				b_bataevka = {
+				}
+				b_chernyyar = {
+				}
+			}
+			c_saqsin = {
+				color={ 185 150 60 }
+				color2={ 255 255 255 }
+
+				b_saqsin = {}
+				b_bundin = {}
+				b_tsarev = {}
+				b_maksima = {}
+				b_el_ton = {}
+				b_katrichev = {}
+				b_zhyra = {}
+			}
+			c_yeruslan = {
+				color={ 160 130 40 }
+				color2={ 255 255 255 }
+
+				b_yeruslan = {}
+				b_taygara = {}
+				b_imash = {}
+				b_orda = {}
+				b_tungysh = {}
+				b_mereke = {}
+				b_borsi = {}
+			}
+		}
+		
+		d_bandja = {
+			color={ 175 150 50 }
+			color2={ 255 255 255 }
+
+			pecheneg = "Pecheneg"
+
+			capital = 616 # Bandja/Pecheneg
+
+			c_pecheneg = {
+				color={ 159 126 38 }
+				color2={ 255 255 255 }
+			
+				b_bandja = {
+				}
+				b_kargala = {
+				}
+				b_saraktash = {
+				}
+				b_khutorka = {
+				}
+				b_tolkachi = {
+				}
+				b_sadovy = {
+				}
+				b_kichkas = {
+				}
+			}
+			c_lower_volga = {
+				color={ 167 134 46 }
+				color2={ 255 255 255 }
+			
+				b_sarysu = {
+				}
+				b_tsaritsyn = {
+				}
+				b_kamyshin = {
+				}
+				b_serebrjakovo = {
+				}
+				b_dubovka = {
+				}
+				b_petrovval = {
+				}
+				b_kotovo = {
+				}
+				b_prishib = {
+				}
+			}
+			c_uvek = {
+				color={ 150 150 75 }
+				color2={ 255 255 255 }
+
+				b_uvek = {}
+				b_marks = {}
+				b_lipovka = {}
+				b_burnyy = {}
+				b_shumeyka = {}
+				b_smelovka = {}
+				b_titorenko = {}
+			}
+		}
+
+		d_atyrau = {
+			color={ 200 175 75 }
+			color2={ 255 255 255 }
+
+			capital = 618 # Atyrau
+
+			c_guryev = { # Atyrau
+				color={ 230 172 16 }
+				color2={ 255 255 255 }
+			
+				b_atyrau = {
+				}
+				b_sarayjuk = {
+				}
+				b_yesmakan = {
+				}
+				b_zhanakush = {
+				}
+				b_karabatyr = {
+				}
+				b_mantyube = {
+				}
+				b_besikty = {
+				}
+				b_arlik = {
+				}
+			}
+			c_ryn = {
+				color={ 240 160 20 }
+				color2={ 255 255 255 }
+
+				b_ryn = {}
+				b_chapaev = {}
+				b_bitik = {}
+				b_bulan = {}
+				b_shagatay = {}
+				b_oyan = {}
+				b_tendik = {}
+			}
+		}
+
+		d_sarkel = {
+			color={ 236 200 105 }
+			color2={ 255 255 255 }
+			
+			capital = 594 # Sarkel
+		
+			c_sugrov = {
+				color={ 240 204 109 }
+				color2={ 255 255 255 }
+			
+				b_sugrov = {
+				}
+				b_yauchy = {
+				}
+				b_khursa = {
+				}
+				b_khazar = {
+				}
+				b_khratayak = {
+				}
+				b_oboyan = {
+				}
+				b_tim = {
+				}
+				b_fatezh = {
+				}
+			}
+			c_desht-i-kipchak = {
+				color={ 242 206 111 }
+				color2={ 255 255 255 }
+			
+				b_bakhmut = {
+				}
+				b_sviatohirsk = {
+				}
+				b_krasne = {
+				}
+				b_dobropillia = {
+				}
+				b_druzhkivka = {
+				}
+				b_kramatorsk = {
+				}
+				b_lyman = {
+				}
+				b_mospyne = {
+				}
+			}
+			c_sarkel = {
+				color={ 244 208 113 }
+				color2={ 255 255 255 }
+			
+				b_kazarki = {
+				}
+				b_sarkel = {
+				}
+				b_belayavezha = {
+				}
+				b_semikarakorsk = {
+				}
+				b_ustdonetskiy = {
+				}
+				b_kotelnikovo = {
+				}
+				b_tsimlyanskoye = {
+				}
+				b_nizhchir = {
+				}
+			}
+			c_don_portage = {
+				color={ 246 210 115 }
+				color2={ 255 255 255 }
+			
+				b_kalach = {
+				}
+				b_illovlya = {
+				}
+				b_ryumino = {
+				}
+				b_loq = {
+				}
+				b_illevka = {
+				}
+				b_donskoy = {
+				}
+				b_tary = {
+				}
+				b_ozerki = {
+				}
+			}
+			c_sharukan = {
+				color={ 238 203 121 }
+				color2={ 255 255 255 }
+				
+				b_kharka = {
+				}
+				b_sumy = {
+				}
+				b_challykala = {
+				}
+				b_khorysdan = {
+				}
+				b_izyum = {
+				}
+				b_balakliia = {
+				}
+				b_kupyansk = {
+				}
+				b_lyubotin = {
+				}
+			}
+			c_chortitza = {
+				color={ 234 194 88 }
+				color2={ 255 255 255 }
+			
+				b_ltava = {
+				}
+				b_chortitza = {
+				}
+				b_baszmacka = {
+				}
+				b_alexandrowsk = {
+				}
+				b_rasumowka = {
+				}
+				b_vosnesjensk = {
+				}
+				b_khorolya = {
+				}
+			}
+		}
+	}
+	k_taurica = {
+		color={ 188 91 154 }
+		color2={ 255 255 20 }
+	}
+	k_crimea = {
+		color={ 125 80 18 }
+		color2={ 255 255 20 }
+		
+		capital = 559 # Crimea
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture = khazar
+					culture = alan
+					culture = crimean_gothic
+				}
+			}
+		}
+
+		crimean_gothic = "Gothia"
+		
+		d_crimea = {
+			color={ 210 160 80 }
+			color2={ 255 255 255 }
+			
+			capital = 559 # Crimea
+		
+			c_lower_don = {
+				color={ 230 190 84 }
+				color2={ 255 255 255 }
+			
+				b_taganrog = {
+				}
+				b_matveevkurgan = {
+				}
+				b_skorokhod = {
+				}
+				b_latonovo = {
+				}
+				b_vesely = {
+				}
+				b_marfinka = {
+				}
+				b_ryasnoye = {
+				}
+				b_novoazovsk = {
+				}
+			}
+			c_lukomorie = {
+				color={ 242 202 96 }
+				color2={ 255 255 255 }
+			
+				b_zaporzhye = {
+				}
+				b_kushunum = {
+				}
+				b_huliaipole = {
+				}
+				b_kalmius = {
+				}
+				b_kalchik = {
+				}
+				b_onkhiv = {
+				}
+				b_polohy = {
+				}
+				b_chernihivka = {
+				}
+			}
+			c_lower_dniepr = { # Tag inverted with c_oleshye
+				color={ 246 206 100 }
+				color2={ 255 255 255 }
+			
+				b_oleshye = {
+				}
+				b_kairy = {
+				}
+				b_kyzylyar = {
+				}
+				b_shagingirei = {
+				}
+				b_kuturogly = {
+				}
+				b_tokmak = {
+				}
+				b_pryazovske = {
+				}
+				b_bilozerka = {
+				}
+			}
+			c_crimea = {
+				color={ 250 210 104 }
+				color2={ 255 255 255 }
+
+				holy_site = tengri_pagan
+				holy_site = tengri_pagan_reformed				
+				
+				b_bakhchisaray = {
+				}
+				b_aqmescit = {
+				}
+				b_dzhankoy = {
+				}
+				b_saq = {
+				}
+				b_perekop = {
+				}
+				b_qarasuvbazar = {
+				}
+				b_kezlev = {
+				}
+				b_qurman = {
+				}
+			}
+		}
+		d_cherson = {
+			color={ 180 180 90 }
+			color2={ 255 255 20 }
+			
+			capital = 560 # Cherson
+
+			crimean_gothic = "Theodoro"
+			
+			c_theodosia = {
+				color={ 190 93 156 }
+				color2={ 255 255 20 }
+				
+				b_theodosia = {
+				}
+				b_soldaia = {
+				}
+				b_kimmerikon = {
+				}
+				b_caffa = {
+				}
+				b_caulita = {
+				}
+				b_olyva = {
+				}
+				b_lusta = {
+				}
+				b_funan = {
+				}
+			}
+			c_korchev = {
+				color={ 192 95 158 }
+				color2={ 255 255 20 }
+				
+				b_bosphoros = {
+				}
+				b_panticapea = {
+				}
+				b_cherco = {
+				}
+				b_nymphaion = {
+				}
+				b_chystopillia = {
+				}
+				b_vosporo = {
+				}
+				b_baherove = {
+				}
+				b_zavitne = {
+				}
+			}
+			c_cherson = {
+				color={ 194 97 160 }
+				color2={ 255 255 20 }
+				
+				b_kherson = {
+				}
+				b_doros = {
+				}
+				b_neapol = {
+				}
+				b_kerkinitis = {
+				}
+				b_cembalo = {
+				}
+				b_charax = {
+				}
+				b_sevastoupolis = {
+				}
+				b_kalamita = {
+				}
+			}
+			c_tmutarakan = {
+				color={ 196 99 162 }
+				color2={ 255 255 20 }
+				
+				b_tmutarakan = {
+				}
+				b_mapa = {
+				}
+				b_taman = {
+				} 
+				b_tumnev = {
+				}
+				b_jevlisia = {
+				}
+				b_sujukqale = {
+				}
+				b_bata = {
+				}
+				b_tsemes = {
+				}
+			}
+		}
+		d_wild_fields = {
+			color={ 125 80 18 }
+			color2={ 255 255 255 }
+			
+			capital = 1646 # Odessa
+						
+			c_oleshye = { # Tag inverted with c_lower_dniepr
+				color={ 238 198 92 }
+				color2={ 255 255 255 }
+			
+				b_dnieprkherson = {
+				}
+				b_kamiansk = {
+				}
+				b_kryvyi_rih = {
+				}
+				b_dnipro = {
+				}
+				b_nikopol = {
+				}
+				b_mykolaiv = {
+				}
+				b_marhanets = {
+				}
+			}
+			c_vinnytsia = {
+				color={ 233 193 87 }
+				color2={ 255 255 255 }
+				
+				b_vinnytsia = {
+				}
+				b_ladyzhyn = {
+				}
+				b_illintsi = {
+				}
+				b_rov = {
+				}
+				b_haisyn = {
+				}
+				b_bershad = {
+				}
+				b_pervomaisk = {
+				}
+			}
+			c_bratslav = {
+				color={ 227 187 82 }
+				color2={ 255 255 255 }
+				
+				b_bratslav = {
+				}
+				b_nemyriv = {
+				}
+				b_yampil = {
+				}
+				b_sharhorod = {
+				}
+				b_zhmerynka = {
+				}
+				b_tomashpil = {
+				}
+				b_kryzhopil = {
+				}
+			}
+			c_korsun = {
+				color={ 230 190 85 }
+				color2={ 255 255 255 }
+	
+				b_korsun = {
+				}
+				b_cherkassy = {
+				}
+				b_smila = {
+				}
+				b_chyhyryn = {
+				}
+				b_oleksandriia = {
+				}
+				b_kirovohrad = {
+				}
+				b_znamianka = {
+				}
+			}
+			c_olvia = {
+				color={ 220 180 80 }
+				color2={ 255 255 255 }
+				
+				b_olvia = {
+				}
+				b_ochakiv = {
+				}
+				b_veselynove = {
+				}
+				b_voznesensk = {
+				}
+				b_kobleve = {
+				}
+				b_stavky = {
+				}
+				b_rybakivka = {
+				}
+			}
+			c_odessa = {
+				color={ 220 200 80 }
+				color2={ 255 255 255 }
+				
+				b_odessa = {
+				}
+				b_holovkivka = {
+				}
+				b_berezivka = {
+				}
+				b_petroverovka = {
+				}
+				b_rozdilna = {
+				}
+				b_illichivsk = {
+				}
+				b_yuzhne = {
+				}
+			}
+		}
+	}
+	k_alania = {
+		color={ 185 140 78 }
+		color2={ 255 255 255 }
+		
+		capital = 603 # Alania
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture = alan
+				}
+			}
+		}
+		
+		culture = alan
+		
+		tengri_pagan_reformed = 200
+
+		d_alania = {
+			color={ 155 110 48 }
+			color2={ 255 255 255 }
+			
+			capital = 603 # Alania
+		
+			c_kasogs = {
+				color={ 250 156 156 }
+				color2={ 255 255 255 }
+				
+				b_myequape = {
+				}
+				b_samiran = {
+				}
+				b_zikh = {
+				}
+				b_bakhtarakhtar = {
+				}
+				b_koshkhab = {
+				}
+				b_ustdzeghuta = {
+				}
+				b_sarytyuz = {
+				}
+				b_eltarkan = {
+				}
+			}
+			c_yegorlyk = {
+				color={ 255 214 92 }
+				color2={ 255 255 255 }
+			
+				b_piatigorie = {
+				}
+				b_madjar = {
+				}
+				b_stauropolis = {
+				}
+				b_beshpagir = {
+				}
+				b_erkenshakhar = {
+				}
+				b_kuguty = {
+				}
+				b_kiankiz = {
+				}
+				b_yamki = {
+				}
+			}
+			c_alania = {
+				color={ 255 218 96 }
+				color2={ 255 255 255 }
+			
+				b_vovnushki = {
+				}
+				b_magas = {
+				}
+				b_arkhyz = {
+				}
+				b_zaur = {
+				}
+				b_tskhinval = {
+				}
+				b_tkhabayerdy = {
+				}
+				b_zadalesk = {
+				}
+				b_tamarasheni = {
+				}
+			}	
+		}
+		d_caspian_steppe = {
+			color={ 155 130 78 }
+			color2={ 255 255 255 }
+
+			capital = 604 # Kuma
+
+			short_name = yes
+
+			c_kuma = {
+				color={ 255 220 98 }
+				color2={ 255 255 255 }
+			
+				b_kizlyar = {
+				}
+				b_kuliyurt = {
+				}
+				b_tereklimekteb = {
+				}
+				b_kizilyurt = {
+				}
+				b_gums = {
+				}
+				b_dylym = {
+				}
+				b_babayurt = {
+				}
+				b_arslanbek = {
+				}
+			}
+			c_manych = {
+				color={ 250 216 94 }
+				color2={ 255 255 255 }
+			
+				b_mozdok = {
+				}
+				b_makhmudmekteb = {
+				}
+				b_nartkala = {
+				}
+				b_malgobekbalka = {
+				}
+				b_kunay = {
+				}
+				b_karabulak = {
+				}
+				b_makhach = {
+				}
+			}
+			c_terek = {
+				color={ 250 212 90 }
+				color2={ 255 255 255 }
+
+				b_terek = {}
+				b_stepnoye = {}
+				b_majar = {}
+				b_termita = {}
+				b_kurskaya = {}
+				b_chanta = {}
+				b_gornyy = {}
+			}
+			c_kalaus = {
+				color={ 250 208 86 }
+
+				b_kalaus = {}
+				b_yankul = {}
+				b_bazovyy = {}
+				b_rozliv = {}
+				b_demino = {}
+				b_armavir = {}
+				b_kugulta = {}
+			}
+		}
+		d_azov = {
+			color={ 218 179 130 }
+			color2={ 255 255 255 }
+			
+			capital = 597 # Azov
+		
+			c_tana = {
+				color={ 222 183 79 }
+				color2={ 255 255 255 }
+			
+				b_tana = {
+				}
+				b_rostovnadonu = {
+				}
+				b_monastyrsky = {
+				}
+				b_bataysk = {
+				}
+				b_gundorovka = {
+				}
+				b_cherkassk = {
+				}
+				b_ustaksayaskaya = {
+				}
+				b_sulin = {
+				}
+			}
+			c_azov = {
+				color={ 226 187 83 }
+				color2={ 255 255 255 }
+			
+				b_azov = {
+				}
+				b_azaq = {
+				}
+				b_sadki = {
+				}
+				b_eysk = {
+				}
+				b_kagalnik = {
+				}
+				b_akhtarsk = {
+				}
+				b_kugey = {
+				}
+				b_katon = {
+				}
+			}
+			c_kuban = {
+				color={ 230 191 87 }
+				color2={ 255 255 255 }
+			
+				b_khumar = {
+				}
+				b_kuban = {
+				}
+				b_psekups = {
+				}
+				b_khutor = {
+				} 
+				b_podkumok = {
+				}
+				b_coparia = {
+				}
+				b_kirpili = {
+				}
+				b_beshtau = {
+				}
+			}
+			c_sarpa = {
+				color={ 255 212 90 }
+				color2={ 255 255 255 }
+			
+				b_elst = {
+				}
+				b_bachanta = {
+				}
+				b_ikburul = {
+				}
+				b_karatchaplak = {
+				}
+				b_yashkul = {
+				} 
+				b_ketchenery = {
+				}
+				b_yashalta = {
+				}
+				b_ysaganaman = {
+				}
+			}
+		}
+		d_derbent = {
+			color={ 203 76 76 }
+			color2={ 255 255 255 }
+			
+			capital = 674 # Derbent
+
+			armenian = "Aghbania"
+			georgian = "Aghbania"
+			alan = "Aghbania"
+			greek = "Albania"
+			
+			
+			c_derbent = {
+				color={ 253 179 179 }
+				color2={ 255 255 255 }
+				
+				b_narinkala = {
+				}
+				b_derbent = {
+				}
+				b_juma = {
+				}
+				b_chikkulkan = {
+				}
+				b_kuli = {
+				}
+				b_tayus = {
+				}
+				b_humraj = {
+				}
+				b_datuna = {
+				}
+			}
+			c_semender = {
+				color={ 253 182 182 }
+				color2={ 255 255 255 }
+				
+				b_kumukh = {
+				}
+				b_semender = {
+				}
+				b_khattibaku = {
+				}
+				b_khannalkala = {
+				}
+				b_urtseki = {
+				}
+				b_burgaikala = {
+				}
+				b_tarki = {
+				}
+			}
+			c_balanjar = {
+				color={ 253 185 185 }
+				color2={ 255 255 255 }
+
+				b_balanjar = {}
+				b_shali = {}
+				b_argun = {}
+				b_vedeno = {}
+				b_shatoy = {}
+				b_karata = {}
+				b_kiri = {}
+			}
+			c_durdzukia = {
+				color={ 253 200 200 }
+				color2={ 255 255 255 }
+
+				b_durdzukia = {}
+				b_nazran = {}
+				b_beslan = {}
+				b_alagir = {}
+				b_mizur = {}
+				b_dargavs = {}
+				b_ardon = {}
+			}
+		}
+	}
+	
+}
+
+e_tartaria = {
+	color = { 211 177 80 }
+	color2={ 255 255 255 }
+	
+	culture = cuman
+	
+	capital = 1457 # Kara Khorum
+	
+	# Creation/Usurp Trigger
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = altaic
+			}
+		}
+	}
+	
+	k_mongolia = {
+		color = { 100 100 250 }
+		
+		capital = 1457 # Kara-khorum
+		
+		culture = mongol
+		
+		uyghur = Uyghur
+		kirghiz = Kirghiz
+		
+		d_beshbaliq = {
+			color={ 135 162 240 }
+
+			capital = 1452 # Beshbaliq
+
+			uyghur = "Beshbalik"
+
+			c_altay = {
+				color = { 130 176 240 }
+				
+				b_altay = {
+				}
+				b_qinggil = {
+				}
+				b_koktokay = {
+				}
+				b_burqin = {
+				}
+				b_burultokay = {
+				}
+				b_kokagax = {
+				}
+				b_jeminay = {
+				}
+			}
+			
+			c_dunkheger = {
+				color = { 130 172 240 }
+				
+				b_dunkheger = {
+				}
+				b_hou_pulei = {
+				}
+				b_yulishi = {
+				}
+				b_mori = {
+				}
+				b_hengling = { # Fictional, for prosperity
+				}
+				b_dawuqiao = { # Fictional, for prosperity
+				}
+				b_majiajie = { # Fictional, for prosperity
+				}
+			}
+			
+			c_beshbaliq = {
+				color={ 135 162 240 }
+				
+				uyghur = "Beshbalik"
+
+				b_beshbalik = {
+					turkish = "Basboluk"
+				}
+				b_gucheng = {
+					uyghur = "Guqung"
+				}
+				b_jiangjunmiao = {
+				}
+				b_lishan = { # Fictional, for prosperity
+				}
+				b_liuwanxiang = { # Fictional, for prosperity
+				}
+				b_pinghu = { # Fictional, for prosperity
+				}
+				b_bashqorghan = { # Fictional, for prosperity
+				}
+			}
+		}
+		d_altay = {
+			color = { 220 220 255 }
+			
+			capital = 1895 # Belukha
+			
+			c_muztau = {
+				color = { 125 160 240 }
+				
+				b_muztau = {
+				}
+				b_zyryan = {
+				}
+				b_oskemen = {
+				}
+				b_urunkhayka = {
+				}
+				b_kurchum = {
+				}
+				b_uryl = {
+				}
+				b_khokh_khot = { # Fictional - For Prosperity
+				}
+			}
+			c_belukha = {
+				color={ 140 180 250 }
+
+				b_belukha = {}
+				b_inya = {}
+				b_multa = {}
+				b_tyungur = {}
+				b_yustik = {}
+				b_aktach = {}
+				b_kuray = {}
+			}
+			c_khuiten = {
+				color={ 145 175 230 }
+
+				b_khuiten = {}
+				b_arshaty = {}
+				b_sorvenok = {}
+				b_khoton = {}
+				b_buyant = {}
+				b_khushuut = {}
+				b_chikhertei = {}
+			}
+			c_monkh_khairkhan = {
+				color={ 135 185 225 }
+
+				b_monkh_khairkhan = {}
+				b_munkh = {}
+				b_jargalant = {}
+				b_fuyun = {}
+				b_tsenkher = {}
+				b_rashaant = {}
+				b_bayan_olgil = {}
+			}
+			c_markakol = {
+				color={ 120 160 220 }
+
+				b_markakol = {}
+				b_altaya = {}
+				b_manat = {}
+				b_zyryanovsk = {}
+				b_maleevsk = {}
+				b_bykovo = {}
+				b_ornek = {}
+			}
+		}
+		d_abakan = {
+			color={ 215 175 240 }
+
+			capital = 1899 # Abakan
+
+			c_abakan = {
+				color={ 220 160 240 }
+
+				b_abakan = {}
+				b_berenzhak = {}
+				b_tuim = {}
+				b_shira = {}
+				b_kommunar = {}
+				b_biskamzha = {}
+				b_birikchul = {}
+			}
+			c_tom = {
+				color={ 225 165 245 }
+
+				b_tom = {}
+				b_terekhino = {}
+				b_uval = {}
+				b_shorokhovo = {}
+				b_slavino = {}
+				b_zhernovo = {}
+				b_ilinka = {}
+			}
+			c_kuznetsk = {
+				color={ 230 180 235 }
+
+				b_kuznetsk = {}
+				b_mutnyy_kuznetsk = {}
+				b_chernoye_kuznetsk = {}
+				b_sarala_kuznetsk = {}
+				b_medvezhka_kuznetsk = {}
+				b_naryk = {}
+				b_belogorsk = {}
+			}
+			c_erchis = {
+				color = { 130 128 230 }
+				
+				b_erchis = {
+				}
+				b_korya = {
+				}#Pavlodar
+				b_semey = {
+				}
+				b_aqsw = {
+				}
+				b_ekibastuz = {
+				}
+				b_ertis = {
+				}
+				b_koktobe = {
+				}
+			}
+		}
+		d_otuken = {
+			color = { 110 150 220 }
+			
+			capital = 1461 # Ötüken
+			
+			c_otuken = {
+				color = { 130 136 220 }
+
+				holy_site = tengri_pagan
+				holy_site = tengri_pagan_reformed
+				
+				b_otuken = {
+				}
+				b_sayan = {
+					turkish = "Kogmen"
+				}
+				b_khori_tumed = {
+				}
+				b_kyren = {
+				}
+				b_kutulik = {
+				}
+				b_tulun = {
+				}
+				b_tenger = { # Fictional - For Prosperity
+				}
+			}
+			c_gorgol = {
+				color = { 130 124 235 }
+				
+				b_gorgol = {
+				}
+				b_abaza = {
+				}
+				b_tashtyp = {
+				}
+				b_belcheeriin = { # Fictional - For Prosperity
+				}
+				b_tsetseg_moriin = { # Fictional - For Prosperity
+				}
+				b_altan_talbar = { # Fictional - For Prosperity
+				}
+				b_guunii_suu = { # Fictional - For Prosperity
+				}
+			}
+			c_khovsgol = {
+				color={ 105 145 235 }
+
+				b_khovsgol = {}
+				b_orlik = {}
+				b_sorok = {}
+				b_botogol = {}
+				b_onot = {}
+				b_arshan = {}
+				b_mondy = {}
+			}
+			c_egiin = {
+				color={ 100 135 225 }
+
+				b_egiin = {}
+				b_hatgal = {}
+				b_saridag = {}
+				b_mandal = {}
+				b_zuulun = {}
+				b_tugul = {}
+				b_murun = {}
+			}
+			c_eastern_sayan = {
+				color={ 110 140 230 }
+
+				b_eastern_sayan = {}
+				b_cherbi = {}
+				b_erzhey = {}
+				b_kundustug = {}
+				b_mezhegey = {}
+				b_sukpak = {}
+				b_arzhan = {}
+			}
+		}
+		d_uvs = {
+			color={ 140 140 250 }
+
+			capital = 1906 # Uvs
+
+			c_uvs = {
+				color={ 130 150 250 }
+
+				b_uvs = {}
+				b_sagil = {}
+				b_davst = {}
+				b_tes = {}
+				b_tsalgar = {}
+				b_ulaangom = {}
+				b_erzin = {}
+			}
+			c_kyzyl = {
+				color = { 136 144 240 }
+				
+				b_kyzyl = {
+				}
+				b_turan = {
+				}
+				b_chadaana = {
+				}
+				b_ulala = {
+				}
+				b_ulagan = {
+				}
+				b_saikhan_zam = { # Fictional - For Prosperity
+				}
+				b_azarga = { # Fictional - For Prosperity
+				}
+			}
+			c_tannu_ola = {
+				color={ 130 150 230 }
+
+				b_tannu_ola = {}
+				b_teeli = {}
+				b_bay_tal = {}
+				b_kara_khol = {}
+				b_sut_khol = {}
+				b_sug_aksy = {}
+				b_chadan_tannu_ola = {}
+			}
+			c_kharkhiraa = {
+				color={ 125 140 235 }
+
+				b_kharkhiraa = {}
+				b_baatar = {}
+				b_tsetseg = {}
+				b_bumbag = {}
+				b_myangan_ugalzat = {}
+				b_darvi_kharkhiraa = {}
+				b_sutay = {}
+			}
+			c_tsambagarav = {
+				color={ 120 135 240 }
+
+				b_tsambagarav = {}
+				b_achit_tsambagarav = {}
+				b_khovd_tsambagarav = {}
+				b_uureg = {}
+				b_tashanta = {}
+				b_kokorya = {}
+				b_kyzyl_khaya = {}
+			}
+		}
+		d_khangai = {
+			color = { 100 120 240 }
+			
+			capital = 1458 # Khangai
+			
+			c_khangai = {
+				color = { 133 142 240 }
+				
+				b_khangai = {
+				}
+				b_ogii = {
+				}
+				b_tsetserleg = {
+				}
+				b_uliastai = {
+				}
+				b_orgil = {
+				}
+				b_erdenet = {
+				}
+				b_sangiin = {}
+			}
+			c_tarvagatai = {
+				color = { 105 105 235 }
+
+				b_tarvagatai = {}
+				b_shuurmak = {}
+				b_tere_khol = {}
+				b_kungurtug = {}
+				b_zuunkhangai = {}
+				b_asgat = {}
+				b_songino = {}
+			}
+			c_terkhiin_tsagaan = {
+				color = { 100 110 230 }
+
+				b_terkhiin_tsagaan = {}
+				b_khorgo = {}
+				b_tariat = {}
+				b_khunt = {}
+				b_avgaldai = {}
+				b_khadat = {}
+				b_tsahir = {}
+			}
+			c_otgontenger = {
+				color = { 90 90 240 }
+
+				b_otgontenger = {}
+				b_gurvanbulag = {}
+				b_taishir = {}
+				b_guulin = {}
+				b_tsagaanchuulut = {}
+				b_zag = {}
+				b_bayanbulag = {}
+			}
+			c_suvraga_khairkhan = {
+				color={ 110 100 220 }
+
+				b_suvraga_khairkhan = {}
+				b_zegstei = {}
+				b_khotont = {}
+				b_tsenher = {}
+				b_jargalant_suvraga = {}
+				b_khushuut_suvraga = {}
+				b_mogod = {}
+			}
+		}
+		d_kara_khorum = {
+			color={ 90 213 240 }
+
+			capital = 1457 # Kara-khorum
+
+			c_kara_khorum = {
+				color = { 130 132 225 }
+				
+				turkish = "Ordu Baliq"
+				uyghur = "Karabalgasun"
+				
+				b_kara_khorum = {
+					turkish = "Ordu Baliq"
+					uyghur = "Karabalgasun"
+				}
+				b_luut = {
+				}
+				b_noin_ula = {
+					mongol = "Noyon Uulyn"
+				}
+				b_zuunmod = {
+				}
+				b_khamag = {
+				}
+				b_lun = {
+				}
+				b_bayan = {
+				}
+			}
+			c_orkhon = {
+				color = { 90 80 245 }
+
+				b_orkhon = {}
+				b_orkhontuul = {}
+				b_sant = {}
+				b_baruunburen = {}
+				b_khutul = {}
+				b_khushaat = {}
+				b_darkhan_orkhon = {}
+			}
+			c_tuul = {
+				color = { 100 90 250 }
+
+				b_tuul = {}
+				b_khustain = {}
+				b_terelj = {}
+				b_argalant = {}
+				b_lun_tuul = {}
+				b_gachuurt = {}
+				b_nalaikh = {}
+			}
+		}
+		d_baygal = {
+			color={ 70 100 200 }
+
+			capital = 1460 # Baygal
+
+			c_baygal = {
+				color = { 139 146 240 }
+				
+				b_baygal = {
+				}
+				b_darkhan = {
+				}
+				b_bargujin = {
+				}
+				b_merkit = {
+					mongol = "Mergid"
+				}
+				b_kyakhta = {
+					mongol = "Khyaagta"
+				}
+				b_galuuta = {
+				}
+				b_ulyun = {}
+			}
+			c_uda = {
+				color = { 60 90 210 }
+
+				b_uda = {}
+				b_bomnak = {}
+				b_umlekan = {}
+				b_zeya = {}
+				b_zeysky = {}
+				b_torom = {}
+				b_chumikan = {}
+			}
+			c_khilok = {
+				color = { 65 95 215 }
+
+				b_khilok = {}
+				b_merkit_khilok = {}
+				b_stolga = {}
+				b_zakaznik = {}
+				b_sharalday = {}
+				b_bilyutay = {}
+				b_kareliya = {}
+			}
+			c_chikoi = {
+				color = { 70 90 220 }
+
+				b_chikoi = {}
+				b_urluk = {}
+				b_bursomon = {}
+				b_shimbilik = {}
+				b_chudotvortsa = {}
+				b_shergol_dzhin = {}
+				b_cheremkhovo = {}
+			}
+			c_selenge = {
+				color = { 80 105 201 }
+
+				b_selenge = {}
+				b_borgoy = {}
+				b_dzhida = {}
+				b_naushki = {}
+				b_khyagt = {}
+				b_yonkhor = {}
+				b_botsiy = {}
+			}
+		}
+		d_ikh_bogd = {
+			color = { 130 120 240 }
+			
+			capital = 1456 # Ikh Bogd
+			
+			c_ikh_bogd = {
+				color = { 115 160 240 }
+				
+				b_ikh_bogd = {
+				}
+				b_gobi = {
+				}
+				b_khereid = {
+				}
+				b_zubu = {
+					turkish = "Suibu"
+				}
+				b_nuuruudyn_hondij = {
+				}
+				b_arguut = {
+				}
+				b_khuld = {
+				}
+			}
+			c_burkhan_buudai = {
+				color = { 140 110 240 }
+
+				b_burkhan_buudai = {}
+				b_biger = {}
+				b_khaliun_burkhan = {}
+				b_tsogt = {}
+				b_chandmani = {}
+				b_tseel = {}
+				b_erdene_burkhan = {}
+			}
+			c_delgerkhangai = {
+				color = { 135 120 240 }
+
+				b_delgerkhangai = {}
+				b_luus = {}
+				b_saikhan = {}
+				b_sangiindalai = {}
+				b_tsant = {}
+				b_delgertsogt = {}
+				b_khuld_delgerkhangai = {}
+			}
+			c_gurvan_saikhan = {
+				color = { 130 125 240 }
+
+				b_gurvan_saikhan = {}
+				b_baruun_saikhany_nuruu = {}
+				b_dund_saikhany_nuruu = {}
+				b_zuun_saikhany_nuruu = {}
+				b_bayandalai = {}
+				b_khurmen = {}
+				b_khankhongor = {}
+			}
+		}
+		d_gobi_altay = {
+			color = { 65 65 255 }
+
+			capital = 1455 # Zavkhan (Old Tsagaannuur)
+
+			c_tsagaannuur = {
+				color = { 120 160 240 }
+				
+				b_tsagaannuur = {
+				}
+				b_naiman = {
+				}
+				b_khovd = {
+				}
+				b_khar = {
+				}
+				b_mankhan = {
+				}
+				b_darvi = {
+				}
+				b_khaliun = {
+				}
+			}
+			c_khokh_serkh = {
+				color = { 60 60 255 }
+
+				b_khokh_serkh = {}
+				b_duruu = {}
+				b_tal = {}
+				b_khovd_khokh_serkh = {}
+				b_tolbo = {}
+				b_tsast = {}
+				b_tugal = {}
+			}
+			c_sutai = {
+				color = { 55 65 255 }
+
+				b_sutai = {}
+				b_ikhes = {}
+				b_bulgan = {}
+				b_darvi_sutai = {}
+				b_tonkhil = {}
+				b_khulmiin = {}
+				b_myangan = {}
+			}
+			c_khasagt_khairkhan = {
+				color = { 65 55 255 }
+
+				b_khasagt_khairkhan = {}
+				b_gegeen = {}
+				b_sharga = {}
+				b_jargalan = {}
+				b_bayan_uul = {}
+				b_guulin_khasagt = {}
+				b_altai_khasagt = {}
+			}
+		}
+		d_barkul = {
+			color = { 140 80 230 }
+
+			capital = 1516 # Barkul
+
+			c_barkul = {
+				color={ 120 120 250 }
+
+				b_barkul = {
+					turkish = "Barköl"
+					uyghur = "Barköl"
+				}
+				b_khoid = {
+				}
+				b_zhangpeng = { # Fictional, for prosperity
+				}
+				b_xiaoguantian = { # Fictional, for prosperity
+				}
+				b_jiuxian = { # Fictional, for prosperity
+				}
+				b_shiniu = { # Fictional, for prosperity
+				}
+				b_tiantoucun = { # Fictional, for prosperity
+				}
+			}
+			c_aj_bogd = {
+				color = { 130 168 240 }
+				
+				b_aj_bogd = {
+				}
+				b_balikun = {
+				}
+				b_qian_pulei = {
+				}
+				b_erdene = {
+				}
+				b_gurvantes = {
+				}
+				b_nanlizhuang = { # Fictional, for prosperity
+				}
+				b_changcun = { # Fictional, for prosperity
+				}
+			}
+		}
+		d_juyan = {
+			color = { 120 160 255 }
+
+			capital = 1919 # Juyan
+
+			c_juyan = {
+				color = { 124 164 255 }
+
+				b_juyan = {}
+				b_chuyen_hai = {}
+				b_sogo_nuur = {}
+				b_gaxun_nur = {}
+				b_subozhuoer = {}
+				b_shivee_khuren = {}
+				b_murengaole = {}
+			}
+			c_ejin = {
+				color={ 120 140 245 }
+
+				b_khara_khoto = {
+				}
+				b_mazongshan = {
+				}
+				b_jijiagou = { # Fictional, for prosperity
+				}
+				b_yuhe = { # Fictional, for prosperity
+				}
+				b_hwantsaopa = { # Fictional, for prosperity
+				}
+				b_zhugentan = { # Fictional, for prosperity
+				}
+				b_tongchongcha = { # Fictional, for prosperity
+				}
+			}
+		}
+	}
+	k_cuman = {
+		color = { 231 192 88 }
+		color2={ 255 255 255 }
+		
+		culture = cuman
+		
+		capital = 895 #	Yaik
+		
+		tengri_pagan_reformed = 500
+		zoroastrian_group = 50 # Crusade target weight
+		
+		# Creation/Usurp Trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture = cuman
+				}
+			}
+		}
+		
+		slavic_pagan_reformed = 50 # Crusade target weight
+
+		d_yaik = {
+			color={ 198 150 11 }
+			color2={ 255 255 255 }
+			
+			capital = 895 # Yaik
+		
+			c_yaik = {
+				color={ 231 178 35 }
+				color2={ 255 255 255 }
+			
+				b_kurgan = {
+				}
+				b_kyzalyar = {
+				}
+				b_lebyazhe = {
+				}
+				b_yurgamysh = {
+				}
+				b_shumikha = {
+				}
+				b_mishkino = {
+				}
+				b_makushino = {
+				}
+			}
+			c_or = {
+				color={ 236 183 40 }
+				color2={ 255 255 255 }
+
+				b_or = {}
+				b_orsk_or = {}
+				b_istemis = {}
+				b_maytobe = {}
+				b_stepnoe = {}
+				b_aschelisay = {}
+				b_mamyt = {}
+			}
+			c_magnitaya = {
+				color={ 241 188 45 }
+				color2={ 255 255 255 }
+
+				b_magnitaya = {}
+				b_kyubas = {}
+				b_balkany = {}
+				b_ulyandy = {}
+				b_bikkulovo = {}
+				b_gusevo = {}
+				b_tirmen = {}
+			}
+		}
+
+		d_turgay = {
+			color={ 150 90 40 }
+			color2={ 255 255 255 }
+
+			capital = 1273 # Turgay
+
+			c_turgay = {
+				color={ 191 114 70 }
+				color2={ 255 255 255 }
+				
+				b_turgay = {}
+				b_ust_turgay = {}
+				b_karakal = {}
+				b_zhailyk = {}
+				b_urlyki = {} #Fictional, for prosperity
+				b_dralyk = {} #Fictional, for prosperity
+				b_mankal = {} #Fictional, for prosperity
+			}
+
+			c_irgiz = {
+				color={ 196 119 75 }
+				color2={ 255 255 255 }
+
+				b_irgiz = {}
+				b_kair = {}
+				b_ulpan = {}
+				b_shalkar = {}
+				b_shaktha = {}
+				b_alabas = {}
+				b_berchogur = {}
+			}
+
+			c_boqtybay = {
+				color={ 201 124 80 }
+				color2={ 255 255 255 }
+
+				b_boqtybay = {}
+				b_guberlinskiy = {}
+				b_zhailma_boqtybay = {}
+				b_taldykol = {}
+				b_urkash = {}
+				b_klochkovo = {}
+				b_pushkino = {}
+			}
+		}
+
+		d_kazakh = {
+			color={ 120 70 40 }
+			color2={ 255 255 255 }
+
+			capital = 1433 # Kazakh
+
+			c_kazakh = {
+				color={ 121 74 40 }
+				color2={ 255 255 255 }
+				
+				b_zhezdi = {}
+				b_zhairem = {}
+				b_zhezkazgan = {}
+				b_karsakpay = {}
+				b_jezkazgan = {}
+				b_kengir = {}
+				b_zhezgir = {} #Fictional, for prosperity
+			}
+
+			c_betpaqdala = {
+				color={ 116 69 35 }
+				color2={ 255 255 255 }
+
+				b_betpaqdala = {}
+				b_kuygan = {}
+				b_mynaral = {}
+				b_ulken = {}
+				b_mirnyy = {}
+				b_shiganak = {}
+				b_burybaytal = {}
+			}
+
+			c_sarysu = {
+				color={ 111 64 30 }
+				color2={ 255 255 255 }
+
+				b_sarysu_kazakh = {}
+				b_aktam = {}
+				b_zhaiylma = {}
+				b_zhanatas = {}
+				b_kumkent = {}
+				b_saudakent = {}
+				b_zhuldyz = {}
+			}
+
+			c_balkhash = {
+				color={ 131 114 20 }
+				color2={ 255 255 255 }
+				
+				b_balkhash = {}
+				b_gulshat = {}
+				b_shashubay = {}
+				b_akshatau = {}
+				b_karazhal = {}
+				b_aktogay = {}
+				b_karagandy = {}
+			}
+
+			c_qarazhyrya = {
+				color={ 125 80 45 }
+				color2={ 255 255 255 }
+
+				b_qarazhyrya = {}
+				b_saryshagan = {}
+				b_aktau_qarazhyrya = {}
+				b_kyzyltau = {}
+				b_zhambul = {}
+				b_ortau = {}
+				b_gulshat_qarazhyrya = {}
+			}
+		}
+
+		d_ob = {
+			color={ 140 130 50 }
+			color2={ 255 255 255 }
+
+			capital = 1873 # Ob
+
+			c_ob = {
+				color={ 135 125 45 }
+				color2={ 255 255 255 }
+
+				b_ob = {}
+				b_akutikha = {}
+				b_odintsovka = {}
+				b_chekanikha = {}
+				b_volodarka = {}
+				b_buranovo = {}
+				b_barnaul = {}
+			}
+			c_katun = {
+				color={ 130 120 40 }
+				color2={ 255 255 255 }
+
+				b_katun = {}
+				b_mayma = {}
+				b_aya = {}
+				b_souzga = {}
+				b_turbaza = {}
+				b_karlushka = {}
+				b_manzherok = {}
+			}
+			c_ket = {
+				color={ 125 115 35 }
+				color2={ 255 255 255 }
+				
+				b_ket = {}
+				b_asino = {}
+				b_ketkas = {}
+				b_sochur = {}
+				b_chachamga = {}
+				b_ketino = {} #Fictional, for prosperity
+				b_alchach = {} #Fictional, for prosperity
+			}
+			c_zaysan = {
+				color={ 120 110 30 }
+				color2={ 255 255 255 }
+
+				b_zaysan = {}
+				b_ulba = {}
+				b_volchanka = {}
+				b_ubinka = {}
+				b_novaya = {}
+				b_ivanovka = {}
+				b_zubair = {}
+			}
+			c_buqtirma = {
+				color={ 115 105 25 }
+				color2={ 255 255 255 }
+
+				b_buqtirma = {}
+				b_akku = {}
+				b_shamshi = {}
+				b_kazantay = {}
+				b_zhanatan = {}
+				b_koyanbay = {}
+				b_shoktal = {}
+			}
+		}
+
+		d_tarbagatai = {
+			color={ 170 100 100 }
+			color2={ 255 255 255 }
+
+			capital = 1876 # Tarbagatai
+
+			c_tarbagatai = {
+				color={ 165 95 95 }
+				color2={ 255 255 255 }
+
+				b_tarbagatai = {}
+				b_beskol = {}
+				b_alakol = {}
+				b_yntaly = {}
+				b_usharal = {}
+				b_zharbulak = {}
+				b_zhanam = {}
+			}
+
+			c_urzhar = {
+				color={ 160 90 90 }
+				color2={ 255 255 255 }
+				
+				b_ayagoz = {}
+				b_urzhar = {}
+				b_akzhar = {}
+				b_taskesken = {}
+				b_ushbik = {}
+				b_manzhar = {} #Fictional, for prosperity
+				b_ayzhar = {} #Fictional, for prosperity
+			}
+			c_aylik = {
+				color={ 155 85 85 }
+				color2={ 255 255 255 }
+
+				b_aylik = {}
+				b_karamay = {}
+				b_baijiantan = {}
+				b_urho = {}
+				b_kuytun = {}
+				b_usu = {}
+				b_shawan = {}
+			}
+			c_saur = {
+				color={ 150 80 80 }
+				color2={ 255 255 255 }
+
+				b_saur = {}
+				b_karatal_saur = {}
+				b_tughyl = {}
+				b_karabulak_saur = {}
+				b_kensay = {}
+				b_dair = {}
+				b_kogeday = {}
+			}
+		}
+
+		d_irtysh = {
+			color={ 150 100 50 }
+			color2={ 255 255 255 }
+
+			capital = 1132 # Irtysh
+
+			c_kirghiz = {
+				color={ 175 150 80 }
+				color2={ 255 255 255 }
+				
+				b_irtysh = {}
+				b_telengit = {}
+				b_tele = {}
+				b_osinniki = {}
+				b_kurchatov = {}
+				b_sinnele = {} #Fictional, for prosperity
+				b_kanbale = {} #Fictional, for prosperity
+			}
+
+			c_kimak = {
+				color={ 141 94 60 }
+				color2={ 255 255 255 }
+				
+				b_karasor = {}
+				b_tengiz = {}
+				b_atasu = {}
+				b_arkalyk = {}
+				b_jutasu = {} #Fictional, for prosperity
+				b_opak = {} #Fictional, for prosperity
+				b_tenul = {} #Fictional, for prosperity
+			}
+		}
+
+		d_ishim = {
+			color={ 210 170 60 }
+			color2={ 255 255 255 }
+
+			capital = 1223 # Ishim
+
+			c_kipchak = {
+				color={ 151 94 60 }
+				color2={ 255 255 255 }
+				
+				b_zhitikara = {}
+				b_zhailma = {}
+				b_kipchak = {}
+				b_amankaragaj = {}
+				b_kusmuryn = {}
+				b_kusma = {} #Fictional, for prosperity
+				b_kipgaj = {} #Fictional, for prosperity
+			}
+
+			c_ishim = {
+				color={ 194 169 40 }
+				color2={ 255 255 255 }
+			
+				b_ishim = {}
+				b_esil = {}
+				b_mamlyut = {}
+				b_ust_ishim = {}
+				b_ulsut = {} #Fictional, for prosperity
+				b_mamshim = {} #Fictional, for prosperity
+				b_esut = {} #Fictional, for prosperity
+			}
+
+			c_seletyteniz = {
+				color={ 175 130 50 }
+				color2={ 255 255 255 }
+
+				b_seletyteniz = {}
+				b_saryoba = {}
+				b_bereke = {}
+				b_babatay = {}
+				b_shubar_seletyteniz = {}
+				b_koyandy = {}
+				b_koschi = {}
+			}
+		}
+
+		d_ubagan = {
+			color={ 220 180 70 }
+			color2={ 255 255 255 }
+
+			capital = 1856 # Ubagan
+
+			c_ubagan = {
+				color={ 225 160 40 }
+				color2={ 255 255 255 }
+
+				b_ubagan = {}
+				b_chernigovka = {}
+				b_karasu = {}
+				b_zhumagul = {}
+				b_auliekol = {}
+				b_kozubay = {}
+				b_tyuntyugur = {}
+			}
+
+			c_kartaly = {
+				color={ 232 171 30 }
+				color2={ 255 255 255 }
+
+				b_kartaly = {}
+				b_talapker = {}
+				b_kirovka = {}
+				b_kachar = {}
+				b_zarechny = {}
+				b_kostanay = {}
+				b_zhdanovka = {}
+			}
+		}
+	}
+	k_sibir = {
+		color={ 181 170 145 }
+		color2={ 255 255 255 }
+
+		capital = 893 # Sibir
+
+		d_sibir = {
+			color={ 210 185 15 }
+			color2={ 255 255 255 }
+			
+			capital = 891 # Tyumen
+		
+			c_sibir = {
+				color={ 227 174 31 }
+				color2={ 255 255 255 }
+			
+				b_surgut = {
+				}
+				b_belyyyar = {
+				}
+				b_iberbolgar = {
+				}
+				b_baduk = {
+				}
+				b_kaik = {
+				}
+				b_langepas = {
+				}
+				b_pokachi = {
+				}
+				b_vysokiy = {
+				}
+				b_sibir = {
+				}
+			}
+
+			c_tura = {
+				color={ 191 154 70 }
+				color2={ 255 255 255 }
+				
+				b_tura = {}
+				b_almaty = {}
+				b_bestobe = {}
+				b_teke = {}
+				b_kishkenekol = {}
+				b_zalivino_tura = {}
+				b_ake = {} # Fictional, for prosperity
+			}
+
+			c_vagay = {
+				color={ 200 160 30 }
+				color2={ 255 255 255 }
+
+				b_vagay = {}
+				b_kordon_vagay = {}
+				b_begitino = {}
+				b_tukuz = {}
+				b_chernoye = {}
+				b_kularovo = {}
+				b_takhtagul = {}
+			}
+			
+			c_osha = {
+				color={ 210 170 50 }
+				color2={ 255 255 255 }
+
+				b_osha = {}
+				b_sartam = {}
+				b_kotochigi = {}
+				b_zaborka = {}
+				b_kargaly = {}
+				b_vikulovo = {}
+				b_balagany = {}
+			}
+		}
+		d_tobol = {
+			color={ 230 230 150 }
+			color2={ 255 255 255 }
+
+			capital = 898 # Tobol
+
+			c_tobol = {
+				color={ 234 176 20 }
+				color2={ 255 255 255 }
+
+				holy_site = tengri_pagan
+				holy_site = tengri_pagan_reformed
+				
+				b_tobol = {
+				}
+				b_isilkul = {
+				}
+				b_kalachinsk = {
+				}
+				b_tyukalinsk = {
+				}
+				b_cherlak = {
+				}
+				b_sargatka = {
+				}
+				b_krasnyyar = {
+				}
+			}
+
+			c_tyumen = {
+				color={ 219 166 23 }
+				color2={ 255 255 255 }
+			
+				b_tyumen = {
+				}
+				b_qashliq = {
+				}
+				b_tobolsk = {
+				}
+				b_tugulym = {
+				}
+				b_novtap = {
+				}
+				b_sumkino = {
+				}
+				b_nizhtavda = {
+				}
+				b_borovskiy = {
+				}
+			}
+
+			c_miass = {
+				color={ 211 150 50 }
+				color2={ 255 255 255 }
+
+				b_miass = {}
+				b_kukushi = {}
+				b_rassvet = {}
+				b_singul = {}
+				b_lipikha = {}
+				b_malyshi = {}
+				b_shatrovo = {}
+			}
+
+			c_tavda = {
+				color={ 205 160 60 }
+				color2={ 255 255 255 }
+
+				b_tavda = {}
+				b_yushala = {}
+				b_yar = {}
+				b_tugulym_tavda = {}
+				b_talitsa = {}
+				b_baykalovo = {}
+				b_igovskoy = {}
+			}
+		}
+		d_yugra = {
+			color={ 250 250 180 }
+			color2={ 255 255 255 }
+			
+			capital = 892 # Mansia
+			
+			c_mansia = {
+				color={ 223 170 27 }
+				color2={ 255 255 255 }
+			
+				b_mansiysk = {
+				}
+				b_yabin = {			
+				}
+				b_yalbak = {
+				}
+				b_pytyakh = {
+				}
+				b_nefteyugansk = {
+				}
+				b_mamontovo = {
+				}
+				b_poykovskiy = {
+				}
+				b_samza = {
+				}
+			}
+			c_khantia = {
+				color={ 249 223 152 }
+				color2={ 255 255 255 }
+			
+				b_chanty = {
+				}
+				b_beloyarskiy = {
+				}
+				b_igrim = {
+				}
+				b_berezovo = {
+				}
+				b_pnobe = {
+				}
+				b_nyagyn = {
+				}
+				b_djinesh = {
+				}
+				b_sherkala = {
+				}
+			}
+			c_yamalia = {
+				color={ 240 214 143 }
+				color2={ 255 255 255 }
+			
+				b_polnovatvozh = {
+				}
+				b_obdorsk = {
+				}
+				b_lapytnangk = {
+				}
+				b_ituyakha = {
+				}
+				b_urengoi = {
+				}
+				b_nazym = {
+				}
+				b_baygul = {
+				}
+				b_kaek = {
+				}
+			}
+		}
+		d_om = {
+			color={ 240 240 150 }
+			color2={ 255 255 255 }
+
+			capital = 1861 # Om
+
+			c_om = {
+				color={ 210 170 130 }
+				color2={ 255 255 255 }
+
+				b_om = {}
+				b_butovka = {}
+				b_omskiy = {}
+				b_stepnoy = {}
+				b_rostovka = {}
+				b_zotino = {}
+				b_borodinka = {}
+			}
+			c_tara = {
+				color={ 205 165 120 }
+				color2={ 255 255 255 }
+
+				b_tara = {}
+				b_karbyza = {}
+				b_okunevo = {}
+				b_zalivino = {}
+				b_keyzes = {}
+				b_nizovoye = {}
+				b_chernovka = {}
+			}
+			c_narim = {
+				color={ 216 175 140 }
+				color2={ 255 255 255 }
+			
+				b_narim = {}
+				b_kolta = {}
+				b_yag = {}
+				b_askiz = {}
+				b_aziz = {} #Fictional, for prosperity
+				b_aruz = {} #Fictional, for prosperity
+				b_uros = {} #Fictional, for prosperity
+			}
+		}
+		d_vasyugan = {
+			color={ 220 220 120 }
+			color2={ 255 255 255 }
+
+			capital = 1860 # Vasyugan
+
+			c_vasyugan = {
+				color={ 200 150 150 }
+				color2={ 255 255 255 }
+
+				b_vasyugan = {}
+				b_bylino = {}
+				b_zaytseva = {}
+				b_vampugol = {}
+				b_megion = {}
+				b_nazino = {}
+				b_sredny = {}
+			}
+
+			c_bolshoy = {
+				color={ 210 160 160 }
+				color2={ 255 255 255 }
+
+				b_bolshoy = {}
+				b_lempino = {}
+				b_banyy = {}
+				b_tundrino = {}
+				b_sytomino = {}
+				b_singapay = {}
+				b_yugan = {}
+			}
+
+			c_tui = {
+				color={ 210 170 170 }
+				color={ 255 255 255 }
+
+				b_tui = {}
+				b_aksurka = {}
+				b_abaul = {}
+				b_azy = {}
+				b_saurgachi = {}
+				b_supra = {}
+				b_shabry = {}
+			}
+
+			c_shish = {
+				color={ 230 180 180 }
+				color2={ 255 255 255 }
+
+				b_shish = {}
+				b_atirka = {}
+				b_vasiss = {}
+				b_knyazevka = {}
+				b_samsonovo = {}
+				b_tevriz = {}
+				b_vyatka = {}
+			}
+		}
+	}
+}
+
+e_idel_ural = {
+	color={ 97 56 55 }
+	color2={ 255 255 255 }
+
+	capital = 610 # Bulgar
+
+	k_volga_bulgaria = {
+		color={ 94 83 70 }
+		color2={ 255 255 255 }
+			
+		capital = 610 # Bulgar
+		
+		culture = bolghar
+		
+		tengri_pagan_reformed = 500 # Crusade target weight
+		finnish_pagan_reformed = 200
+		slavic_pagan_reformed = 100
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = altaic
+				}
+			}
+		}
+	
+		d_maris = {
+			color = { 150 132 110 }
+			
+			capital = 588 # Mari
+			
+			culture = mordvin
+
+			c_merya = { # Actually Mari
+				
+				color={ 234 174 13 }
+				color2={ 255 255 255 }
+			
+				b_yoshkarola = {
+				}
+				b_volzhsk = {
+				}
+				b_lopatino = {
+				}
+				b_tsikma = {
+				}
+				b_provoi = {
+				}
+				b_kilemary = {
+				}
+				b_mariturek = {
+				}
+				b_morki = {
+				}
+			}
+			c_hlynov = {
+				color={ 116 131 71 }
+				color2={ 255 255 255 }
+				
+				b_hlynov = {
+				}
+				b_egra = {
+				}
+				b_glazkar = {
+				}
+				b_izkar = {
+				}
+				b_kambarka = {
+				}
+				b_mozjga = {
+				}
+				b_wotka = {
+				}
+			}
+			c_galich_mersky = {
+				color={ 190 204 146 }
+				color2={ 255 255 255 }
+						
+				b_galichmersky = {
+				}
+				b_levkovo = {
+				}
+				b_gradmersky = {
+				}
+				b_buy = {
+				}
+				b_chistyebory = {
+				}
+				b_susanino = {
+				}
+				b_kadyy = {
+				}
+				b_isaevo = {
+				}
+			}
+		}
+		d_bulgar = {
+			color={ 110 90 67 }
+			color2={ 255 255 255 }
+			
+			capital = 610 # Bulgar
+		
+			c_bilyar = {
+				color={ 201 166 71 }
+				color2={ 255 255 255 }
+			
+				b_bilyar = {
+				}
+				b_tukhchin = {
+				}
+				b_cukataw = {
+				}
+				b_urussu = {
+				}
+				b_bogulma = {
+				}
+				b_bryakhimov = {
+				}
+				b_nurlat = {
+				}
+				b_dzhalil = {
+				}
+			}
+			c_bulgar = {
+				color={ 193 158 63 }
+				color2={ 255 255 255 }
+			
+				b_bulgar = {
+				}
+				b_suar = {
+				}
+				b_balimer = {
+				}
+				b_arbuga = {
+				}
+				b_tawille = {
+				}
+				b_tetyushi = {
+				}
+				b_koshki = {
+				}
+				b_iq = {
+				}
+			}
+			c_syrt = {
+				color={ 205 170 75 }
+				color2={ 255 255 255 }
+			
+				b_samara = {
+				}
+				b_kinel = {
+				}
+				b_syzran = {
+				}
+				b_tashia = {
+				}
+				b_sarbay = {
+				}
+				b_osinki = {
+				}
+				b_shungut = {
+				}
+			}
+			c_ashli = {
+				color={ 207 172 77 }
+				color2={ 255 255 255 }
+				
+				b_ashli = {
+				}
+				b_boro = {
+				}
+				b_durtojle = {
+				}
+				b_daulakan = {
+				}
+				b_blagovescen = {
+				}
+				b_tuimasy = {
+				}
+				b_janauyl = {
+				}
+				b_yamantaw = {
+				}
+			}
+			c_naberezhnye = {		#Changed Volga Bulgaria's province of Naberezhnye
+                color={ 173 128 43 }
+                color2={ 255 255 255 }
+                
+                b_naberezhnye = {
+                }
+				b_bugulma = {
+                }
+				b_aznakayevo = {
+                }
+				b_chatyr-tau = {
+                }
+				b_tuymazy = {
+                }
+				b_nizhnekamsk = {
+				}
+				b_almetyevsk = {
+                }
+            }
+		}
+		d_kazan = {
+			color = { 89 62 30 }
+			color2 = { 255 255 255 }
+			
+			capital = 611 # Kazan
+			
+			c_qazan = {
+				color={ 199 164 69 }
+				color2={ 255 255 255 }
+			
+				b_qazan = {
+				}
+				b_osa = {
+				}
+				b_chastye = {
+				}
+				b_usttuntor = {
+				}
+				b_krmayak = {
+				}
+				b_pal = {
+				}
+				b_uymuzh = {
+				}
+				b_belyaevka = {
+				}
+				b_pakli = {
+				}
+			}
+			c_khlynov = {
+				color={ 229 184 89 }
+				color2={ 255 255 255 }
+			
+				b_khlynov = {
+				}
+				b_uchel = {
+				}
+				b_kabachischi = {
+				}
+				b_arsk = {
+				}
+				b_kukmor = {
+				}
+				b_voljsk = {
+				}
+				b_dubyazy = {
+				}
+			}
+			c_kremenchuk = {
+				color={ 170 135 40 }
+				color2={ 255 255 255 }
+			
+				b_volgakremenchuk = {
+				}
+				b_sharan = {
+				}
+				b_mamadich = {
+				}
+				b_albay = {
+				}
+				b_katmysh = {
+				}
+				b_shumbut = {
+				}
+				b_otarka = {
+				}
+			}
+			c_alabuga = {
+				color={ 189 154 59 }
+				color2={ 255 255 255 }
+			
+				b_alabuga = {
+				}
+				b_sarapul = {
+				}
+				b_siva = {
+				}
+				b_bima = {
+				}
+				b_lyali = {
+				}
+				b_agryz = {
+				}
+				b_mozhga = {
+				}
+			}
+			c_vetluga = {
+				color={ 205 169 79 }
+				color2={ 255 255 255 }
+			
+				b_vetluga = {
+				}
+				b_vokhma = {
+				}
+				b_syava = {
+				}
+				b_ouren = {
+				}
+				b_chakhunia = {
+				}
+				b_charia = {
+				}
+				b_kajirv = {
+				}
+			}
+		}
+		d_cheremisa = {
+			color={ 99 102 49 }
+			color2={ 255 255 255 }
+			
+			capital = 591 # Cheremisa
+	
+			c_grassland_cheremisa = { # Kerzhenets
+				color={ 231 171 10 }
+				color2={ 255 255 255 }
+			
+				b_yarcalli = {
+				}
+				b_zay = {
+				}
+				b_cistay = {
+				}
+				b_aznaqay = {
+				}
+				b_bua = {
+				}
+				b_bawli = {
+				}
+				b_cherm = {
+				}
+			}
+			c_chuvash = {
+				color={ 237 177 16 }
+				color2={ 255 255 255 }
+			
+				b_vedasuvar = {
+				}
+				b_makaryevo = {
+				}
+				b_cheboksary = {
+				}
+				b_alatyr = {
+				}
+				b_kozlovka = {
+				}
+				b_sundyr = {
+				}
+				b_tsivilsk = {
+				}
+				b_yadrin = {
+				}
+			}
+			c_mountain_cheremisa = { # Cheremisa
+				color={ 240 180 19 }
+				color2={ 255 255 255 }
+			
+				b_simbirsk = {
+				}
+				b_kanadey = {
+				}
+				b_stanichnaya = {
+				}
+				b_melekess = {
+				}
+				b_butyrskaya = {
+				}
+				b_vybornaya = {
+				}
+				b_barysh = {
+				}
+			}
+		}
+		d_mordvins = {
+			color = { 15 64 33 }
+			color2={ 255 255 255 }
+	
+			capital = 579 # Mordva
+	
+			culture = mordvin
+
+			c_mordva = {
+				color={ 246 186 25 }
+				color2={ 255 255 255 }
+			
+				b_saransk = {
+				}
+				b_insar = {
+				}
+				b_temnikow = {
+				}
+				b_ardatovo = {
+				}
+				b_krasnoslobodsk = {
+				}
+				b_yalga = {
+				}
+				b_penza = {
+				}
+				b_yavas = {
+				}
+			}
+			c_burtasy = {
+				color={ 243 183 22 }
+				color2={ 255 255 255 }
+			
+				b_saratov = {
+				}
+				b_mechetnaya = {
+				}
+				b_pokrovsk = {
+				}
+				b_atkarsk = {
+				}
+				b_balakova = {
+				}
+				b_sosnovyostrov = {
+				}
+				b_golykaramysh = {
+				}
+				b_rtishchevo = {
+				}
+			}
+			c_khopyor = {
+				color={ 238 202 107 }
+				color2={ 255 255 255 }
+			
+				b_khopyorsk = {
+				}
+				b_borisoglebsk = {
+				}
+				b_tambov = {
+				} 
+				b_uryupin = {
+				}
+				b_balashov = {
+				}
+				b_kirsanov = {
+				}
+				b_ustmedveditskaya = {
+				}
+				b_uvarovo = {
+				}
+			}
+		}
+	}
+	k_perm = {
+		color={ 204 188 127 }
+		color2={ 255 255 255 }
+		
+		capital = 886 # Perm
+		
+		finnish_pagan_reformed = 500 # Crusade target weight
+		slavic_pagan_reformed = 100 # Crusade target weight
+		tengri_pagan_reformed = 50
+		
+		culture = komi
+		
+		# Creation/usurpation trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = finno_ugric
+				}
+			}
+		}
+	
+		d_perm = {
+			color={ 234 208 137 }
+			color2={ 255 255 255 }
+			
+			capital = 886 # Perm
+		
+			c_perm = {
+				color={ 237 211 140 }
+				color2={ 255 255 255 }
+
+				holy_site = finnish_pagan
+				holy_site = finnish_pagan_reformed
+				
+				b_perym = {
+				}
+				b_perm = {
+				}
+				b_gorodki = {
+				}
+				b_yagoshikha = {
+				}
+				b_lysva = {
+				}
+				b_cherdyn = {
+				}
+				b_chemuska = {
+				}
+				b_biser = {
+				}
+			}
+			c_komi = {
+				color={ 243 217 146 }
+				color2={ 255 255 255 }
+			
+				b_inta = {
+				}
+				b_vorkuta = {
+				}
+				b_ustkolom = {
+				}
+				b_usttsilma = {
+				}
+				b_aykino = {
+				}
+				b_vorgashor = {
+				}
+				b_kharp = {
+				}
+				b_khalmeryu = {
+				}
+			}
+			c_udmurts = {
+				color={ 237 200 130 }
+				color2={ 255 255 255 }
+			
+				b_udmurts = {
+				}
+				b_iz = {
+				}
+				b_votkinsk = {
+				}
+				b_karlutka = {
+				}
+				b_uva = {
+				}
+				b_sarkan = {
+				}
+				b_postol = {
+				}
+			}
+			c_kudymkar = {
+				color={ 250 237 166 }
+				color2={ 255 255 255 }
+			
+				b_kudymkar = {
+				}
+				b_kirs = {
+				}
+				b_gayny = {
+				}
+				b_omotninsk = {
+				}
+				b_lesnoy = {
+				}
+				b_seyva = {
+				}
+				b_yurla = {
+				}
+			}
+			c_kolva = {
+				color={ 230 210 160 }
+				color2={ 255 255 255 }
+
+				b_kolva = {}
+				b_seleya = {}
+				b_kumay = {}
+				b_ayya = {}
+				b_tulpan = {}
+				b_nizva = {}
+				b_mudyl = {}
+			}
+			c_tynea = {
+				color={ 195 190 140 }
+				color2={ 255 255 255 }
+
+				b_tynea = {}
+				b_yelovo = {}
+				b_akbash = {}
+				b_fedorki = {}
+				b_posha = {}
+				b_osa_tynea = {}
+				b_voyady = {}
+			}
+		}
+		d_ural = {
+			color={ 246 240 180 }
+			color2={ 255 255 255 }
+
+			capital = 889 # Ural
+
+			c_ural = {
+				color={ 246 220 149 }
+				color2={ 255 255 255 }
+			
+				b_ural = {
+				}
+				b_ustkatav = {
+				}
+				b_asha = {
+				}
+				b_chebarkul = {
+				}
+				b_kaslinsky = {
+				}
+				b_kyshtym = {
+				}
+				b_satka = {
+				}
+			}
+			c_thisageta = {
+				color={ 246 230 120 }
+				color2={ 255 255 255 }
+
+				b_thisageta = {}
+				b_chudova = {}
+				b_sarany = {}
+				b_vizhay = {}
+				b_pashiya = {}
+				b_skal_nyy = {}
+				b_promysla = {}
+			}
+			c_vishera = {
+				color={ 246 240 100 }
+				color2={ 255 255 255 }
+
+				b_vishera = {}
+				b_akchim = {}
+				b_yazva = {}
+				b_vels = {}
+				b_moyva = {}
+				b_lypiya = {}
+				b_niols = {}
+			}
+		}
+		d_votyaki = {
+			color={ 197 162 67 }
+			color2={ 255 255 255 }
+
+			capital = 612 # Votyaki
+
+			c_votyaki = {
+				color={ 197 162 67 }
+				color2={ 255 255 255 }
+			
+				b_achit = {
+				}
+				b_sarana = {
+				}
+				b_ufimskiy = {
+				}
+				b_bisert = {
+				}
+				b_arti = {
+				}
+				b_atig = {
+				}
+				b_shalya = {
+				}
+				b_shamary = {
+				}
+			}
+			c_keltma = {
+				color={ 190 155 60 }
+				color2={ 255 255 255 }
+
+				b_keltma = {}
+				b_nem = {}
+				b_smolyanka = {}
+				b_kerchomya = {}
+				b_yugyd_yag = {}
+				b_kadamskoye = {}
+				b_okos = {}
+			}
+		}
+		d_bashkirs = {
+			color={ 220 220 150 }
+			color2={ 255 255 255 }
+
+			capital = 615 # Bashkirs
+
+			c_bashkirs = {
+				color={ 209 174 79 }
+				color2={ 255 255 255 }
+			
+				b_ufa = {
+				}
+				b_belebey = {
+				}
+				b_chishmy = {
+				}
+				b_bajmaq = {
+				}
+				b_isembaj = {
+				}
+				b_beloret = {
+				}
+				b_meleus = {
+				}
+				b_sterlitamak = {
+				}
+			}
+			c_belaya = {
+				color={ 200 160 60 }
+				color2={ 255 255 255 }
+
+				b_belaya = {}
+				b_shipovo = {}
+				b_asy = {}
+				b_urunda = {}
+				b_slutka = {}
+				b_akberdino = {}
+				b_balazhi = {}
+			}
+		}
+		d_ustug = {
+			color={ 140 130 40 }
+			color2={ 255 255 255 }
+
+			capital = 402 # Veliky Ustug
+
+			c_veliky_ustug = {
+				color={ 125 140 80 }
+				color2={ 255 255 255 }
+				
+				b_velikyustug = {}
+				b_gleden = {}
+				b_krasavino = {}
+				b_luza = {}
+				b_pinyug = {}
+				b_podosinovets = {}
+				b_maromitsa = {}
+				b_oparino = {}
+			}
+			c_zyriane = {
+				color={ 195 160 65 }
+				color2={ 255 255 255 }
+			
+				b_kungur = {
+				}
+				b_kordon = {
+				}
+				b_suksun = {
+				}
+				b_kukushtan = {
+				}
+				b_gari = {
+				}
+				b_lek = {
+				}
+				b_ergach = {
+				}
+				b_posad = {
+				}
+			}
+			c_bolshaya = {
+				color={ 145 160 75 }
+				color2={ 255 255 255 }
+
+				b_bolshaya = {}
+				b_soyga = {}
+				b_urdoma = {}
+				b_sorovo = {}
+				b_litvino = {}
+				b_lena_bolshaya = {}
+				b_tyva = {}
+			}
+			c_syktyvkar = {
+				color={ 120 140 95 }
+				color2={ 255 255 255 }
+
+				b_syktyvkar = {}
+				b_sysola = {}
+				b_vyl_gort = {}
+				b_pazhga = {}
+				b_choy = {}
+				b_koyty = {}
+				b_zelenets = {}
+			}
+		}
+		d_komi = {
+			color={ 200 180 140 }
+			color2={ 255 255 255 }
+
+			capital = 1827 # Lyzha
+
+			c_lyzha = {
+				color={ 230 150 120 }
+				color2={ 255 255 255 }
+
+				b_lyzha = {}
+				b_akis = {}
+				b_ust_usa = {}
+				b_novikobzh = {}
+				b_mutnyy = {}
+				b_materik = {}
+				b_zakharvan = {}
+			}
+			c_kozhva = {
+				color={ 234 154 124 }
+				color2={ 255 255 255 }
+
+				b_kozhva = {}
+				b_berozovka = {}
+				b_iz_yayu = {}
+				b_puteyets = {}
+				b_byzovaya = {}
+				b_ozornyy = {}
+				b_chikshino = {}
+			}
+			c_izhma = {
+				color={ 238 158 128 }
+				color2={ 255 255 255 }
+
+				b_izhma = {}
+				b_diyur = {}
+				b_mokhcha = {}
+				b_sizyabsk = {}
+				b_shchell = {}
+				b_kartayol = {}
+				b_ust_izhma = {}
+			}
+			c_vel = {
+				color={ 242 162 132 }
+				color2={ 255 255 255 }
+
+				b_vel = {}
+				b_lemyu = {}
+				b_ayuva = {}
+				b_lemtybozh = {}
+				b_dutovo = {}
+				b_vuktyl_vel = {}
+				b_kyrta = {}
+			}
+			c_severnaya = {
+				color={ 246 166 136 }
+				color2={ 255 255 255 }
+
+				b_severnaya = {}
+				b_pokcha = {}
+				b_ilych = {}
+				b_sherlyaga = {}
+				b_abar = {}
+				b_ust_ilych = {}
+				b_sevkcha = {} # Fictitious 
+			}
+		}
+		d_zyriane = {
+			color={ 184 192 140 }
+			color2={ 255 255 255 }
+
+			capital = 1838 # Vychegda
+
+			c_vychegda = {
+				color={ 180 188 136 }
+				color2={ 255 255 255 }
+
+				b_vychegda = {}
+				b_vol_dino = {}
+				b_pomozdino = {}
+				b_pozheg = {}
+				b_anyb = {}
+				b_ruch = {}
+				b_kulom = {}
+			}
+			c_yolva = {
+				color={ 176 184 132 }
+				color2={ 255 255 255 }
+
+				b_vym = {}
+				b_vorykva = {}
+				b_edva = {}
+				b_chub = {}
+				b_yolva = {}
+				b_pizma = {}
+				b_koin = {}
+			}
+			c_sedyu = {
+				color={ 172 180 128 }
+				color2={ 255 255 255 }
+
+				b_sedyu = {}
+				b_ukhta_sedyu = {}
+				b_kedva = {}
+				b_ayuva_sedyu = {}
+				b_sebys = {}
+				b_akim = {}
+				b_yuger = {}
+			}
+		}
+	}
+	k_nenets = {
+		color={ 180 110 80 }
+		color2={ 255 255 255 }
+
+		capital = 1828 # Zavarot
+
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture = samoyed
+				}
+			}
+		}
+
+		d_bjarmia = {
+			color = { 95 50 20 }
+			color2={ 255 255 255 }
+			
+			capital = 396 # Bjarmia
+			
+			culture = komi
+			
+			c_north_dvina = {
+				color={ 106 121 61 }
+				color2={ 255 255 255 }
+				
+				b_kholmogory = {
+				}
+				b_nikolokorelski = {
+				}
+				b_solvychegodsk = {
+				}
+				b_novokholmogory = {
+				}
+				b_antonievosiysky = {
+				}
+				b_koryazhma = {
+				}
+				b_usolsk = {
+				}
+				b_archangelsk = {
+				}
+			}
+			c_bjarmia = {
+				color={ 109 124 64 }
+				color2={ 255 255 255 }
+				
+				b_okladnikowa = {}
+				b_okulovsky = {				}
+				b_kusnezowa = {}
+				b_kamenka_bj = {}
+				b_lampozhnya = {}
+				b_intsy = {}
+				b_kepino = {}
+			}
+			c_onega_peninsula = {
+				color={ 105 150 50 }
+				color2={ 255 255 255 }
+
+				b_onega_peninsula = {}
+				b_una = {}
+				b_yaren_ga = {}
+				b_zhizgin = {}
+				b_letnyaya = {}
+				b_letniy = {}
+				b_kyanda = {}
+			}
+
+			c_pinega = {
+				color={ 100 175 40 }
+				color2={ 255 255 255 }
+
+				b_kuloy = {}
+				b_soyana = {}
+				b_nemnyuga = {}
+				b_sotka = {}
+				b_kyolda = {}
+				b_vilan = {}
+				b_nizhneye = {}
+			}
+		}
+		d_samoyed = {
+			color={ 100 115 55 }
+			color2={ 255 255 255 }
+
+			capital = 397
+
+			c_samoyeds = {
+				color={ 100 115 55 }
+				color2={ 255 255 255 }
+				
+				b_verkhmgla = {
+				}
+				b_yazhma = {
+				}
+				b_sukhanikha = {
+				}
+				b_arkhipovo = {
+				}
+				b_vizhas = {
+				}
+				b_tarasova = {
+				}
+				b_kiya = {
+				}
+			}
+			c_kanin = {
+				color={ 130 150 100 }
+				color2={ 255 255 255 }
+
+				b_kanin = {}
+				b_kiya_kanin = {}
+				b_shoyna = {}
+				b_ozero = {}
+				b_chizha = {}
+				b_mesna = {}
+				b_chesha = {}
+			}
+			c_mezen = {
+				color={ 150 180 120 }
+				color2={ 255 255 255 }
+
+				b_mezen = {}
+				b_sula = {}
+				b_kyzma = {}
+				b_kimzha = {}
+				b_pyoza = {}
+				b_pyssa = {}
+				b_loptyuga = {}
+			}
+			c_ugra = {
+				color={ 119 134 74 }
+				color2={ 255 255 255 }
+				
+				b_ukhta = {
+				}
+				b_sosnogorsk = {
+				}
+				b_yarega = {
+				}
+				b_vodnyy = {
+				}
+				b_nizhodes = {
+				}
+				b_vuktyl = {
+				}
+				b_kadzherom = {
+				}
+				b_voyvozh = {
+				}
+			}			
+		}
+		d_kargopol = {
+			color={ 100 40 10 }
+			color2={ 255 255 255 }
+
+			capital = 1819 # Kargopol
+
+			c_kargopol = {
+				color={ 100 40 10 }
+				color2={ 255 255 255 }
+
+				b_kargopol = {}
+				b_kazakovo = {}
+				b_lacha = {}
+				b_pesok = {}
+				b_lyaga = {}
+				b_voloshka = {}
+				b_ivanovo_kargopol = {}
+			}
+			c_romny = {
+				color={ 128 143 83 }
+				color2={ 255 255 255 }
+				
+				b_ugol = {
+				}
+				b_vozhega = {
+				}
+				b_marinskaya = {
+				}
+				b_yuchka = {
+				}
+				b_bykovskaya = {
+				}
+				b_kholuy = {
+				}
+				b_vysokaya = {
+				}
+			}
+			c_trans-portage = {
+				color={ 103 118 58 }
+				color2={ 255 255 255 }
+				
+				finnish = "Ääninen"
+				lappish = "Ääninen"
+				ugricbaltic = "Ääninen"
+				komi = "Ääninen"
+				samoyed = "Ääninen"
+				mordvin = "Ääninen"
+				meshchera = "Ääninen"
+				
+				b_solovetsky = {
+				}
+				b_shenkursk = {
+				}
+				b_konosha = {
+				}
+				b_nyandoma = {
+				}
+				b_plesetsk = {
+				}
+				b_samoded = {
+				}
+				b_obozerskiy = {
+				}
+			}
+		}	
+		d_hlynov = { # Ugra
+			color={ 134 145 31 }
+			color2={ 255 255 255 }
+			
+			capital = 1826 # Ugra
+			
+			c_velsk = {
+				color={ 130 120 60 }
+				color2={ 255 255 255 }
+
+				b_velsk = {}
+				b_vaga_velsk = {}
+				b_vel_velsk = {}
+				b_kuloy_velsk = {}
+				b_shunema = {}
+				b_pezhma = {}
+				b_shilovskaya = {}
+			}
+			c_syrj = {
+				color={ 122 137 77 }
+				color2={ 255 255 255 }
+				b_pyras = {
+				}
+				b_yugydyag = {
+				}
+				b_mikun = {
+				}
+				b_emva = {
+				}
+				b_ezhva = {
+				}
+				b_sindor = {
+				}
+				b_zheshart = {
+				}
+			}
+			c_yezhuga = {
+				color={ 114 144 94 }
+				color2={ 255 255 255 }
+
+				b_pinega = {}
+				b_yula = {}
+				b_vyva = {}
+				b_yeyuga = {}
+				b_yezhuga = {}
+				b_shirokoye = {}
+				b_pilisa = {}
+			}
+			c_vashka = {
+				color={ 106 151 104 }
+				color2={ 255 255 255 }
+
+				b_vashka = {}
+				b_olema = {}
+				b_rezya = {}
+				b_keba = {}
+				b_vazhgort = {}
+				b_sel_za = {}
+				b_tsilenga = {}
+			}	
+		}
+		d_zavarot = {
+			color={ 210 150 120 }
+			color2={ 255 255 255 }
+
+			capital = 1828 # Zavarot
+
+			c_zavarot = {
+				color={ 207 147 117 }
+				color2={ 255 255 255 }
+
+				b_zavarot = {}
+				b_andeg = {}
+				b_kuya = {}
+				b_makarovo = {}
+				b_oksino = {}
+				b_pylemets = {}
+				b_khongurey = {}
+			}
+			c_kolguyev = {
+				color={ 204 144 114 }
+				color2={ 255 255 255 }
+
+				b_kolguyev = {}
+				b_velikaya = {}
+				b_konkina = {}
+				b_pervaya = {}
+				b_bugryanka = {}
+				b_gubistaya = {}
+				b_gusinaya = {}
+			}
+			c_soyma = {
+				color={ 201 141 111 }
+				color2={ 255 255 255 }
+
+				b_indiga = {}
+				b_soyma = {}
+				b_volonga = {}
+				b_korgovoye = {}
+				b_vyucheyskiy = {}
+				b_timan_ridge = {}
+				b_chosha = {}
+			}
+		}
+		d_pechora = {
+			color={ 180 110 80 }
+			color2={ 255 255 255 }
+
+			capital = 1832 # Tobysh
+
+			c_koshma = {
+				color={ 176 106 76 }
+				color2={ 255 255 255 }
+
+				b_koshma = {}
+				b_keshar = {} # Fictitious 
+				b_ourenter = {} # Fictitious
+				b_plurel = {} # Fictitious
+				b_listma = {} # Fictitious
+				b_ilner = {} # Fictitious
+				b_hurai = {} # Fictitious
+			}
+			c_tobysh = {
+				color={ 172 102 72 }
+				color2={ 255 255 255 }
+
+				b_tobysh = {}
+				b_sula_tobysh = {}
+				b_shchelino = {}
+				b_medvezhka = {}
+				b_kotkino = {}
+				b_labozhskoye = {}
+				b_velikovisochnoye = {}
+			}
+			c_tsilma = {
+				color={ 168 98 68 }
+				color2={ 255 255 255 }
+
+				b_tsilma = {}
+				b_byk = {}
+				b_uyeg = {}
+				b_mutnaya = {}
+				b_rudyanka = {}
+				b_nonbur = {}
+				b_myla = {}
+			}
+		}
+	}
+}
+
+e_turkestan = {
+	color={ 232 231 195 }
+	color2={ 255 255 255 }
+
+	culture = turkish
+
+	capital = 626 # Khiva
+
+	turkish = "Turkestan"	
+	pecheneg = "Turkestan"
+	cuman = "Turkestan"
+	khazar = "Turkestan"
+	bolghar = "Turkestan"
+	avar = "Turkestan"
+
+	k_turkestan = {
+		color={ 204 150 21 }
+		color2={ 255 255 255 }
+		
+		capital = 1794 # Syr Darya
+		
+		culture = turkish
+		
+		tengri_pagan_reformed = 500
+		zoroastrian_group = 150 # Crusade target weight
+		
+		d_turkestan = {
+			color={ 224 170 24 }
+			color2={ 255 255 255 }
+			
+			capital = 622 # Turkestan
+			
+			culture = turkish
+			
+			turkish = "Oghuz"
+			
+			c_aral = {
+				color={ 227 173 27 }
+				color2={ 255 255 255 }
+			
+				b_kassarma = {
+				}
+				b_dawletgirei = {
+				}
+				b_kuljandi = {
+				}
+				b_kaszkarata = {
+				}
+				b_aszczeatrik = {
+				}
+				b_kosbulak = {
+				}
+				b_sokyrbulak = {
+				}
+				b_karakul = {
+				}
+			}
+			c_turkestan = {
+				color={ 236 182 36 }
+				color2={ 255 255 255 }
+			
+				b_akdzulpas = {
+				}
+				b_sapak = {
+				}
+				b_aralkum = {
+				}
+				b_kosskul = {
+				}
+				b_akespe = {
+				}
+				b_saksaulskiy = {
+				}
+				b_akshelek = {
+				}
+			}
+		}
+		d_usturt = {
+			color={ 180 120 40 }
+			color2={ 255 255 255 }
+
+			capital = 625 # Usturt
+
+			c_usturt = {
+				color={ 238 184 38 }
+				color2={ 255 255 255 }
+			
+				b_bailjar = {
+				}
+				b_barsakelmos = {
+				}
+				b_bussaga = {
+				}
+				b_sengirkum = {
+				}
+				b_sumbe = {
+				}
+				b_akkuduk = {
+				}
+				b_aksu = {
+				}
+				b_karamola = {
+				}
+			}
+			c_mangyshlak = {
+				color={ 233 179 33 }
+				color2={ 255 255 255 }
+			
+				b_aqtaw = {
+				}
+				b_kzyluzen = {
+				}
+				b_amankyzylit = {
+				}
+				b_uzen = {
+				}
+				b_araldy = {
+				}
+				b_ashchimuryn = {
+				}
+				b_tigen = {
+				}
+				b_sayutes = {
+				}
+			}
+			c_buzachi = {
+				color={ 140 150 38 }
+				color2={ 255 255 255 }
+
+				b_buzachi = {}
+				b_durneva = {}
+				b_tyuleniy = {}
+				b_karakishu = {}
+				b_kyzan_kul = {}
+				b_kara_kichu_tuz = {}
+				b_ag_urpa = {}
+			}
+			c_kara_bogaz = {
+				color={ 135 145 35 }
+				color2={ 255 255 255 }
+
+				b_kara_bogaz = {}
+				b_bekdash = {}
+				b_geksay = {}
+				b_kadzhan = {}
+				b_amandor = {}
+				b_karadzhari = {}
+				b_severvykh = {}
+			}
+			c_kusbulak = {
+				color={ 130 140 30 }
+				color2={ 255 255 255 }
+
+				b_kusbulak = {}
+				b_jasliq = {}
+				b_aidabul = {}
+				b_gusken = {}
+				b_sellizure = {}
+				b_kyushe = {}
+				b_kyzyl_bulak = {}
+			}
+		}
+		d_syr_darya = {
+			color= { 145 115 40 }
+			color2={ 255 255 255 }
+			
+			capital = 1794 # Syr Darya
+			
+			culture = turkish
+			
+			c_yangikent = {
+				color={ 189 214 146 }
+				color2={ 255 255 255 }
+				
+				b_djend = {}
+				b_yangikent = {}
+				b_itchankila = {}
+				b_xazorasp = {}
+				b_bogot = {}
+				b_xonqa = {}
+				b_qorovul = {}
+				b_yangiariq = {}
+				b_shovot = {}
+			}
+			c_syr_darya = {
+				color={ 236 178 22 }
+				color2={ 255 255 255 }
+
+				holy_site = tengri_pagan
+				holy_site = tengri_pagan_reformed
+				
+				b_syganak = {
+				}
+				b_akmechet = {
+				}
+				b_kyzylorda = {
+				}
+				b_kazaly = {
+				}
+				b_terenuzyak = {
+				}
+				b_dzhanadzhol = {
+				}
+				b_sarytogay = {
+				}
+				b_zhalagash = {
+				}
+			}
+			c_otrar = {
+				color= { 165 155 55 }
+				color2={ 255 255 255 }
+			
+				b_otrar = {}
+				b_shaulder = {}
+				b_shoshkakoi = {}
+				b_birlik = {}
+				b_chernak = {}
+				b_kentau = {}
+				b_turtkul = {}
+			}
+			c_chach = {
+				color= { 205 155 55 }
+				color2={ 255 255 255 }
+				
+				b_chach = {}
+				b_navekat = {}
+				b_sayram = {}
+				b_isbijab = {}
+				b_shymkent = {}
+				b_pskent = {}
+				b_turbat = {}
+			}
+		}
+		d_emba = {
+			color={ 200 140 5 }
+			color2={ 255 255 255 }
+
+			capital = 1793 # Emba Steppes
+
+			c_emba = {
+				color={ 210 156 10 }
+				color2={ 255 255 255 }
+
+				b_emba = {}
+				b_akbulak = {}
+				b_akkube = {
+				}
+				b_bakachi = {
+				}
+				b_azgyl = {}
+				b_besbay = {}
+				b_mukur = {}
+			}
+
+			c_kangly = {
+				color={ 230 176 30 }
+				color2={ 255 255 255 }
+			
+				b_kangly = {
+				}
+				b_koshkar = {
+				}
+				b_makat = {
+				}
+				b_qulsary = {
+				}
+				b_kizay = {
+				}
+				b_tengiz_kangly = {}
+				b_karasha = {}
+			}	
+		}
+	}
+	k_zhetysu = {
+		color={ 200 130 70 }
+		color2={ 255 255 255 }
+
+		capital = 1797 # Almaty
+
+		d_chuy = {
+			color={ 165 155 55 }
+			color2={ 255 255 255 }
+
+			capital = 1424 # Chuy
+
+			c_chuy = {
+				color= { 165 155 55 }
+				color2={ 255 255 255 }
+
+				mongol = "Gobalik"
+			
+				b_balasagun = {
+					mongol = Gobalik
+				}
+				b_suyab = {}
+				b_bishkek = {}
+				b_almatu = {}
+				b_tokmok = {}
+				b_korday = {}
+				b_keru = {}
+			}
+			c_talas = {
+				color={ 145 165 50 }
+				color2={ 255 255 255 }
+
+				b_taraz = {}
+				b_shelji = {}
+				b_merke = {}
+				b_asa = {}
+				b_akchulak = {}
+				b_sheker = {}
+				b_myrzatay = {}
+			}
+			c_barskhan = {
+				color={ 140 170 40 }
+				color2={ 255 255 255 }
+
+				b_barskhan = {}
+				b_kyzyl_suu = {}
+				b_kyzyl_tuu = {}
+				b_tyup = {}
+				b_lipenka = {}
+				b_ak_terek = {}
+				b_tosor = {}
+			}
+		}
+		d_zhetysu = {
+			color= { 175 165 60 }
+			color2={ 255 255 255 }
+			
+			capital = 1797 # Almaty
+			
+			culture = turkish
+			
+			c_zhetysu = {
+				color= { 180 125 75 }
+				color2={ 255 255 255 }
+
+				b_karatal = {}
+				b_sarkand = {}
+				b_taldykorgan = {}
+				b_koksu = {}
+				b_matay = {}
+				b_lepsy = {}
+				b_kuraksu = {}
+			}
+			c_almaty = {
+				color={ 180 145 35 }
+				color2={ 255 255 255 }
+
+				b_almaty_saryesik = {}
+				b_kapchagai = {}
+				b_kargal = {}
+				b_saryesik = {}
+				b_karaoy_almaty = {}
+				b_koktal_almaty = {}
+				b_akzhar_almaty = {}
+			}
+			c_karluk = {
+				color= { 180 165 15 }
+				color2={ 255 255 255 }
+
+				b_nushibi = {}
+				b_ulug_ok = {}
+				b_alishi = {}
+				b_sakla_baga = {}
+				b_saryshaghan = {}
+				b_zhaylaukol = {}
+				b_shagkol = {} #Fictional, for prosperity
+			}
+		}
+		d_ili = {
+			color={ 145 165 40 }
+			color2={ 255 255 255 }
+
+			capital = 1425 # Ili
+
+			c_ili = {
+				color= { 205 155 55 }
+				color2={ 255 255 255 }
+			
+				b_ilibaliq = {}
+				b_kulja = {}
+				b_koktal = {}
+				b_tekes = {}
+				b_kax = {}
+				b_kunes = {}
+				b_sharyn = {}
+			}
+			c_almaliq = {
+				color={ 195 165 45 }
+				color2={ 255 255 255 }
+
+				b_almaliq = {}
+				b_xinyuan = {}
+				b_nilka = {}
+				b_zeketaizhen = {}
+				b_taledzhen = {}
+				b_nalatizhen = {}
+				b_kashi = {}
+			}
+			c_qayaliq = {
+				color={ 185 175 35 }
+				color2={ 255 255 255 }
+
+				b_qayaliq = {}
+				b_shubar = {}
+				b_shagan = {}
+				b_sayram_qayaliq = {}
+				b_sadyr = {}
+				b_wenquan_qayaliq = {}
+				b_horgos = {}
+			}
+		}
+	}
+	k_khotan = {
+		color={ 255 228 109 }
+		
+		capital = 1440 # Khotan
+		
+		turkish = "Uyghurstan"
+		uyghur = "Altishahr"
+		tocharian = "Ytarimypoy"
+		han = "Xiyu"
+		saka = "Hvamna"
+		
+		d_kashgar = {
+			color={ 216 195 104 }
+			
+			capital = 1439 # Kashgar
+			
+			tocharian = "Kasake"
+			han = "Shule"
+			bodpa = "Su-lig"
+			
+			c_kashgar = {
+			
+				color={ 200 170 0 }
+				
+				tocharian = "Kasake"
+				han = "Shule"
+				bodpa = "Su-lig"
+
+				b_kashgar = {
+					tocharian = "Kasake"
+					han = "Shule"
+					bodpa = "Su-lig"
+				}
+				b_xiuxun = {
+				}
+				b_weitou = {
+				}
+				b_akto = {
+				}
+				b_ulugqat = {
+				}
+				b_bukou = { # Fictional, for prosperity
+				}
+				b_tsofa = { # Fictional, for prosperity
+				}
+			}	
+			
+			c_aksu = {
+				color={ 144 110 0 }
+				
+				tocharian = "Bharuka"
+				
+				b_aksu_mongolia = {
+					tocharian = "Bharuka"
+				}
+				b_tumshuk = {
+					uyghur = "Tumxuk"
+				}
+				b_wensu = {
+					uyghur = "Onsu"
+					mongol = "Onsu"
+				}
+				b_awat = {
+				}
+				b_kelpin = {
+				}
+				b_aral = {
+				}
+				b_laofutian = { # Fictional, for prosperity
+				}
+			}
+			c_uchturpan = {
+				color={ 144 110 20 }
+
+				b_uqturpan = {
+				}
+				b_yezheguan = {
+				}
+				b_jizhuoguan = {
+				}
+				b_gaochetian = { # Fictional, for prosperity
+				}
+				b_tunglingching = { # Fictional, for prosperity
+				}
+				b_yuyu = { # Fictional, for prosperity
+				}
+				b_zhaojiazui = { # Fictional, for prosperity
+				}
+			}
+			c_artux = {
+				color={ 144 110 40 }
+
+				b_atush = {
+				}
+				b_poskam = {
+				}
+				b_dalihe = { # Fictional, for prosperity
+				}
+				b_yanzi = { # Fictional, for prosperity
+				}
+				b_hugou = { # Fictional, for prosperity
+				}
+				b_changjiang = { # Fictional, for prosperity
+				}
+				b_cuocaogou = { # Fictional, for prosperity
+				}
+			}
+			c_yopurga = {
+				color={ 144 110 60 }
+
+				b_yopurga = {
+				}
+				b_jiashi = {
+				}
+				b_biancheng = {
+				}
+				b_beijiang = { # Fictional, for prosperity
+				}
+				b_fanjiaxiaozhang = { # Fictional, for prosperity
+				}
+				b_houshan = { # Fictional, for prosperity
+				}
+				b_palichuang = { # Fictional, for prosperity
+				}
+			}
+		}
+		d_kumul = {
+			color={ 235 208 59 }
+			
+			capital = 1450 # Kumul
+			
+			tocharian = "Krorän"
+			han = "Xizhou"
+			
+			c_kumul = {
+				color={ 159 135 0 }
+				
+				mongol = "Qamil"
+				tocharian = "Kunlyu"
+				han = "Yizhou"
+				
+				b_kumul = {
+					tocharian = "Kunlyu"
+					han = "Yizhou"
+				}
+				b_yiwu = {
+					uyghur = "Aratürük"
+				}
+				b_dahe = {
+				}
+				b_piqan = {
+				}
+				b_yanghai = {
+				}
+				b_toyuq = {
+				}
+				b_nanhu_tarim = {
+				}
+			}
+			c_charkliq = {
+				color={ 190 190 20 }
+				
+				tocharian = "Narubho"
+				han = "Ruoqiang"
+
+				b_charkliq = {
+					tocharian = "Narubho"
+					han = "Ruoqiang"
+				}
+				b_miran = {
+				}
+				b_kargan = {
+				}
+				b_lop = {
+					tocharian = "Lyam"
+				}
+				b_merdek = {
+				}
+				b_zhehor = { # Fictional, for prosperity
+				}
+				b_maojiaxiang = { # Fictional, for prosperity
+				}
+			}
+			
+			c_loulan = {
+				color={ 190 180 25 }
+				
+				tocharian = "Krorän"
+				uyghur = "Qroran"
+				
+				b_loulan = {
+				}
+				b_kroran = {
+				}
+				b_kara_koshun = {
+				}
+				b_shanshan = {
+				}
+				b_yingpan = {
+				}
+				b_huxinba = { # Fictional, for prosperity
+				}
+				b_donghuamen = { # Fictional, for prosperity
+				}
+			}
+			
+			c_yuni = {
+				color={ 190 170 30 }
+
+				b_yuni = {
+				}
+				b_ruoqiang = {
+				}
+				b_shikeng = { # Fictional, for prosperity
+				}
+				b_beilanzhuang = { # Fictional, for prosperity
+				}
+				b_xiafang = { # Fictional, for prosperity
+				}
+				b_pailouxia = { # Fictional, for prosperity
+				}
+				b_huachuantsun = { # Fictional, for prosperity
+				}
+			}
+			
+			c_lopnor = {
+				color={ 190 160 35 }
+
+				b_lopnor = {
+					tocharian = "Salyilyam"
+				}
+				b_qitun = {
+				}
+				b_dingjiazhai = { # Fictional, for prosperity
+				}
+				b_nantung = { # Fictional, for prosperity
+				}
+				b_nanhedong = { # Fictional, for prosperity
+				}
+				b_beidijiadun = { # Fictional, for prosperity
+				}
+				b_bibian = { # Fictional, for prosperity
+				}
+			}
+			
+			c_kumtag = {
+				color={ 190 150 40 }
+
+				b_kumtag = {
+				}
+				b_chiting = {
+				}
+				b_luohu = {
+				}
+				b_xiaoguoyu = { # Fictional, for prosperity
+				}
+				b_xiaojian = { # Fictional, for prosperity
+				}
+				b_dajin = { # Fictional, for prosperity
+				}
+				b_guojia = { # Fictional, for prosperity
+				}
+			}
+		}
+		d_khotan = {
+			color={ 216 184 43 }
+			
+			capital = 1440 # Khotan
+			
+			uyghur = "Hotan"
+			han = "Yutian"
+			saka = "Hvamna"
+			
+			c_khotan = {
+			
+				color={ 190 120 0 }
+
+				holy_site = bon
+				holy_site = bon_reformed
+				holy_site = taoist
+				
+				uyghur = "Hotan"
+				han = "Yutian"
+				saka = "Hvamna"
+
+				b_khotan = {
+					uyghur = "Hotan"
+					han = "Yutian"
+				}
+				b_jingjue = {
+				}
+				b_jiandu = {
+				}
+				b_qira = {
+				}
+				b_weiguan = {
+				}
+				b_bojiayi = {
+				}
+				b_pishan = {
+				}
+			}
+			c_cherchen = {
+				color={ 145 102 8 }
+				
+				uyghur = "Qarqan"
+				tocharian = "Jemotwona"
+				sogdian = "Calmandana"
+				han = "Qiemo"
+
+				b_cherchen = {
+					uyghur = "Qarqan"
+					tocharian = "Jemotwona"
+					sogdian = "Calmandana"
+					han = "Qiemo"
+				}
+				b_calmandana = {
+				}
+				b_mocheng = {
+				}
+				b_zuomo = {
+				}
+				b_yuling = {
+				}
+				b_yeyik = {
+				}
+				b_sutang = {
+				}
+			}
+			c_yarkand = {
+				color={ 190 155 0 }
+				
+				tocharian = "Yarkam"
+				han = "Suoju"
+				saka = "Suoju"
+
+				b_yarkand = {
+					tocharian = "Yarkam"
+					han = "Suoju"
+				}
+				b_yecheng = {
+					uyghur = "Chokkuka"
+				}
+				b_mazar = {
+				}
+				b_guma = {
+				}
+				b_gujiazhai = { # Fictional, for prosperity
+				}
+				b_kuqa = { # Fictional, for prosperity
+				}
+				b_baizhangzi = { # Fictional, for prosperity
+				}
+			}
+			c_cadota = {
+				color={ 180 144 0 }
+
+				b_niya = {
+					tocharian = "Cadota"
+				}
+				b_endere = {
+				}
+				b_wogou = { # Fictional, for prosperity
+				}
+				b_xinjiancun = { # Fictional, for prosperity
+				}
+				b_huangyangshan = { # Fictional, for prosperity
+				}
+				b_zengwujing = { # Fictional, for prosperity
+				}
+				b_guqintang = { # Fictional, for prosperity
+				}
+			}
+			c_keriya = {
+				color={ 170 133 0 }
+
+				b_keriya = {
+					han = "Yumi"
+				}
+				b_dandan_uilik = {
+				}
+				b_pimo = {
+				}
+				b_chejiang = { # Fictional, for prosperity
+				}
+				b_gaoyuanqiang = { # Fictional, for prosperity
+				}
+				b_zhoucun = { # Fictional, for prosperity
+				}
+				b_yiyi = { # Fictional, for prosperity
+				}
+			}
+			c_karghalik = {
+				color={ 160 122 0 }
+
+				b_karghalik = {
+				}
+				b_qiepantuo = {
+				}
+				b_chishi = { # Fictional, for prosperity
+				}
+				b_zhongqing = { # Fictional, for prosperity
+				}
+				b_xiachen = { # Fictional, for prosperity
+				}
+				b_dingkengkou = { # Fictional, for prosperity
+				}
+				b_zhenzigou = { # Fictional, for prosperity
+				}
+			}
+		}
+		d_karashar = {
+			color={ 170 130 0 }
+			
+			capital = 1443 # Karashar
+			
+			uyghur = "Qocho"
+			tocharian = "Arsi-Kuci"
+			sogdian = "Agnidesa"
+			turkish = "Yanghi"
+			han = "Yanqi"
+			
+			c_karashar = {
+				color={ 170 130 0 }
+				
+				tocharian = "Arsi"
+				sogdian = "Agnidesa"
+				turkish = "Yanghi"
+				han = "Yanqi"
+
+				b_karashar = {
+					tocharian = "Arsi"
+					sogdian = "Agnidesa"
+					turkish = "Yanghi"
+					han = "Yanqi"
+				}
+				b_korla = {
+					han = "Kuerle"
+				}
+				b_shanguo = {
+					uyghur = "Kuruk"
+				}
+				b_weixu = {
+					uyghur = "Hoxud"
+					tocharian = "Oresu"
+				}
+				b_weili = {
+				}
+				b_tiemenguan = {
+				}
+				b_paohsinchi = { # Fictional, for prosperity
+				}
+			}
+			c_kucha = {
+				color={ 135 102 0 }
+				
+				tocharian = "Kuci"
+				sogdian = "Kucina"
+				han = "Qiuci"
+				
+				b_kucha = {
+					tocharian = "Kuci"
+					sogdian = "Kucina"
+					han = "Qiuci"
+				}
+				b_xayar = {
+				}
+				b_bay = {
+				}
+				b_kizil = {
+					tocharian = "Kesil"
+				}
+				b_subashi = {
+					tocharian = "Muskriye"
+				}
+				b_kumtura = {
+				}
+				b_zhangjiawan = { # Fictional, for prosperity
+				}
+			}
+			c_kara_khoja = {
+				color={ 179 160 0 }
+				
+				uyghur = "Qocho"
+				tocharian = "Turtam"
+				han = "Gaochang"
+	
+				b_kara_khoja = {
+					tocharian = "Koto"
+					han = "Gaochang"
+				}
+				b_turfan = {
+					tocharian = "Turtam"
+				}
+				b_jiaohe = {
+					uyghur = "Yarkhoto"
+					tocharian = "Gauhar"
+				}
+				b_huhu = {
+				}
+				b_shangwangguo = {
+				}
+				b_bezeklik = {
+					tocharian = "Biseklis"
+				}
+				b_astana = {
+				}
+			}
+			c_luntai = {
+				color={ 199 177 0 }
+				
+				uyghur = "Ürümqi"
+				mongol = "Ürümqi"
+				tocharian = "Urabo"
+				
+				b_luntai = {
+					uyghur = "Ürümqi"
+					mongol = "Ürümqi"
+					tocharian = "Urabo"
+				}
+				b_fukang = {
+				}
+				b_danhuan = {
+				}
+				b_wutanzili = {
+				}
+				b_qiemi = {
+				}
+				b_manas = {
+				}
+				b_changji = {
+					uyghur = "Sanji"
+				}
+			}
+			c_mingoi = {
+				color={ 188 166 0 }
+				
+				b_mingoi = {
+				}
+				b_qigexing = {
+					uyghur = "Xorqu"
+					tocharian = "Kertik"
+				}
+				b_shorshuq = {
+				}
+				b_shikshin = {
+				}
+				b_yushe = { # Fictional, for prosperity
+				}
+				b_pingpo = { # Fictional, for prosperity
+				}
+				b_taibaiya = { # Fictional, for prosperity
+				}
+			}
+			c_kubera = {
+				color={ 177 155 0 }
+				
+				b_kubera = {
+				}
+				b_axiyan = {
+				}
+				b_toqsu = {
+				}
+				b_gexianmiao = { # Fictional, for prosperity
+				}
+				b_yangtaoshan = { # Fictional, for prosperity
+				}
+				b_shitun = { # Fictional, for prosperity
+				}
+				b_dazhou_fenchang = { # Fictional, for prosperity
+				}
+			}
+		}
+	}
+	k_khiva = {
+		color = { 204 217 184 }
+		color2={ 255 255 255 }
+		
+		capital	= 626 # Khiva
+		culture = persian
+		
+		tengri_pagan_reformed = 50
+		zoroastrian_group = 2000 # Crusade target weight
+		zun_pagan_reformed = 100 # Crusade target weight
+		
+		sogdian = "Sogdiana"
+		saka = "Margiana"
+		
+		d_khiva = {
+			color={ 185 210 142 }
+			color2={ 255 255 255 }
+			
+			capital = 626 # Khiva
+			
+			c_khiva = {
+				color={ 167 245 32 }
+				color2={ 255 255 255 }
+				
+				b_darvaza = {
+				}
+				b_kath = {
+				}
+				b_kuskupir = {
+				}
+				b_tahta = {
+				}
+				b_kizketken = {
+				}
+				b_atajab = {
+				}
+				b_sumanay = {
+				}
+				b_khiva = {
+				}
+			}
+			
+			c_urgench = {
+				color={ 147 215 30 }
+				color2={ 255 255 255 }
+				
+				b_madminiya = {
+				}
+				b_kungrat = {
+				}
+				b_kizil_agir = {
+				}
+				b_ulkun = {
+				}
+				b_kanlykul = {
+				}
+				b_achamayli = {}
+				b_kunkhodzha = {}
+			}
+
+			c_gurganj = {
+				color={ 127 210 15 }
+				color2={ 255 255 255 }
+
+				b_urgench = {}
+				b_kyrkmolla = {}
+				b_nukus = {
+				}
+				b_khodjali = {
+				}
+				b_karaoy = {}
+				b_karadepe = {}
+				b_uzynsuv = {}
+			}
+			
+			c_dashhowuz = {
+				color={ 193 217 150 }
+				color2={ 255 255 255 }
+				
+				b_dashhowuz = {
+				}
+				b_kunyaurgench = {
+				}
+				b_tagta = {
+				}
+				b_akdepe = {
+				}
+				b_gubadag = {
+				}
+				b_boldumsaz = {
+				}
+				b_yylanly = {
+				}
+				b_gorogly = {
+				}
+			}
+		}
+		d_samarkand = {
+			color={ 155 170 132 }
+			color2={ 255 255 255 }
+			
+			capital = 903 # Samarkand
+			
+			c_samarkand = {
+				color={ 157 201 100 }
+				color2={ 255 255 255 }
+				
+				holy_site = manichean # Patriarch of the east			
+				
+				b_afrasiyab = {
+				}
+				b_samarkand = {
+				}
+				b_khokand = {
+				}
+				b_urgut = {
+				}
+				b_koshrabot = {
+				}
+				b_ishtikhon = {
+				}
+				b_ziadin = {
+				}
+				b_laish = {
+				}
+			}
+			c_oshrusana = {
+				color={ 112 217 30 }
+				color2={ 255 255 255 }
+				
+				b_banjikat = {
+				}
+				b_khujand = {
+				}
+				b_oshrusana = {
+				}
+				b_isfana = {
+				}
+				b_kurkat = {
+				}
+				b_nau = {
+				}
+				b_bekobod = {
+				}
+			}
+			c_bukhara = {
+				color={ 169 247 34 }
+				color2={ 255 255 255 }
+				
+				b_gizhduvan = {
+				}
+				b_bukhara = {
+				}
+				b_vabkent = {
+				}
+				b_karkuh = {
+				}
+				b_chardjul = {
+				}
+				b_kogon = {
+				}
+				b_ayrybaba = {
+				}
+			}
+			c_nakhshab = {
+				color={ 112 217 30 }
+				color2={ 255 255 255 }
+				
+				b_nakhsab = {}
+				b_paykand = {}
+				b_firabr = {}
+				b_ukrach = {} # Fictional, for prosperity
+				b_bozariq = {} # Fictional, for prosperity
+				b_qizilcha = {} # Fictional, for prosperity
+				b_mirzomomin = {} # Fictional, for prosperity
+			}
+		}
+		
+		d_khuttal = {
+			color={ 175 160 90 }
+			color2={ 255 255 255 }
+			
+			capital = 1188 # Khuttal
+			
+			c_khuttal = {
+				color={ 175 150 45 }
+				color2={ 255 255 255 }
+				
+				b_kulob = {}
+				b_halaward = {}
+				b_washjird = {}
+				b_vakash = {}
+				b_qobadhiyan = {}
+				b_rasht = {}
+				b_munk = {}
+				#b_munjan = {}
+				#b_jauz_gun = {}
+				#b_taloqan = {}
+				#b_jurm = {}
+				#b_dushanbe = {}
+			}
+			c_vakhan = {
+				color={ 175 95 62 }
+				color2={ 255 255 255 }
+				
+				b_vakhan = {}
+				b_ishkashim = {}
+				b_daritubat = {}
+				b_sughnan = {}
+				b_khandud = {}
+				b_khorog = {}
+				b_sast = {}
+			}
+			c_chaghaniyan = {
+				color={ 175 110 50 }
+				color2={ 255 255 255 }
+				
+				b_chaghaniyan = {}
+				b_termez ={}
+				b_kalif = {}
+				b_shuman = {}
+				b_di-l-kifl = {}
+				b_di-l-qarnain = {}
+				b_sapoltepa = {}
+			}
+			c_badakhshan = {
+				color={ 175 130 75 }
+				color2={ 255 255 255 }
+				
+				b_badakhshan = {}
+				b_rustaq = {}
+				b_jerm = {}
+				b_kerran = {}
+				b_panj = {}
+				b_kamar = {}
+				b_jarf = {}
+			}
+		}
+		
+		d_ferghana = {
+			color={ 90 171 30 }
+			color2={ 255 255 255 }
+			
+			capital = 1423 # Fergana
+			
+			c_fergana = {
+				color={ 90 155 25 }
+				color2={ 255 255 255 }
+				
+				b_uzkand = {} # Aka Mavarannahr. Today Uzgen.
+				b_andijan = {}
+				b_osh = {}
+				b_marginan = {}
+				b_aval = {}
+				b_nadaq = {}
+				b_rishton = {}
+			}
+			c_khojand = {
+				color={ 90 190 45 }
+				color2={ 255 255 255 }
+				
+				b_khojand = {}
+				b_asht = {}
+				b_sokh = {}
+				b_kendibadam = {}
+				b_tunket = {}
+				b_ilaq = {}
+				b_khavakend = {}
+			}
+			c_khaylam = {
+				color={ 90 205 20 }
+				color2={ 255 255 255 }
+				
+				b_khaylam = {}
+				b_akhsikath = {}
+				b_kasan = {}
+				b_wankath = {}
+				b_miyanrudhan = {}
+				b_ardalankath = {}
+				b_najm = {}
+			}
+		}
+	}
+}
+
+e_persia = {
+	color={ 131 204 20 }
+	color2={ 255 255 255 }
+	
+	capital = 646 #	Esfahan
+	
+	culture = persian
+
+	roman = "Parthicum"
+	
+	zun_pagan_reformed = 500 # Crusade target weight
+	
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = iranian
+			}
+		}
+	}
+	
+	short_name = yes
+
+	k_persia = {
+		color={ 151 224 24 }
+		color2={ 255 255 255 }
+		
+		capital = 646 #	Esfahan
+		
+		culture = persian
+
+		roman = "Parthicum"
+		
+		muslim = 400 # Crusade target weight
+		zoroastrian_group = 4000 # Crusade target weight
+		zun_pagan_reformed = 100 # Crusade target weight
+		
+		d_mafaza = {
+			color={ 142 176 84 }
+			color2={ 255 255 255 }
+			
+			capital = 636 # Mafaza/Lut
+			
+			c_yazd = {
+				color={ 148 182 90 }
+				color2={ 255 255 255 }
+				
+				b_meybod = {
+				}
+				b_yazd = {
+				}
+				b_chak_chak = {
+				}
+				b_ardakan = {
+				}
+				b_zarch = {
+				}
+				b_taft = {
+				}
+				b_nir = {
+				}
+				b_dar_anjir = {
+				}
+			}
+			c_lut = { # Mafaza
+				color={ 119 170 29 }
+				color2={ 255 255 255 }
+				
+				b_tabas = {
+				}
+				b_dayhouk = {
+				}
+				b_mazanabad = {
+				}
+				b_aspak = {
+				}
+				b_kalateh = {
+				}
+				b_amanieh = {
+				}
+				b_bibaz = {
+				}
+				b_esfandiar = {
+				}
+			}
+		}
+		d_kerman = {
+			color={ 98 118 63 }
+			color2={ 255 255 255 }
+			
+			capital = 639 # Kerman
+			
+			c_kerman = {
+				color={ 110 130 75 }
+				color2={ 255 255 255 }
+				
+				b_rayen = {
+				} 
+				b_behdesir = {
+				}
+				b_kerman = {
+				}
+				b_maymand = {
+				}
+				b_nough = {
+				}
+				b_bardsir = {
+				}
+				b_zarand = {
+				}
+				b_ghaleganj = {
+				}
+			}
+			c_bam = {
+				color={ 144 177 88 }
+				color2={ 255 255 255 }
+				
+				b_bampur = {
+				}
+				b_bal_chah = {
+				}
+				b_kaj = {
+				}
+				b_baravat = {
+				}
+				b_fahraj = {
+				}
+				b_nukjub = {
+				}
+				b_sol_hasan = {
+				}
+				b_abeshkan = {
+				}
+			}
+			
+			c_hormuz = {
+				color={ 106 126 71 }
+				color2={ 255 255 255 }
+				
+				b_gombroon = {
+				}
+				b_abarkawan = {
+				}
+				b_jiroth = {
+				}
+				b_abu_musa = {
+				}
+				b_minab = {
+				}
+				b_kish = {
+				}
+				b_bam = {
+				}
+				b_fin = {
+				}
+			}
+			c_sirjan = {
+				color={ 118 138 83 }
+				color2={ 255 255 255 }
+				
+				b_sirjan = {
+				}
+				b_borougheeyeh = {
+				}
+				b_faragheh = {
+				}
+				b_shahrbabak = {
+				}
+				b_abarkuh = {
+				}
+				b_dehbid = {
+				}
+				b_mehrabad = {
+				}
+			}
+			c_sistan = {
+				color={ 102 122 67 }
+				color2={ 255 255 255 }
+
+				holy_site = zoroastrian # Lake Hamun / Mount Khwaja
+				
+				b_haozdar = {
+				}
+				b_kuh_taftan = {
+				}
+				b_nok_kundi = {
+				}
+				b_dozz_aap = {
+				}
+				b_shahresukhteh = {
+				}
+				b_esfandak = {
+				}
+				b_dehak = {
+				}
+				b_adar = {
+				}
+			}
+		}
+		d_fars = {
+			color={ 89 128 22 }
+			color2={ 255 255 255 }
+			
+			capital = 643 # Fars
+			
+			c_fars = {
+				color={ 91 130 24 }
+				color2={ 255 255 255 }
+
+				holy_site = zoroastrian # The Great Fire of Adur Farnbag
+				holy_site = yazidi
+				holy_site = qarmatian
+				
+				b_perozabad = {
+				}
+				b_kakhesasan = {
+				}
+				b_darab = {
+				}
+				b_jahrom = {
+				}
+				b_estahbanat = {
+				}
+				b_lamerd = {
+				}
+				b_gerash = {
+				}
+				b_khafr = {
+				}
+			}
+			c_hendjan = {
+				color={ 93 132 26 }
+				color2={ 255 255 255 }
+				
+				b_argan = {
+				}
+				b_bandaremashoor = {
+				}
+				b_susa = {
+				}
+				b_ramhormoz = {
+				}
+				b_bandarshahpur = {
+				}
+				b_omidiyeh = {
+				}
+				b_behbahan = {
+				}
+				b_jayzan = {
+				}
+			}
+			c_ladistan = {
+				color={ 114 134 79 }
+				color2={ 255 255 255 }
+				
+				b_lad = {
+				}
+				b_khonj = {
+				}
+				b_evaz = {
+				}
+				b_jask = {
+				}
+				b_bastak = {
+				}
+				b_morbagh = {
+				}
+				b_forg = {
+				}
+				b_bandarkhamir = {
+				}
+			}
+			c_istakhr = {
+				color={ 134 158 76 }
+				color2={ 255 255 255 }
+				
+				b_istakhr = {
+				}
+				b_abadha = {
+				}
+				b_abarquh = {
+				}
+				b_sarmaq = {
+				}
+				b_iqlid = {
+				}
+				b_kamin = {
+				}
+				b_main = {
+				}
+			}
+			c_shiraz = {
+				color={ 154 188 96 }
+				color2={ 255 255 255 }
+				
+				b_shiraz = {
+				}
+				b_estakhr = {
+				}
+				b_bishapur = {
+				}
+				b_persepolis = {
+				}
+				b_azargarta = {
+				}
+				b_abadeh = {
+				}
+				b_bavanat = {
+				}
+				b_arsanjan = {
+				}
+			}
+		}
+		d_khozistan = {
+			color={ 120 144 28 }
+			color2={ 255 255 255 }
+			
+			capital = 648
+			
+			c_khozistan = {
+				color={ 95 134 28 }
+				color2={ 255 255 255 }
+				
+				holy_site = manichean # Where Mani was martyred and near the place of first revelation
+				
+				b_abadan = {
+				}
+				b_izaj = {
+				}
+				b_hoveizeh = {
+				}
+				b_ahvaz = {
+				}
+				b_dora = {
+				}
+				b_fao = {
+				}
+				b_khorramshahr = {
+				}
+				b_shadegan = {
+				}
+			}
+			c_avhaz = {
+				color={ 151 185 93 }
+				color2={ 255 255 255 }
+				
+				b_dezful = {
+				}
+				b_shushtar = {
+				}
+				b_helen = {
+				}
+				b_idhaj = {
+				}
+				b_masjedsoleyman = {
+				}
+				b_shahrekord = {
+				}
+				b_koohrang = {
+				}
+				b_farsan = {
+				}
+			}
+			c_tigris = {
+				color={ 92 174 52 }
+				color2={ 255 255 255 }
+				
+				ashkenazi = "Chideqel"
+				sephardi = "Chideqel"
+				
+				b_majaralkabir = {
+				}
+				b_bismaya = {
+				}
+				b_qalatsjergat = {
+				}
+				b_nuffar = {
+				}
+				b_ishan = {
+				}
+				b_Warka = {
+				}
+				b_samawah = {
+				}
+				b_tellelhiba = {
+				}
+			}
+		}
+		d_jibal = {
+			color={ 184 225 112 }
+			color2={ 255 255 255 }
+			
+			capital = 646 #	Esfahan
+			
+			c_qom = {
+				color={ 187 228 115 }
+				color2={ 255 255 255 }
+				
+				b_khourabad = {
+				}
+				b_qom = {
+				}
+				b_jamkaran = {
+				}
+				b_kahak = {
+				}
+				b_dastjerd = {
+				}
+				b_salafchegan = {
+				}
+				b_qanavat = {
+				}
+				b_jafariyeh = {
+				}
+			}
+			c_hamadan = {
+				color={ 190 231 118 }
+				color2={ 255 255 255 }
+
+				holy_site = jewish
+				holy_site = samaritan
+				holy_site = karaite
+				
+				b_hamadan = {
+				}
+				b_nahavand = {
+				}
+				b_ganjnameh = {
+				}
+				b_malayer = {
+				}
+				b_ecbatana = {
+				}
+				b_asadabad = {
+				}
+				b_kabudrahang = {
+				}
+				b_roudavar = {
+				}
+			}
+			c_rayy = {
+				color={ 193 234 121 }
+				color2={ 255 255 255 }
+
+				b_rayy = {
+				}
+				b_tehran = {
+				}
+				b_roudehen = {
+				}
+				b_hashtgerd = {
+				}
+				b_shahriar = {
+				}
+				b_eslamshahr = {
+				}
+				b_karaj = {
+				}
+				b_pakdasht = {
+				}
+			}
+			c_zanjan_abhar = {
+				color={ 182 238 131 }
+				color2={ 255 255 255 }
+				
+				b_zahanj = {
+				}
+				b_abhar = {
+				}
+				b_wasamkuh = {
+				}
+				b_aba = {
+				}
+				b_suhraward = {
+				}
+				b_mozaffari = { # Fictional, for prosperity
+				}
+				b_quzlucheh = { # Fictional, for prosperity
+				}
+			}
+			c_luristan = {
+				color={ 75 164 110 }
+				color2={ 255 255 255 }
+				
+				b_dezbar = {
+				}
+				b_khorramabad = {
+				}
+				b_borujerd = {
+				}
+				b_dorood = {
+				}
+				b_aligoodarz = {
+				}
+				b_koohdasht = {
+				}
+				b_poledokhtar = {
+				}
+				b_alashtar = {
+				}
+			}
+			c_esfahan = {
+				color={ 145 179 87 }
+				color2={ 255 255 255 }
+				
+				b_esfahan = {
+				}
+				b_zarrinshahr = {
+				}
+				b_khansar = {
+				}
+				b_kashan = {
+				}
+				b_sedeh = {
+				}
+				b_qomsheh = {
+				}
+				b_abyaneh = {
+				}
+				b_ardestan = {
+				}
+			}
+		}
+		d_kurdistan = {
+			color={ 124 232 67 }
+			color2={ 255 255 255 }
+			
+			capital = 686 #Kurdistan
+			
+			c_kurdistan = {
+				color={ 124 180 90 }
+				color2={ 255 255 255 }
+				
+				holy_site = zoroastrian # The Great Fire of Adur Gushnasp
+				
+				b_duhok = {
+				}
+				b_araden = {
+				}
+				b_bebadi = {
+				}
+				b_dehi = {
+				}
+				b_harmashi = {
+				}
+				b_marqayoma = {
+				}
+				b_dawodiya = {
+				}
+				b_sarsink = {
+				}
+			}
+			c_shahrazur = {
+				color={ 124 199 5 }
+				color2={ 255 255 255 }
+			
+				b_shahrazur = {
+				}
+				b_sanda = {
+				}
+				b_saqqez = {
+				}
+				b_amkaleh = { # Fictional, for prosperity
+				}
+				b_kavand = { # Fictional, for prosperity
+				}
+				b_kabgan = { # Fictional, for prosperity
+				}
+				b_eskelabad = { # Fictional, for prosperity
+				}
+			}
+		}
+	}
+	
+	k_baluchistan = { # Kingdom of Sistan
+		color={ 155 169 114 }
+		color2={ 255 255 255 }
+		
+		capital = 1183 # Bost
+		
+		zoroastrian_group = 1500 # Crusade target weight
+		zun_pagan_reformed = 300 # Crusade target weight
+		
+		saka = "Sagistan"
+		baloch = "Baluchistan"
+		
+		culture = afghan
+	
+		d_baluchistan = { # Makran
+			color={ 150 170 118 }
+			color2={ 255 255 255 }
+			
+			capital = 1139 # Makran
+			
+			c_makran = {
+				color={ 152 185 96 }
+				color2={ 255 255 255 }
+				
+				b_al_haur = {
+				}
+				b_kiz = {
+				}
+				b_ormara = {
+				}
+				b_kannazbun = {
+				}
+				b_chhajian = { # Fictional, for prosperity
+				}
+				b_mughal = { # Fictional, for prosperity
+				}
+				b_man = { # Fictional, for prosperity
+				}
+				b_karim_bakhsh = { # Fictional, for prosperity
+				}
+			}
+			c_chagai = {
+				color={ 152 185 96 }
+				color2={ 255 255 255 }
+				
+				b_nushki = {
+				}
+				b_dad = { # Fictional, for prosperity
+				}
+				b_chachoke = { # Fictional, for prosperity
+				}
+				b_kandar = { # Fictional, for prosperity
+				}
+				b_bochra = { # Fictional, for prosperity
+				}
+				b_kallarwala = { # Fictional, for prosperity
+				}
+				b_kashmir_kili = { # Fictional, for prosperity
+				}
+				b_peshai = { # Fictional, for prosperity
+				}
+			}
+			c_armail = {
+				color={ 152 185 96 }
+				color2={ 255 255 255 }
+				
+				b_armail = {
+				}
+				b_hingula = {
+				}
+				b_kambali = {
+				}
+				b_yusli = {
+				}
+				b_rihana_sahu = { # Fictional, for prosperity
+				}
+				b_basti_basira = { # Fictional, for prosperity
+				}
+				b_pejoke = { # Fictional, for prosperity
+				}
+				b_daryun = { # Fictional, for prosperity
+				}
+			}
+			c_saravan = {
+				color={ 152 185 96 }
+				color2={ 255 255 255 }
+				
+				b_saravan = {
+				}
+				b_pahrah = {
+				}
+				b_khash = {
+				}
+				b_jaleq = {
+				}
+				b_pishin = {
+				}
+				b_sarbaz = {
+				}
+				b_rasak = {
+				}
+				b_sangan = {
+				}
+			}
+			c_tis = {
+				color={ 148 181 92 }
+				color2={ 255 255 255 }
+				
+				b_parak = {
+				}
+				b_kursar = {
+				}
+				b_tis = {
+				}
+				b_chabahar = {
+				}
+				b_pozm_machchan = {
+				}
+				b_regedan = {
+				}
+				b_sergen = {
+				}
+			}
+		}
+		d_sistan = {
+			color={ 118 148 40 }
+			color2={ 255 255 255 }
+			
+			saka = "Sakastan"
+			
+			capital = 1183 # Bost
+			
+			c_bost = {
+				color={ 189 110 60 }
+				color2={ 255 255 255 }
+
+				holy_site = zun_pagan
+				holy_site = zun_pagan_reformed
+				
+				b_bost = { # Aka Lashgar Gah
+				}
+				b_kandahar = {
+				}
+				b_sangin = {
+				}
+				b_gereshk = {
+				}
+				b_chaman = {
+				}
+				b_chora = {
+				}
+				b_panjwai = {
+				}
+			}
+			c_zaranj = {
+				color={ 204 160 60 }
+				color2={ 255 255 255 }
+				
+				b_zaranj = {
+				}
+				b_zabol = {
+				}
+				b_zahak = {
+				}
+				b_rudbar = {
+				}
+				b_milak = {
+				}
+				b_bonjar = {
+				}
+				b_nimeh = {
+				}
+			}
+			c_farrah = {
+				color={ 173 140 84 }
+				color2={ 255 255 255 }
+				
+				b_farrah = {
+				}
+				b_bakwa = {
+				}
+				b_baladuluk = {
+				}
+				b_anardara = {
+				}
+				b_khakisafed = {
+				}
+				b_qalaikah = {
+				}
+				b_shibkoh = {
+				}
+				b_juwayn = {
+				}
+			}
+			c_zahedan = {
+				color={ 142 175 86 }
+				color2={ 255 255 255 }
+				
+				b_zahedan = {
+				}
+				b_khajeh = {
+				}
+				b_kuhtaftan = {
+				}
+				b_hamun = {
+				}
+				b_jahangir = {
+				}
+				b_golchah = {
+				}
+				b_buk = {
+				}
+				b_kacharud = {
+				}
+			}
+		}
+	}
+
+	k_afghanistan = { # Kingdom of Kabulistan
+		color={ 163 121 57 }
+		color2={ 220 220 0 }
+		
+		capital = 1185 # Kabul
+		
+		culture = afghan
+		
+		zun_pagan_reformed = 1000 # Crusade target weight
+		zoroastrian_group = 1500 # Crusade target weight
+		
+		d_kabul = {
+			color={ 125 68 23 }
+			color2={ 255 255 255 }
+			
+			capital = 1185 # Kabul
+			
+			zun_pagan_reformed = 300 # Crusade target weight
+			
+			c_kabul = {
+				color={ 135 90 30 }
+				color2={ 255 255 255 }
+
+				holy_site = zun_pagan
+				holy_site = zun_pagan_reformed
+				
+				b_kabul = {
+				}
+				b_adinapur = {
+				}
+				b_nagarahara = {
+				}
+				b_kapisa = {
+				}
+				b_lampara = {
+				}
+				b_kunar = {
+				}
+				b_kharabat = {
+				}
+			}
+			c_bamiyan = {
+				color={ 175 140 30 }
+				color2={ 255 255 255 }
+				
+				holy_site = buddhist
+				
+				b_bamiyan = {
+				}
+				b_shar_i_gholghola = {
+				}
+				b_istalif = {
+				}
+				b_zakhak = {
+				}
+				b_shibar = {
+				}
+				b_shihak = { #Fictional, for prosperity
+				}
+				b_shilif = { #Fictional, for prosperity
+				}
+			}
+			c_kunduz = {
+				color={ 155 110 30 }
+				color2={ 255 255 255 }
+				
+				b_aibak = {
+				}
+				b_baghlan = {
+				}
+				b_surkh_kotal = {
+				}
+				b_kunduz = {
+				}
+				b_siminjan = {
+				}
+				b_nahrain = {
+				}
+				b_mogholan = {
+				}
+				b_khomri = {
+				}
+			}
+		}
+		d_zabulistan = {
+			color={ 179 120 64 }
+			color2={ 255 255 255 }
+			
+			saka = "Seyanish"
+			
+			capital = 1182 # Ghazna
+			
+			zun_pagan_reformed = 300 # Crusade target weight
+			
+			c_ghazna = {
+				color={ 175 110 50 }
+				color2={ 255 255 255 }
+				
+				b_ghazna = {}
+				b_gardez = {}
+				b_khost = {}
+				b_loman = {}
+				b_katawaz = {}
+				b_sharana = {}
+				b_sangar = {}
+			}
+			c_zamindawar = {
+				color={ 195 100 65 }
+				color2={ 255 255 255 }
+				
+				b_zamindawar = {
+				}
+				b_bishlang = {
+				}
+				b_khalai = {
+				}
+				b_ymanda = { #Fictional, for prosperity
+				}
+				b_langi = { #Fictional, for prosperity
+				}
+				b_afgilai = { #Fictional, for prosperity
+				}
+				b_amandawar = { #Fictional, for prosperity
+				}
+			}
+			c_kalat = {
+				color={ 152 185 96 }
+				color2={ 255 255 255 }
+				
+				b_kalat = {
+				}
+				b_talq = {
+				}
+				b_kot_waras = { # Fictional, for prosperity
+				}
+				b_palasi = { # Fictional, for prosperity
+				}
+				b_bhaminpur = { # Fictional, for prosperity
+				}
+				b_katewala = { # Fictional, for prosperity
+				}
+				b_chenga = { # Fictional, for prosperity
+				}
+				b_nautasal = { # Fictional, for prosperity
+				}
+			}
+		}
+	}
+	
+	k_mesopotamia = {
+		color={ 75 185 47 }
+		color2={ 255 255 255 }
+		
+		capital	= 697 # Mosul
+		
+		culture = levantine_arabic
+		
+		roman = "Assyria"
+		armenian = "Assyria"
+		greek = "Assyria"
+		alan = "Assyria"
+		georgian = "Assyria"
+		assyrian = "Assyria"
+		
+		muslim = 400 # Crusade target weight
+		zoroastrian_group = 2000 # Crusade target weight
+		zun_pagan_reformed = 300 # Crusade target weight
+		jewish_group = 500 # Crusade target weight
+		
+		d_mosul = {
+			color={ 11 205 70 }
+			color2={ 255 255 255 }
+			
+			capital = 697 # Mosul
+			
+			assyrian = "Niniveh"
+			
+			c_mosul = {
+				color={ 9 236 89 }
+				color2={ 255 255 255 }
+				
+				holy_site = yazidi
+				
+				assyrian = "Niniveh"
+				
+				b_mosul = {
+				}
+				b_bakhdida = {
+				}
+				b_karamlish = {
+				}
+				b_shekhan = {
+				}
+				b_aqrah = {
+				}
+				b_bartella = {
+				}
+				b_arbil = {
+				}
+				b_baqofah = {
+				}
+			}
+			c_oromieh = {
+				color={ 21 180 70 }
+				color2={ 255 255 255 }
+				
+				b_oroumieh = {
+				}
+				b_khoy = {
+				}
+				b_takhtesoleyman = {
+				}
+				b_avajiq = {
+				}
+				b_chaldiran = {
+				}
+				b_charekelisa = {
+				}
+				b_mahabad = {
+				}
+				b_salmas = {
+				}
+			}
+			c_sinjar = {
+				color={ 61 160 70 }
+				color2={ 255 255 255 }
+				
+				b_sinjar = {
+				}
+				b_hatra = {
+				}
+				b_telassar = {
+				}
+				b_nineveh = {
+				}
+				b_talkayf = {
+				}
+				b_baaj = {
+				}
+				b_kouyunik = {
+				}
+				b_nabiyunus = {
+				}
+			}
+			c_nisibin = {
+				color={ 133 170 52 }
+				color2={ 255 255 255 }
+				
+				b_nusaybin = {
+				}
+				b_savur = {
+				}
+				b_dairodmorhannanyo = {
+				}
+				b_kerburan = {
+				}
+				b_cizre = {
+				}
+				b_sittiradviyyemadrasa = {
+				}
+				b_dayrodmorgabriel = {
+				}
+				b_yaqobnsibnaya = {
+				}
+			}
+		}
+		d_jazira = {
+			color={ 95 180 35 }
+			color2={ 255 255 255 }
+			
+			capital = 700 # Bira
+			
+			c_bira = {
+				color={ 95 186 30 }
+				color2={ 255 255 255 }
+				
+				b_bira = {
+				}
+				b_tella = {
+				}
+				b_resaina = {
+				}
+				b_qalarebete = {
+				}
+				b_derik = {
+				}
+				b_qoser = {
+				}
+				b_samrah = {
+				}
+				b_stewr = {
+				}
+			}
+			c_amida = {
+				color={ 129 166 48 }
+				color2={ 255 255 255 }
+				
+				b_kiaburc = {
+				}
+				b_amida = {
+				}
+				b_ulucamii = {
+				}
+				b_suraamede = {
+				}
+				b_mayyafarikin = {
+				}
+				b_hazretisuleymancamii = {
+				}
+				b_egil = {
+				}
+				b_idtodyolataloho = {
+				}
+			}
+		}
+		d_mudar = {
+			color={ 95 180 35 }
+			color2={ 255 255 255 }
+			
+			capital = 712 # Rahbah
+			
+			c_rahbah = {
+				color={ 41 238 26 }
+				color2={ 255 255 255 }
+			
+				b_rahbah = {
+				}
+				b_taraba = {
+				}
+				b_nimreh = {
+				}
+				b_salah = {
+				}
+				b_busan = {
+				}
+				b_tlilin = {
+				}
+				b_qummoualad = {
+				}
+				b_anah = {
+				}
+			}
+			c_al_bichri = {
+				color={ 15 242 95 }
+				color2={ 255 255 255 }
+				
+				b_bichri = {
+				}
+				b_deiralzur = {
+				}
+				b_osrhoene = {
+				}
+				b_abukamal = {
+				}
+				b_shamiyya = {
+				}
+				b_mayadin = {
+				}
+				b_sirhi = {
+				}
+				b_mhaymidah = {
+				}
+			}
+			c_al_jazira = {
+				color={ 70 160 30 }
+				color2={ 255 255 255 }
+				
+				b_hasakah = {
+				}
+				b_dayrik = {
+				}
+				b_qamishhlo = {
+				}
+				b_darbasiyah = {
+				}
+				b_teltamer = {
+				}
+				b_hamoukar = {
+				}
+				b_amuda = {
+				}
+				b_dakhiliyah = {
+				}
+			}
+		}
+	}
+	
+	k_iraq = {
+		color={ 45 118 57 }
+		color2={ 255 255 255 }
+		
+		capital	= 693 # Baghdad
+		
+		culture = levantine_arabic
+		
+		roman = "Babylonia"
+		armenian = "Babylonia"
+		greek = "Babylonia"
+		alan = "Babylonia"
+		georgian = "Babylonia"
+		assyrian = "Babylonia"
+		
+		muslim = 400 # Crusade target weight
+		zoroastrian_group = 2000 # Crusade target weight
+		zun_pagan_reformed = 300 # Crusade target weight
+		jewish_group = 500 # Crusade target weight
+		
+		d_baghdad = {
+			color={ 6 100 2 }
+			color2={ 255 255 255 }
+			
+			capital = 693 # Baghdad
+			
+			zun_pagan_reformed = 200 # Crusade target weight
+			
+			roman = "Babylonia"
+			armenian = "Asoristan"
+			greek = "Asoristan"
+			alan = "Asoristan"
+			georgian = "Asoristan"
+			assyrian = "Asoristan"
+			assyrian = "Asoristan"
+			
+			c_karbala = {
+				color={ 16 110 12 }
+				color2={ 255 255 255 }
+				
+				b_ainaltamur = {
+				}
+				b_karbala = {
+				}
+				b_hindiya = {
+				}
+				b_ofak = {
+				}
+				b_hamzah = {
+				}
+				b_shamiyah = {
+				}
+				b_qisair = {
+				}
+				b_ukhaidir = {
+				}
+			}
+			c_baghdad = {
+				color={ 16 135 12 }
+				color2={ 255 255 255 }
+
+				holy_site = sunni
+				holy_site = nestorian # Metropolitan site and important for missionaries
+				holy_site = manichean # Patriarch of the west
+				
+				b_baqubah = {
+				}
+				b_bagdad = {
+				}
+				b_hillah = {
+				}
+				b_iskandariya = {
+				}
+				b_taji = {
+				}
+				b_babel = {
+				}
+				b_madain = {
+				}
+				b_latifiya = {
+				}
+			}
+			c_kermanshah = {
+				color={ 75 114 90 }
+				color2={ 255 255 255 }
+				
+				b_javanroud = {
+				}
+				b_kermanshah = {
+				}
+				b_hulwan = {
+				}
+				b_paveh = {
+				}
+				b_mahalkufa = {
+				}
+				b_kangavar = {
+				}
+				b_kuzaran = {
+				}
+				b_ravansar = {
+				}
+			}
+			c_ilam = {
+				color={ 105 150 52 }
+				color2={ 255 255 255 }
+				
+				b_dehloran = {
+				}
+				b_ilam = {
+				}
+				b_chahartaghi = {
+				}
+				b_abdanan = {
+				}
+				b_hezardar = {
+				}
+				b_mehran = {
+				}
+				b_ghalehghiran = {
+				}
+				b_towhid = {
+				}
+			}
+			c_al_nadjaf = {
+				color={ 105 150 32 }
+				color2={ 255 255 255 }
+
+				holy_site = shiite
+				holy_site = qarmatian
+
+				b_nadjaf = {
+				}
+				b_kufah = {
+				}
+				b_taqtaqanah = {
+				}
+				b_jasim = {
+				}
+				b_midhrawi = {
+				}
+				b_rashid = {
+				}
+				b_jaarah = {
+				}
+			}
+			c_al_amarah = {
+				color={ 92 144 82 }
+				color2={ 255 255 255 }
+				
+				b_amarah = {
+				}
+				b_kutelamara = {
+				}
+				b_wasit = {
+				}
+				b_badra = {
+				}
+				b_suwaira = {
+				}
+				b_hai = {
+				}
+				b_azeeziaya = {
+				}
+				b_zurbatiyah = {
+				}
+			}
+		}
+		d_samarra = {
+			color={ 110 190 80 }
+			color2={ 255 255 255 }
+			
+			capital = 696 # Samarra/c_euphrates
+			
+			c_deir = {
+				color={ 150 205 80 }
+				color2={ 255 255 255 }
+				
+				b_takrit = {
+				}
+				b_anbar = {
+				}
+				b_rutbah = {
+				}
+				b_rawa = {
+				}
+				b_hit = {
+				}
+				b_ramadi = {
+				}
+				b_kasra = {
+				}
+				b_nehardea = {
+				}
+			}
+			c_euphrates = {
+				color={ 110 190 80 }
+				color2={ 255 255 255 }
+				
+				ashkenazi = "Peros"
+				sephardi = "Perat"
+				
+				b_bayji = {
+				}
+				b_tagrit = {
+				}
+				b_samarra = {
+				}
+				b_balad = {
+				}
+				b_dujail = {
+				}
+				b_amirli = {
+				}
+				b_ishaqi = {
+				}
+				b_faris = {
+				}
+			}
+			c_kirkuk = {
+				color={ 90 160 105 }
+				color2={ 255 255 255 }
+				
+				b_kirkuk = {
+				}
+				b_daquq = {
+				}
+				b_ranya = {
+				}
+				b_halabja = {
+				}
+				b_makhmur = {
+				}
+				b_dukan = {
+				}
+				b_chuartan = {
+				}
+				b_kifri = {
+				}
+			}
+		}
+		d_basra = {
+			color={ 6 150 2 }
+			color2={ 255 255 255 }
+			
+			capital = 649 # Basra
+			
+			c_kufa = {
+				color={ 46 150 2 }
+				color2={ 255 255 255 }
+				
+				b_kufa = {
+				}
+				b_bussayyah = {
+				}
+				b_suqash = {
+				}
+				b_hammar = {
+				}
+				b_chibayish = {
+				}
+				b_alqurnah = {
+				}
+				b_shuyukh = {
+				}
+				b_ragai = {
+				}
+			}
+			c_rummah = {
+				color={ 40 170 5 }
+				color2={ 255 255 255 }
+				
+				b_hafaralbatin = {
+				}
+				b_alqalt = {
+				}
+				b_samoudah = {
+				}
+				b_qaisumah = {
+				}
+				b_altheebiyah = {
+				}
+				b_arraqai = {
+				}
+				b_assuayerah = {
+				}
+				b_assufayri = {
+				}
+			}
+			c_basra = {
+				color={ 80 147 30 }
+				color2={ 255 255 255 }
+				
+				b_basra = {
+				}
+				b_ummqasr = {
+				}
+				b_azzubayr = {
+				}
+				b_arah = {
+				}
+				b_mohammera = {
+				}
+				b_sukelsheyuhk = {
+				}
+				b_kalaatderat = {
+				}
+				b_qurna = {
+				}
+			}
+		}
+	}
+	
+	k_daylam = {
+		color={ 70 125 147 }
+		color2={ 255 255 255 }
+		
+		capital = 666 # Gilan
+		
+		culture = persian
+		
+		roman = "Hyrcania"
+		armenian = "Hyrcania"
+		greek = "Hyrcania"
+		alan = "Hyrcania"
+		georgian = "Hyrcania"
+		assyrian = "Hyrcania"
+
+		muslim = 400 # Crusade target weight
+		zoroastrian_group = 500 # Crusade target weight
+		zun_pagan_reformed = 300 # Crusade target weight
+		jewish_group = 100 # Crusade target weight
+		
+		d_gilan = {
+			color={ 65 90 137 }
+			color2={ 255 255 255 }
+			
+			capital = 666 # Gilan
+			
+			c_gilan = {
+				color={ 106 143 61 }
+				color2={ 255 255 255 }
+				
+				b_gilan = {
+				}
+				#b_rasht = {}
+				b_talysh = {
+				}
+				b_astara = {
+				}
+				b_rudkhan = {
+				}
+				b_lahijan = {
+				}
+				b_masouleh = {
+				}
+				b_masal = {
+				}
+			}
+			c_daylam = {
+				color={ 72 178 109 }
+				color2={ 255 255 255 }
+				
+				b_khunaj = {
+				}
+				b_soltaniyeh = {
+				}
+				b_gheydar = {
+				}
+				b_zanjan = {
+				}
+				b_tarom = {
+				}
+				b_mahneshan = {
+				}
+				b_khalkhal = {
+				}
+			}
+			c_qazwin = {
+				color={ 55 144 90 }
+				color2={ 255 255 255 }
+				
+				b_lambsar = {
+				}
+				b_qazwin = {
+				}
+				b_ahmadabad = {
+				}
+				b_avaj = {
+				}
+				b_abeyek = {
+				}
+				b_takestan = {
+				}
+				b_alvand = {
+				}
+				b_buinzahra = {
+				}
+			}
+		}
+		d_mazandaran = { # Tabaristan
+			color={ 92 155 187 }
+			color2={ 255 255 255 }
+			
+			capital = 662 # Mazandaran
+			
+			c_tabaristan = {
+				color={ 98 68 152 }
+				color2={ 255 255 255 }
+				
+				b_firuzkuh = {
+				}
+				b_amul = {
+				}
+				b_sari = {
+				}
+				b_rarem = {
+				}
+				b_mamatir = {
+				}
+				b_chamnoo = {
+				}
+				b_farim = {
+				}
+				b_lavij = {
+				}
+			}
+			c_alamut = {
+				color={ 113 153 43 }
+				color2={ 255 255 255 }
+				
+				b_alamut = {
+				}
+				b_chaloos = {
+				}
+				b_rostamrood = {
+				}
+				b_kojoor = {
+				}
+				b_sisangan = {
+				}
+				b_damavand = {
+				}
+				b_garmsar = {
+				}
+				b_varamin = {
+				}
+				b_kalar = {
+				}
+			}
+			c_gurgan = {
+				color={ 107 158 17 }
+				color2={ 255 255 255 }
+				
+				b_gurgan = {
+				}
+				b_gonbadeqabus = {
+				}
+				b_komishdepa = {
+				}
+				b_kordkuy = {
+				}
+				b_aqqala = {
+				}
+				b_ramian = {
+				}
+				b_minudasht = {
+				}
+				b_khanbebin = {
+				}
+			}
+			c_qwivir = {
+				color={ 115 155 45 }
+				color2={ 255 255 255 }
+				
+				b_semnan = {
+				}
+				b_darvar = {
+				}
+				b_damqan = {
+				}
+				b_dehnamak = {
+				}
+				b_sangsar = {
+				}
+				b_sharequmis = {
+				}
+				b_gerdkuh = {
+				}
+				b_kohandej = {
+				}
+			}
+		}
+		d_tabriz = {
+			color={ 76 103 200 }
+			color2={ 255 255 255 }
+			
+			capital = 667 # Gilan
+			
+			c_tabriz = {
+				color={ 106 115 180 }
+				color2={ 255 255 255 }
+				
+				b_babak = {
+				}
+				b_tabriz = {
+				}
+				b_ahar = {
+				}
+				b_zahhak = {
+				}
+				b_sarab = {
+				}
+				b_shabestar = {
+				}
+				b_dihnakhirjan = {
+				}
+			}
+			c_maragha = {
+				color={ 116 90 165 }
+				color2={ 255 255 255 }
+				
+				b_maragheh = {
+				}
+				b_kursara = {
+				}
+				b_miyaneh = {
+				}
+				b_ujan = {
+				}
+				b_bahaduran = { # Fictional, for prosperity
+				}
+				b_kileh_shin = { # Fictional, for prosperity
+				}
+				b_mansurlu = { # Fictional, for prosperity
+				}
+			}
+		}
+		d_azerbaijan = {
+			color={ 112 120 180 }
+			color2={ 255 255 255 }
+			
+			capital = 670 # Azerbaijan
+			
+			culture = persian
+			
+			c_shirvan = {
+				color={ 162 234 22 }
+				color2={ 255 255 255 }
+				
+				b_baku = {
+				}
+				b_lankaran = {
+				}
+				b_absheron = {
+				}
+				b_shirvan = {
+				}
+				b_shakhriyar = {
+				} 
+				b_salyan = {
+				}
+				b_khizirzinda = {
+				}
+				b_altiagay = {
+				}
+			}
+			c_azerbaijan = {
+				color={ 164 236 24 }
+				color2={ 255 255 255 }
+				
+				b_urmiah = {
+				}
+				b_kapalak = {
+				}
+				b_takhtesuleiman = {
+				}
+				b_bastam = {
+				}
+				b_maku = {
+				} 
+				b_kalaberd = {
+				}
+				b_chaldoran = {
+				}
+				b_deglane = {
+				}
+			}
+			c_suenik = {
+				color={ 166 238 26 }
+				color2={ 255 255 255 }
+				
+				turkish = "Kafan"
+				persian = "Kafan"
+				armenian = "Syunik"
+				
+				b_ghapan = {
+				}
+				b_areni = {
+				}
+				b_noravank = {
+				}
+				b_vorotnavank = {
+				}
+				b_tatev = {
+				}
+				b_prochabert = {
+				}
+				b_gandzassar = {
+				}
+				b_goris = {
+				}
+			}
+			c_shemakha = {
+				color={ 168 240 28 }
+				color2={ 255 255 255 }
+				
+				b_ahemakha = {
+				}
+				b_quba = {
+				}
+				b_shikhlar = {
+				}
+				b_khachmaz = {
+				}
+				b_chiraggala = {
+				}
+				b_anig = {
+				}
+				b_maraza = {
+				}
+				b_khil = {
+				}
+			}
+		}
+		d_dihistan = {
+			color={ 153 160 180 }
+			color2={ 255 255 255 }
+			
+			capital = 631 # Dihistan
+			
+			c_dihistan = {
+				color={ 162 210 79 }
+				color2={ 255 255 255 }
+				
+				b_akhur = {
+				}
+				b_gasankuli = {
+				}
+				b_bayatkhadzi = {
+				}
+				b_kumdag = {
+				}
+				b_torskhali = {
+				}
+				b_yasydepe = {
+				}
+				b_yarymtyk = {
+				}
+				b_kemir = {
+				}
+			}
+			c_kara-kum = {
+				color={ 165 243 30 }
+				color2={ 255 255 255 }
+				
+				b_farava = {
+				}
+				b_gazanjyk = {
+				}
+				b_ohk = {
+				}
+				b_khodzhakala = {}
+				b_kyzyl_arvat = {}
+				b_kochevka = {}
+				b_toutli = {}
+			}
+			c_kyzyl-su = {
+				color={ 155 203 73 }
+				color2={ 255 255 255 }
+
+				b_kyzyl-su = {}
+				b_dzhanga = {
+				}
+				b_awaza = {
+				}
+				b_yangadzha = {
+				}
+				b_kenar = {}
+				b_akdash = {}
+				b_belek = {}
+			}
+		}
+	}
+	
+	k_khorasan = {
+		color = { 89 175 30 }
+		color2={ 255 255 255 }
+		
+		capital	= 634 # Nishapur
+		culture = persian
+		
+		d_khorasan = {
+			color={ 99 150 9 }
+			color2={ 255 255 255 }
+			
+			capital = 634 # Nishapur
+			
+			c_tus = {
+				color={ 103 154 13 }
+				color2={ 255 255 255 }
+				
+				b_bojnurd = {
+				}
+				b_shervan = {
+				}
+				b_mashhad = {
+				}
+				b_hasanabad = {
+				}
+				b_ghaisar = {
+				}
+				b_isfarayen = {
+				}
+				b_fagdatdezh = {
+				}
+				b_solak = {
+				}
+				b_tus = {
+				}
+			}
+			c_birjand = {
+				color={ 138 171 82 }
+				color2={ 255 255 255 }
+				
+				b_nehbandan = {
+				}
+				b_birjand = {
+				}
+				b_toon = {
+				}
+				b_furg = {
+				}
+				b_sarayan = {
+				}
+				b_boshruyeh = {
+				}
+				b_qaen = {
+				}
+				b_paeenshahr = {
+				}
+			}
+			c_nishapur = {
+				color={ 111 162 21 }
+				color2={ 255 255 255 }
+
+				holy_site = zoroastrian # The Great Fire of Adur Burzen-Mehr
+				holy_site = yazidi
+				holy_site = zun_pagan
+				holy_site = zun_pagan_reformed
+				holy_site = qarmatian
+				
+				b_nishapur = {
+				}
+				b_jajarm = {
+				}
+				b_sabzevar = {
+				}
+				b_akhlamad = {
+				}
+				b_quchan = {
+				}
+				b_daregaz = {
+				}
+				b_chenaran = {
+				}
+				b_shamat = {
+				}
+			}
+			c_qohistan = {
+				color={ 115 166 25 }
+				color2={ 255 255 255 }
+				
+				b_torshiz = {
+				}
+				b_beyhaq = {
+				}
+				b_gonabad = {
+				}
+				b_torbatjam = {
+				}
+				b_bardaskan = {
+				}
+				b_mahvalat = {
+				}
+				b_fariman = {
+				}
+				b_dasu = {
+				}
+			}
+		}
+		d_herat = {
+			color = { 175 234 82 }
+			color2={ 255 255 255 }
+			
+			capital = 905 # Herat
+			
+			c_herat = {
+				color={ 205 244 152 }
+				color2={ 255 255 255 }
+				
+				b_herat = {
+				}
+				b_karukh = {
+				}
+				b_kushk = {
+				}
+				b_gulran = {
+				}
+				b_obe = {
+				}
+				b_zarghun = {
+				}
+				b_farsi = {
+				}
+				b_chishti = {
+				}
+			}
+			c_badghis = {
+				color = { 145 244 62 }
+				color2={ 255 255 255 }
+				
+				b_zurabad = {
+				}
+				b_kusuya = {
+				}
+				b_buzgan = {
+				}
+				b_pushang = {
+				}
+				b_malin = {
+				}
+				b_jabal_al_adda = {
+				}
+				b_kuhsim = {
+				}
+			}
+			c_kanj_rustaq = {
+				color = { 112 200 51 }
+				color2={ 255 255 255 }
+				
+				b_diza = {
+				}
+				b_baghsur = {
+				}
+				b_kusak = {
+				}
+				b_aufah = {
+				}
+				b_nab = {
+				}
+				b_tajarg = { # Fictional, for prosperity
+				}
+				b_fenesk = { # Fictional, for prosperity
+				}
+			}
+			c_mandesh = {
+				color={ 183 210 94 }
+				color2={ 255 255 255 }
+				
+				b_chaghcharan = {
+				}
+				b_adraskan = {
+				}
+				b_baluci = {
+				}
+				b_saghar = {
+				}
+				b_kwajaha = {
+				}
+				b_taywara = {
+				}
+				b_gozareh = {
+				}
+			}
+		}
+		d_merv = {
+			color={ 163 241 28 }
+			color2={ 255 255 255 }
+			
+			capital = 630 # Merv
+			
+			c_merv = {
+				color={ 156 204 73 }
+				color2={ 255 255 255 }
+				
+				holy_site = nestorian # Metropolitan site and important for missionaries
+				
+				b_merv = {
+				}
+				b_bayramaly = {
+				}
+				b_tagtabazar = {
+				}
+				b_yoloten = {
+				}
+				b_gulanly = {
+				}
+				b_kushka = {
+				}
+				b_wekilbazar = {
+				}
+				b_sakarcage = {
+				}
+			}
+			c_amol = {
+				color={ 136 194 63 }
+				color2={ 255 255 255 }
+				
+				b_amol = {
+				}
+				b_zamm = {
+				}
+				b_akhsisak = {
+				}
+				b_kenekesyr = { # Fictional, for prosperity
+				}
+				b_mirzabek = { # Fictional, for prosperity
+				}
+				b_dautly = { # Fictional, for prosperity
+				}
+				b_megejik = { # Fictional, for prosperity
+				}
+			}
+			c_sarakhs = {
+				color={ 171 210 85 }
+				color2={ 255 255 255 }
+				
+				b_sarakhs = {
+				}
+				b_mazduran = {
+				}
+				b_shiraz_merv = {
+				}
+				b_maihana = {
+				}
+				b_dandanqan = {
+				}
+				b_yuzlar = { # Fictional, for prosperity
+				}
+				b_paxtachi = { # Fictional, for prosperity
+				}
+			}
+			c_konjikala = {
+				color={ 153 128 53 }
+				color2={ 255 255 255 }
+				
+				b_nisa = {
+				}
+				b_abiward = {
+				}
+				b_gokdepe = {
+				}
+				b_konjikala = {
+				}
+				b_kyzylarvat = {
+				}
+				b_sarahs = {
+				}
+				b_ulugdepe = {
+				}
+			}
+		}
+		d_balkh = {
+			color={ 171 215 108 }
+			color2={ 255 255 255 }
+			
+			capital = 904 # Balkh
+			
+			roman = "Bactria"
+			armenian = "Bactria"
+			greek = "Bactria"
+			alan = "Bactria"
+			georgian = "Bactria"
+			assyrian = "Bactria"
+
+			c_maymana = {
+				color={ 179 214 53 }
+				color2={ 255 255 255 }
+				
+				b_maymana = {
+				}
+				b_gurziwan = {
+				}
+				b_darzab = {
+				}
+				b_almar = {
+				}
+				b_bilcheragh = {
+				}
+				b_basin = {
+				}
+				b_dihekhala = {
+				}
+			}
+			
+			c_balkh = {
+				color={ 201 225 158 }
+				color2={ 255 255 255 }
+
+				holy_site = bon
+				holy_site = bon_reformed
+				holy_site = zoroastrian
+
+				roman = "Bactria"
+				armenian = "Bactria"
+				greek = "Bactria"
+				alan = "Bactria"
+				georgian = "Bactria"
+				assyrian = "Bactria"
+				
+				b_balkh = {
+				}
+				b_tiliatepe = {
+				}
+				b_takhtisangin = {
+				}
+				b_alkhanoum = {
+				}
+				b_surkhkotal = {
+				}
+				b_dalverzintepe = {
+				}
+				b_khulm = {
+				}
+			}
+			
+			c_guzgan = {
+				color={ 179 214 53 }
+				color2={ 255 255 255 }
+				
+				b_talaqan = {
+				}
+				b_jahudan = {
+				}
+				b_faryab = {
+				}
+				b_andkhud = {
+				}
+				b_usbuman = {
+				}
+				b_naryan = {
+				}
+				b_qasrahnaf = {
+				}
+			}
+		}
+	}
+}
+
+
+e_carpathia = {
+	color={ 210 115 35 }
+	color2={ 255 255 255 }
+	
+	capital = 522 # Pest
+	
+	culture = hungarian
+	
+	tengri_pagan_reformed = 100
+	slavic_pagan_reformed = 50 # Crusade target weight
+	
+	k_dacia = {
+		color={ 220 132 40 }
+		color2={ 255 255 255 }
+		
+		culture = romanian
+		
+		capital = 515 # Tirgoviste
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture = romanian
+				}
+			}
+		}
+		
+		d_wallachia = {		#Muntenia
+			color={ 238 192 69 }
+			color2={ 255 255 255 }
+			
+			capital = 515 # Tirgoviste
+			
+			c_tirgoviste = {
+				color={ 244 198 75 }
+				color2={ 255 255 255 }
+			
+				b_targoviste = {
+				}
+				b_tabla_butii = {
+				}
+				b_snagov = {
+				}
+				b_bucov = {
+				}
+				b_ramnicu_sarat = {
+				}
+				b_buzau = {
+				}
+				b_valeni = {
+				}
+			}
+			c_turnu = {
+				color={ 241 195 72 }
+				color2={ 255 255 255 }
+			
+				b_turnu = {
+				}
+				b_giurgiu = {
+				}
+				b_comana = {
+				}
+				b_zimnicea = {
+				}
+				b_bucuresti = {
+				}
+				b_rosiorriidevede = {
+				}
+				b_glavacioc = {
+				}
+			}
+			c_campulung = {
+				color={ 248 182 69 }
+				color2={ 255 255 255 }
+				
+				b_campulung = {
+				}
+				b_arges = {
+				}
+				b_pitesti = {
+				}
+				b_bran = {
+				}
+				b_bovora = {
+				}
+				b_cozla = {
+				}
+				b_mioveni = {
+				}
+			}
+			c_calarasi = {
+				color={ 238 212 80 }
+				color2={ 255 255 255 }
+				
+				b_calarasi = {
+				}
+				b_coconi = {
+				}
+				b_cornatei = {
+				}
+				b_floci = {
+				}
+				b_oltenita = {
+				}
+				b_slobozia = {
+				}
+				b_fetesti = {
+				}
+			}			
+		}
+		
+		d_oltenia = {
+			color={ 238 150 50 }
+			color2={ 255 255 255 }
+			
+			capital = 1643 # Craiova
+			
+			c_craiova = {
+				color={ 248 166 66 }
+				color2={ 255 255 255 }
+				
+				b_craiova = {
+				}
+				b_corabia = {
+				}
+				b_caracal = {
+				}
+				b_calafat = {
+				}
+				b_slatina = {
+				}
+				b_resita = {
+				}
+				b_hotarani = {
+				}
+			}
+			c_targu_jiu = {
+				color={ 211 170 77 }
+				color2={ 255 255 255 }
+				
+				b_targu_jiu = {
+				}
+				b_bistrita = {
+				}
+				b_baia_de_arama = {
+				}
+				b_polovragi = {
+				}
+				b_visina = {
+				}
+				b_tismana = {
+				}
+				b_vulcan = {
+				}
+			}
+			c_severin = {
+				color={ 247 201 78 }
+				color2={ 255 255 255 }
+			
+				b_severin = {
+				}
+				b_mehadia = {
+				}
+				b_orsova = {
+				}
+				b_drobeta = {
+				}
+				b_caransebes = {
+				}
+				b_gradet = {
+				}
+				b_vodita = {
+				}
+			}
+		}
+		
+		d_moldau = {
+			color={ 223 202 145 }
+			color2={ 255 255 255 }
+			
+			capital = 545 # Torki
+			
+			volhynian = "Tivertsians"
+			
+			c_torki = {				#Suceava since HF
+				color={ 227 206 149 }
+				color2={ 255 255 255 }
+			
+				b_suceava = {
+				}
+				b_radauti = {
+				}
+				b_bogdana = {
+				}
+				b_baia = {
+				}
+				b_moldovita = {
+				}
+				b_siret = {
+				}
+				b_putna = {
+				} 
+			}
+			c_bacau = {
+				color={ 207 226 166 }
+				color2={ 255 255 255 }
+				
+				b_bacau = {
+				}
+				b_targu_neamnt = {
+				}
+				b_neamnt = {
+				}
+				b_targu_trotus = {
+				}
+				b_bodesti = {
+				}
+				b_tazlau = {
+				}
+				b_bistrita_bacau = {
+				}
+			}
+			c_iasi = {
+				color={ 203 222 145 }
+				color2={ 255 255 255 }
+				
+				b_iasi = {
+				}
+				b_harlau = {
+				}
+				b_hotin = {
+				}
+				b_cernauti = {
+				}
+				b_dorohoi = {
+				}
+				b_varzaresti = {
+				}
+				b_ungheni = {
+				}
+			}
+			c_peresechen = {
+				color={ 225 204 147 }
+				color2={ 255 255 255 }
+			
+				b_soroca = {
+				}
+				b_orhei = {			
+				}
+				b_butuceni = {
+				}
+				b_balti = {
+				}
+				b_tuzara = {
+				}
+				b_falesti = {
+				}
+				b_rautu = {
+				}
+			}
+		}
+		
+		d_bessarabia = {
+			color={ 190 202 175 }
+			color2={ 255 255 255 }
+			
+			capital = 1640 # Chilia
+			
+			pecheneg = "Pecheneg"
+			
+			c_chilia = {
+				color={ 210 212 145 }
+				color2={ 255 255 255 }
+				
+				b_chilia = {
+				}
+				b_oblucita = {
+				}
+				b_tigheci = {
+				}
+				b_reni_ro = {
+				}
+				b_cahul = {
+				}
+				b_lisky = {
+				}
+				b_palada = {
+				}
+			}			
+			c_galaz = {
+				color={ 240 202 135 }
+				color2={ 255 255 255 }
+				
+				b_galaz = {
+				}
+				b_falciu = {
+				}
+				b_husi = {
+				}
+				b_oancea = {
+				}
+				b_beresti = {
+				}
+				b_targu_bujor = {
+				}
+				b_murgeni = {
+				}
+			}
+			c_birlad = {
+				color={ 233 212 155 }
+				color2={ 255 255 255 }
+
+				holy_site = slavic_pagan
+				holy_site = slavic_pagan_reformed
+				
+				b_barlad = {
+				}
+				b_tecuci = {
+				}
+				b_focsani = {
+				}
+				b_adjud = {
+				}
+				b_craciuna = {
+				}
+				b_targu_putnei = {
+				}
+				b_marasesti = {
+				}
+			}
+			c_belgorod = {
+				color={ 231 210 153 }
+				color2={ 255 255 255 }
+			
+				b_cetatea_alba = {
+				}
+				b_belgorod = {
+				}
+				b_tighina = {
+				}
+				b_capriana = {
+				}
+				b_chisinau = {
+				}
+				b_causeni = {
+				}
+				b_cedaesti = {
+				}
+			}
+		}
+	}
+
+	k_hungary = {
+		color={ 250 120 90 }
+		color2={ 255 255 255 }
+		
+		capital	= 444 # Esztergom
+
+		slovieni = Pannonia
+		frankish = Pannonia
+		bulgarian = Pannonia
+		bohemian = Pannonia
+		german = Pannonia
+		carantanian = Pannonia
+		avar = Avaria
+		croatian = Pannonia
+		polish = Pannonia
+		russian = Pannonia
+		romanian = Pannonia
+		serbian = Pannonia
+		greek = Pannonia
+		roman = Pannonia
+		bosnian = Pannonia
+
+		allow = {
+			OR = {
+				culture_group = magyar
+				culture = avar
+			}
+		}
+		
+		culture = hungarian
+		
+		catholic = 500 # Crusade target weight
+		
+		d_pecs = {
+			color={ 155 25 65 }
+			color2={ 255 255 255 }
+			
+			capital = 452 # Pecs
+			
+			bohemian = Blatno
+			carantanian = Blatno
+			slovieni = Blatno
+			hungarian = Balaton
+			
+			c_pecs={
+				color={ 182 72 72 }
+				color2={ 255 255 255 }
+
+				croatian = Pecuh
+				serbian = Pecuj
+				bosnian = Pecuh
+				german = Fünfkirchen
+				bohemian = Petikostelí
+				carantanian = Patkostolie
+				slovieni = Patkostolie
+				
+				b_pecs = { 
+					slovieni = Patkostolie
+					bohemian = Petikostelí
+					german = Funfkirchen
+					croatian = Pecuh
+				}
+				b_kalocsa = { 
+					slovieni = Kaloca
+					bohemian = Kaloca
+					german = Kollotschau
+				}
+				b_mohacs = { 
+					slovieni = Mohác
+					bohemian = Mohác
+					german = Mohatsch
+					croatian = Mohác
+				}
+				b_sasd = { 
+					slovieni = Šašd
+					bohemian = Šašd
+					german = Schaschd
+					croatian = Šardin
+				}
+				b_pecsvarad = { 
+					slovieni = Pecvar
+					bohemian = Pecvar
+					german = Petschwar
+					croatian = Pecvar
+				}
+				b_siklos = { 
+					slovieni = Šikloš
+					bohemian = Šikloš
+					croatian = Šikloš
+					german = Sieglos
+				}
+				b_szentlorinc = { 
+					slovieni = "Svatý Vavrinec"
+					bohemian = "Svatý Vavrinec"
+					croatian = Selurinac
+					german = "Sankt Laurenz"
+				}
+				b_darda = { 
+					slovieni = Darda
+					bohemian = Darda
+					german = Lanzenau
+				}
+			}
+			c_szekezfehervar = {
+				color={ 189 74 74 }
+				color2={ 255 255 255 }
+				
+				croatian = Šomod
+				german = Schomodei
+				bohemian = Šomod
+				slovieni = Šomod
+				hungarian = Somogy
+				
+				b_szekezfehervar = { 
+					croatian = Šomod
+					german = Schomodei
+					bohemian = Šomod
+					slovieni = Šomod
+					hungarian = Somogy
+				}
+				b_csurgo = { 
+					slovieni = Curgov
+					bohemian = Curgov
+				}
+				b_kaposvar = { 
+					slovieni = Kapošvár
+					bohemian = Kapošvár
+					german= Kopisch
+				}
+				b_szigetvar = { 
+					slovieni = Sihot
+					bohemian = Sihot
+					croatian = Siget
+					german = Inselburg
+				}
+				b_barcs = { 
+					slovieni = Barc
+					bohemian = Barc
+					croatian = Barca
+					german = Bartsch
+				}
+				b_marcali = {
+					german = Martzal
+					croatian = Marcalin
+					slovieni = Marcalin
+					bohemian = Marcalin
+				}
+				b_nagyatad = {
+				}
+				b_lengyeltoti = {
+				}
+			}
+			c_vas = {
+				color={ 191 76 76 }
+				color2={ 255 255 255 }
+
+				german = Eisenburg
+				croatian = Zelezna
+				bosnian = Zelezna
+				carantanian = Zelezna
+				bohemian = Železna
+				slovieni = Železna
+				hungarian = Vas
+				
+				b_szombathely = { 
+					slovieni = Kamenec
+					german = Steinamanger
+				}
+				b_szentgotthard = { 
+					slovieni = "Svatý Gothard"
+					bohemian = "Svatý Gothard"
+					carantanian = Monošter
+					german = "Sankt Gotthard"
+				}
+				b_vasvar = { 
+					slovieni = "Železný hrad"
+					bohemian = "Železný hrad"
+					german = Eisenburg
+					carantanian = Železnograd
+				}
+				b_sarvar = {
+					german = Kotenburg
+				}
+				b_celldomolk = {
+					german = Kleinmariazell
+				}
+				b_kormend = {
+					german = Kirment
+				}
+				b_koszeg = { 
+					slovieni = Kysek
+					bohemian = Kysek
+					german = Güns
+					croatian = Kiseg
+				}
+				b_nemetujvar = { 
+					german = Güssing
+					croatian = Novigrad
+				}
+			}
+			c_fejer = {
+				color={ 193 78 78 }
+				color2={ 255 255 255 }
+				
+				german = Stuhlweiss
+				croatian = "Stolni Belegrad"
+				bosnian = "Stolni Belegrad"
+				carantanian = "Stolni Belegrad"
+				bohemian = "Stolicný Belehrad"
+				slovieni = "Stolicný Belehrad"
+
+				b_sarbogard = {
+					german = Bochart
+				}
+				b_adony = {
+					german = Adam
+				}
+				b_mor = {
+					german = Moor
+				}
+				b_val = {
+				}
+				b_szekszard = {
+					german = Sechshard
+				}
+				b_dombovar = {
+					german = Dombowa
+				}
+				b_tamasi = {
+					german = Tammasching
+				}
+				b_bonyhad = {
+					german = Bonnhard
+				}
+			}
+		}
+		d_esztergom = {
+			color={ 230 55 55 }
+			color2={ 255 255 255 }
+			
+			capital = 444 # Esztergom
+
+			german = Gran
+			bohemian = Ostrihom
+			slovieni = Ostrihom
+			hungarian = Esztergom
+			croatian = Ostrogon
+			bosnian = Ostrogon
+			carantanian = Ostrogon
+			polish = Ostrzyhom
+			
+			c_sopron = {
+				color={ 211 63 63 }
+				color2={ 255 255 255 }
+				
+				german = Ödenburg
+				slovieni = Šopron
+				bohemian = Šopron
+
+				b_sopron = { 
+					slovieni = Šopron
+					bohemian = Šopron
+					german = Ödenburg
+				}
+				b_gyor = {
+					slovieni = Ráb
+					german = Raab
+					bohemian = Ráb
+				}
+				b_csorna = {
+					german = Gschirnau
+				}
+				b_borsmonostor = {
+					german = Klostermarienberg
+				}
+				b_csepreg = {
+					german = Schapring
+				}
+				b_kapuvar = {
+					slovieni = Kapuvár
+					bohemian = Kapuvár
+					german = Kobrunn
+				}
+				b_kismarton = {
+					slovieni = Železno
+					bohemian = Železno
+					german = Eisenstadt
+					croatian = Željezno
+				}
+				b_nagymarton = {
+					german = Mattersburg
+					croatian = Materštof
+				}
+			}
+			c_esztergom = {
+				color={ 214 66 66 }
+				color2={ 255 255 255 }
+				
+				german = Gran
+				bohemian = Ostrihom
+				slovieni = Ostrihom
+				hungarian = Esztergom
+				croatian = Ostrogon
+				bosnian = Ostrogon
+				carantanian = Ostrogon
+				polish = Ostrzyhom
+				
+				b_esztergom = { 
+					german = Gran
+					bohemian = Ostrihom
+					slovieni = Ostrihom
+					hungarian = Esztergom
+					croatian = Ostrogon
+					bosnian = Ostrogon
+					carantanian = Ostrogon
+					polish = Ostrzyhom
+				}
+				b_komarom = { 
+					slovieni = Komárno
+					bohemian = Komárno
+					hungarian = Komárom
+					german = Komorn
+				}
+				b_kakath = { 
+					slovieni = Kokot
+					bohemian = Kokot
+				}
+				b_tatabanya = {
+					german = Totiserkolonie
+				}
+				b_nagyigmand = {
+				}
+				b_nemesocsa = { 
+					slovieni = "Zemianska Olca"
+					bohemian = "Zemianska Olca"
+				}
+				b_ogylla = { 
+					slovieni = "Stará Dala"
+					bohemian = "Stará Dala"
+					german = Altdala
+					hungarian = Ogyalla
+				}
+			}
+			c_pressburg = {
+				color={ 217 69 69 }
+				color2={ 255 255 255 }
+
+				german = Pressburg
+				hungarian = Pozsony
+				bohemian = Prešpurk
+				slovieni = Prešporok
+				
+				b_pressburg = { 
+					german = Pressburg
+					hungarian = Pozsony
+					bohemian = Prešpurk
+					slovieni = Prešporok
+				}
+				b_nagyszombat = { 
+					slovieni = Trnava
+					bohemian = Trnava
+					german = Tyrnau
+				}
+				b_bazin = { 
+					slovieni = Devín
+					bohemian = Devin
+					hungarian = Dévény
+					german = Theben
+				}
+				b_modor = { 
+					slovieni = Modra
+					bohemian = Modra
+					german = Modern
+				}
+				b_szentgyorgy = { 
+					slovieni = "Svatý Jur"
+					bohemian = "Svatý Jur"
+					german = "Sankt Georgen"
+				}
+				b_dunaszerdahely = { 
+					slovieni = "Dunajská Streda"
+					bohemian = "Dunajská Streda"
+					german = Niedermarkt
+				}
+				b_galanta = { 
+					slovieni = Galanta
+					bohemian = Galanta
+					german = Gallandau
+				}
+				b_somorja = { 
+					slovieni = Šamorín
+					bohemian = Šamorín
+					german = Sommerein
+				}
+			}
+		}
+		d_nyitra = {
+			color={ 190 21 21 }
+			color2={ 255 255 255 }
+			
+			capital = 443 # Nitra
+
+			german = Neutra
+			bohemian = Nitra
+			slovieni = Nitra
+			hungarian = Nyitra
+			polish = Nitra
+			
+			c_nitra = {
+				color={ 194 25 25 }
+				color2={ 255 255 255 }
+
+				german = Neutra
+				bohemian = Nitra
+				slovieni = Nitra
+				hungarian = Nyitra
+				polish = Nitra
+				
+				b_nyitra = { 
+					german = Neutra
+					bohemian = Nitra
+					slovieni = Nitra
+					hungarian = Nyitra
+					polish = Nitra
+				}
+				b_nagytapolcsany = { 
+					slovieni = Topolcany
+					bohemian = Topolcany
+					german = Topoltschan
+				}
+				b_stbenedek = { 
+					slovieni = "Hronský Benadik"
+					bohemian = "Hronský Benadik"
+					german = "Sankt Benedikt"
+				}
+				b_nagysurany = { 
+					slovieni = "Velké Šurany"
+					bohemian = "Velké Šurany"
+					german = Schuran
+				}
+				b_galgoc = { 
+					slovieni = Hlohovec
+					bohemian = Hlohovec
+					german = Freistadt
+				}
+				b_zabokreky = { 
+					slovieni = Žabokreky
+					bohemian = Žabokreky
+					hungarian = Zsámbokrét
+				}
+				b_postyen = { 
+					slovieni = Pieštany
+					bohemian = Pieštany
+					german = Pistyan
+				}
+				b_preuigan = { 
+					slovieni = Prievidza
+					bohemian = Prievidza
+					german = Priwitz
+				}
+			}
+			c_trencin = {
+				color={ 198 29 29 }
+				color2={ 255 255 255 }
+
+				german = Trentschin
+				bohemian = Trencín
+				slovieni = Trencín
+				hungarian = Trencsen
+				polish = Trenczyn
+				
+				b_trencsen = { 
+					german = Trentschin
+					bohemian = Trencín
+					slovieni = Trencín
+					hungarian = Trencsen
+					polish = Trenczyn
+				}
+				b_zilina = { 
+					slovieni = Žilina
+					bohemian = Žilina
+					german = Sillein
+					hungarian = Zsolna
+				}
+				b_turoc = { 
+					slovieni = Turiec
+					bohemian = Turiec
+					german = Turz
+				}
+				b_ban = { 
+					slovieni = Vyšehrad
+					bohemian = Vyšehrad
+					german = Plintenburg
+					hungarian = Visegrád
+				}
+				b_illava = { 
+					slovieni = Ilava
+					bohemian = Ilava
+					german = Illau
+				}
+				b_povazskabystrica = { 
+					slovieni = "Považská Bystrica"
+					bohemian = "Považská Bystrica"
+					german = Waagbistritz
+					hungarian = Vágbeszterce
+				}
+				b_congsberg = { 
+					slovieni = Beckov
+					bohemian = Beckov
+					german = Beckow
+					hungarian = Becko
+				}
+				b_puho = { 
+					slovieni = Puchov
+					bohemian = Puchov
+					german = Puchau
+				}
+			}
+			c_gemer = {
+				color={ 202 33 33 }
+				color2={ 255 255 255 }
+				
+				german = Gemer
+				bohemian = Gemer
+				slovieni = Gemer
+				hungarian = Gömör
+				polish = Gemer
+				
+				b_gomor = { 
+					german = Gemer
+					bohemian = Gemer
+					slovieni = Gemer
+					hungarian = Gömör
+					polish = Gemer
+				}
+				b_losonc = { 
+					slovieni = Lucenec
+					bohemian = Lucenec
+					german = Lizenz
+				}
+				b_dobsina = { 
+					slovieni = Dobšiná
+					bohemian = Dobšiná
+					german = Dobschau
+				}
+				b_rozsnyo = { 
+					slovieni = Rožnava
+					bohemian = Rožnava
+					german = Rosenau
+				}
+				b_balassagyarmat = { 
+					slovieni = "Balážske Darmoty"
+					bohemian = "Balážske Darmoty"
+					german = Jahrmarkt
+				}
+				b_jolsva = { 
+					slovieni = Jelšava
+					bohemian = Jelšava
+					german = Eltsch
+				}
+				b_nagyroce = { 
+					slovieni = "Velká Revúca"
+					bohemian = "Velká Revúca"
+					german = Grossrauschenbach
+				}
+				b_nyustya = { 
+					slovieni = Zvolen
+					bohemian = Zvolen
+					hungarian = Zólyom
+					german =  Altsohl
+				}
+			}
+			c_orava = {
+				color={ 205 36 36 }
+				color2={ 255 255 255 }
+
+				german = Arwa
+				bohemian = Orava
+				slovieni = Orava
+				hungarian = Arva
+				polish = Orawa
+				
+				b_arvavara = { 
+					german = Arwa
+					bohemian = Orava
+					slovieni = Orava
+					hungarian = Arva
+					polish = Orawa
+				}
+				b_nameszto = { 
+					slovieni = Námestovo
+					bohemian = Námestovo
+					polish = Namiestowo
+					hungarian = Námeszto
+				}
+				b_liptovskymikulas = { 
+					slovieni = "Liptovský Mikuláš"
+					bohemian = "Liptovský Mikuláš"
+					polish = "Liptowski Mikulasz"
+					german = "Liptau Nikolaus"
+					hungarian = Liptoszentmiklos
+				}
+				b_zolyom = { 
+					slovieni = "Dolný Kubín"
+					bohemian = "Dolný Kubín"
+					hungarian = Alsókubin
+					german = Unterkubin
+				}
+				b_trsztena = { 
+					slovieni = Trstená
+					bohemian = Trstená
+					polish = Trzciana
+					hungarian = Trsztena
+					german = Bingenstadt
+				}
+				b_turdossin = { 
+					slovieni = Tvrdošín
+					bohemian = Tvrdošín
+					hungarian = Turdossin
+					german = Turdoschin
+					polish = Twardoszyn
+				}
+				b_nemetlipcse = { 
+					slovieni = "Nemecká Lupca"
+					bohemian = "Nemecká Lupca"
+					german = Deutschliptsch
+					hungarian = Németlipcse
+				}
+				b_rozsahegy = { 
+					slovieni = Ružomberok
+					bohemian = Ružomberok
+					german = Rosenberg
+					hungarian = Rozsahegy
+					polish = Ruzomberk
+				}
+			}
+		}
+		d_ungvar = {
+			color={ 156 15 15 }
+			color2={ 255 255 255 }
+			
+			capital = 538 # Abauj
+			
+			croatian = Užgorod
+			german = Ungwar
+			bohemian = Užhorod
+			slovieni = Užhorod
+			hungarian = Ungvár
+			polish = Uzhorod
+			
+			c_saris = { # "Spiš" in-game
+				color={ 158 17 17 }
+				color2={ 255 255 255 }
+				
+				german = Zips
+				bohemian = Spiš
+				slovieni = Spiš
+				hungarian = Szepes
+				polish = Spisz
+				
+				b_saris = { 
+					german = Zips
+					bohemian = Spiš
+					slovieni = Spiš
+					hungarian = Szepes
+					polish = Spisz
+				}
+				b_bartfa = { 
+					slovieni = Bardejov
+					bohemian = Bardejov
+					polish = Bardejów
+					german = Bartfeld
+					hungarian = Bártfa
+				}
+				b_kisszeben = { 
+					slovieni = Sabinov
+					bohemian = Sabinov
+					german = Zeben
+					hungarian = Kisszeben
+				}
+				b_eperjes = { 
+					slovieni = Prešov
+					bohemian = Prešov
+					german = Eperies
+					hungarian = Eperjes
+					polish = Preszów
+				}
+				b_scyuidnyk = { 
+					slovieni = Svidník
+					bohemian = Svidník
+					german = Oberswidnik
+					hungarian = Felsovízkoz
+				}
+				b_giralth = { 
+					slovieni = Giraltovce
+					bohemian = Giraltovce
+					hungarian = Girált
+				}
+				b_hethars = { 
+					slovieni = Lipany
+					bohemian = Lipany
+					hungarian = Héthárs
+					german = Siebenlinden
+				}
+				b_lemesany = { 
+					slovieni = Lemešany
+					bohemian = Lemešany
+					hungarian = Lemes
+				}
+			}
+			c_bereg = {
+				color={ 160 19 19 }
+				color2={ 255 255 255 }
+
+				german = Berg
+				bohemian = Berehovo
+				slovieni = Berehovo
+				hungarian = Bereg
+				
+				b_beregszasz = { 
+					german = Berg
+					bohemian = Berehovo
+					slovieni = Berehovo
+					hungarian = Bereg
+				}
+				b_perecseny = { 
+					slovieni = Perecín
+				}
+				b_munkacs = { 
+					slovieni = Mukacevo
+					german = Munkatsch
+				}
+				b_ungvar = { 
+					slovieni = Užhorod
+					german = Ungwar
+				}
+				b_ilosva = { 
+					slovieni = Iršava
+				}
+				b_szolyva = { 
+					slovieni = Svalava
+				}
+				b_szobranc = { 
+					slovieni = Sobrance
+				}
+				b_kapos = { 
+					slovieni = Kapoš
+				}
+			}
+			c_abauj = {
+				color={ 162 21 21 }
+				color2={ 255 255 255 }
+
+				german = Neuburg
+				bohemian = Abov
+				slovieni = Abov
+				hungarian = Abauj
+				
+				b_abauj = { 
+					german = Neuburg
+					bohemian = Abov
+					slovieni = Abov
+					hungarian = Abauj
+				}
+				b_satoraljaujhely = { 
+					slovieni = "Nové Mesto pod Šiatrom"
+					bohemian = "Nové Mesto pod Šiatrom"
+				}
+				b_kassa = { 
+					slovieni = Košice
+					bohemian = Košice
+					polish = Koszyce
+					hungarian = Kassa
+					german = Kaschau
+					croatian = Kašava
+				}
+				b_szikszo = { 
+					slovieni = Siksov
+					bohemian = Siksov
+				}
+				b_turna = { 
+					slovieni = Turna
+					bohemian = Turna
+					german = Tornau
+					hungarian = Torna
+				}
+				b_szepsi = { 
+					slovieni = Moldava
+					bohemian = Moldava
+					hungarian = Szepsi
+					german = Sepschi
+				}
+				b_sarospatak = { 
+					slovieni = Trebišov
+					bohemian = Trebišov
+					german = Trebischau
+					hungarian = Toketerebes
+				}
+				b_tokaj = { 
+					slovieni = Tokaj
+					bohemian = Tokaj
+				}
+			}
+			c_marmaros = {
+				color={ 164 23 23 }
+				color2={ 255 255 255 }
+				
+				german = Maramuresch
+				bohemian = Marmaroš
+				slovieni = Marmaroš
+				hungarian = Máramaros
+				
+				b_maramarossziget = { 
+					slovieni = "Marmarošská Sihot"
+					german = Marmaroschsiget
+				}
+				b_nagybanya = { 
+					slovieni = "Velká Bana"
+					german = Neustadt
+				}
+				b_nagykaroly = { 
+					slovieni = Carei
+				}
+				b_huszt = { 
+					slovieni = Chust
+				}
+				b_aknasugatag = {
+				}
+				b_tecso = {
+				}
+				b_raho = { 
+					slovieni = Rachiv
+				}
+				b_felsoviso = {
+				}
+			}
+		}
+		d_pest = {
+			color={ 150 51 51 }
+			color2={ 255 255 255 }
+			
+			capital = 522 # Pest
+			
+			polish = Peszt
+			slovieni = Pešt
+			bohemian = Pešt
+			serbian = Pešta
+			german = Pest
+			
+			c_heves = {
+				color={ 173 64 64 }
+				color2={ 255 255 255 }
+				
+				german = Hewesch
+				slovieni = Heveš
+				bohemian = Heveš
+				hungarian = Heves
+
+				b_heves = { 
+					german = Hewesch
+					slovieni = Heveš
+					bohemian = Heveš
+					hungarian = Heves
+				}
+				b_eger = { 
+					slovieni = Jáger
+					german = Erlau
+				}
+				b_gyongyos = {
+					german = Gengess
+				}
+				b_miskolc = { 
+					slovieni = Miškovec
+					german = Mischkolz
+				}
+				b_petervasara = {
+				}
+				b_hatvan = {
+				}
+				b_tiszafured = {
+				}
+				b_mezokovesd = {
+				}
+			}
+			c_pest = {
+				color={ 176 67 67 }
+				color2={ 255 255 255 }
+				
+				german = Pest
+				slovieni = Pešt
+				bohemian = Pešt
+				hungarian = Pest
+				serbian = Pešta
+
+				b_pest = {
+					german = Pest
+					slovieni = Pešt
+					bohemian = Pešt
+					hungarian = Pest
+					serbian = Pešta
+				}
+				b_vac = {
+				}
+				b_kecskemet = {
+				}
+				b_kiskunhalas = {
+				}
+				b_szentendre = {
+				}
+				b_cegled = {
+				}
+				b_abrahamtelke = {
+				}
+				b_kiskoros = {
+				}
+			}
+			c_csanad = {
+				color={ 179 70 70 }
+				color2={ 255 255 255 }
+				
+				german = Tschanad
+				slovieni = Canád
+				bohemian = Canád
+				hungarian = Csanád
+
+				b_csanad = {
+				}
+				b_szeged = {
+				}
+				b_mako = {
+				}
+				b_battonya = {
+				}
+				b_csongrad = {
+				}
+				b_mindszent = {
+				}
+				b_szentes = {
+				}
+				b_hodmezovasarhely = {
+				}
+			}
+		}
+		d_transylvania = {
+			color={ 255 150 150 }
+			color2={ 255 255 255 }
+			
+			capital = 519 # Feher
+			
+			c_szekelyfold = {
+				color={ 237 54 54 }
+				color2={ 255 255 255 }
+
+				german = Szeklerland
+				bohemian = Sikulsko
+				slovieni = Sikulsko
+				hungarian = Székelyfold
+				
+				b_csik = {
+				}
+				b_aranyos = {
+				}
+				b_haromszek = {
+				}
+				b_maros = {
+				}
+				b_kezdi = {
+				}
+				b_szekelyudvarhely = {
+				}
+				b_sepsiszentgyorgy = {
+				}
+				b_marosvasarhely = {
+				}
+			}
+			c_bihar = {
+				color={ 241 58 58 }
+				color2={ 255 255 255 }
+				
+				romanian = Bihor
+				german = Bihar
+				bohemian = Biharsko
+				slovieni = Biharsko
+				
+				b_bihar = {
+				}
+				b_nagyvarad = {
+				}
+				b_debrecen = {
+				}
+				b_biharkeresztes = {
+				}
+				b_nagybajom = {
+				}
+				b_szalard = {
+				}
+				b_zolonta = {
+				}
+				b_elesd = {
+				}
+			}
+			c_feher = {
+				color={ 245 62 62 }
+				color2={ 255 255 255 }
+
+				german = Unterweissenburg
+				
+				b_feher = {
+				}
+				b_arad = {
+				}
+				b_gyulafehervar = {
+					romanian = Balgrad
+					german = Karlsburg
+				}
+				b_elek = {
+				}
+				b_abrudbanya = {
+				}
+				b_nagyenyed = {
+					romanian = Aiud
+				}
+				b_vizakna = {
+				}
+				b_tovis = {
+				}
+			}
+		}
+		d_temes = {
+			color={ 147 121 58 }
+			color2={ 255 255 255 }
+			
+			capital = 517 # Temes
+
+			german = Temesch
+			romanian = Timis
+			serbian = Tamis
+			slovieni = Tamiš
+			bohemian = Tamiš
+			
+			c_temes = {
+				color={ 153 127 64 }
+				color2={ 255 255 255 }
+
+				romanian = Timis
+				serbian = Tamis
+				
+				b_temesvar = {
+				}
+				b_lugos = {
+				}
+				b_csak = {
+				}
+				b_buzias = {
+				}
+				b_versecz = {
+				}
+				b_detta = {
+				}
+				b_kevevara = {
+				}
+				b_karansebes = {
+				}
+			}
+			c_bacs = {
+				color={ 156 130 67 }
+				color2={ 255 255 255 }
+
+				hungarian = Bács
+				german = Batsch
+				bohemian = Bac
+				slovieni = Bac
+
+				b_bacs = {
+					slovieni = Bac
+				}
+				b_apatin = {
+				}
+				b_szintarev = {
+				}
+				b_baja = {
+				}
+				b_zombor = {
+				}
+				b_bacsalmas = {
+				}
+				b_pancsova = {
+				}
+				b_pardany = {
+				}
+			}
+		}
+	}
+}
+	
+e_france = {
+	color={ 11 22 170 }
+	color2={ 255 255 20 }
+	
+	capital = 112 # Ile de France
+	
+	culture = frankish
+
+	roman = "Gallia"
+	
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture = frankish
+				culture = norman
+				culture = occitan
+			}
+		}
+		any_demesne_title = {
+			tier = king
+			NOT = { title = k_france }
+			NOT = { title = k_aquitaine }
+			NOT = { title = k_brittany }
+			NOT = { title = k_burgundy }
+		}
+	}
+
+	k_france = {
+		color={ 15 27 187 }
+		color2={ 255 255 20 }
+		
+		capital = 112 # Ile de France
+		dignity = 30 # Counted as having this many more counties than it does
+		
+		culture = frankish
+		
+		catholic = 5000 # Crusade target weight
+		norse_pagan_reformed = 100 # Crusade target weight
+		aztec_reformed = 500
+		
+		d_berry = {
+			color={ 24 52 226 }
+			color2={ 255 255 255 }
+			
+			capital = 140 # Tours
+			
+			c_tourraine = {
+				color={ 27 55 229 }
+				color2={ 255 255 255 }
+				
+				b_chinon = {
+				}
+				b_tours = {
+				}
+				b_beaulieu = {
+				}
+				b_amboise = {
+				}
+				b_loches = {
+				}
+				b_langeais = {
+				}
+				b_fierbois = {
+				}
+				b_montbazon = {
+				}
+			}
+			c_bourges = {
+				color={ 30 58 232 }
+				color2={ 255 255 255 }
+				
+				b_bourges = {
+				}
+				b_deols = {
+				}
+				b_chateauroux = {
+				}
+				b_issoudun = {
+				}
+				b_stsatur = {
+				}
+				b_mehun = {
+				}
+				b_vierzon = {
+				}
+			}
+			c_sancerre = {	#NEW
+				color={ 22 65 240 }
+				color2={ 255 255 255 }
+				
+				b_sancerre = {
+				}
+				b_gien = {
+				}
+				b_cosne = {
+				}
+				b_cours = {
+				}
+				b_pouilly = {
+				}
+				b_assigny = {
+				}
+				b_jars = {
+				}
+			}
+		}
+		d_anjou = {
+			color={ 43 24 226 }
+			color2={ 255 255 255 }
+			
+			capital = 107 # Anjou
+			
+			c_anjou = {
+				color={ 45 26 228 }
+				color2={ 255 255 255 }
+				
+				b_angers = {
+				}
+				b_lude = {
+				}
+				b_graon = {
+				}
+				b_montsoreau = {
+				}
+				b_vihiers = {
+				}
+				b_treves = {
+				}
+				b_chateaugontier = {
+				}
+			}
+			c_saumur = {
+				color={ 65 26 218 }
+				color2={ 255 255 255 }
+				
+				b_saumur = {
+				}
+				b_cholet = {
+				}
+				b_fontevraud-l_abbaye = {
+				}
+				b_doue_la_fontaine = {
+				}
+				b_maulevrier = {
+				}
+				b_beaupreau = {
+				}
+				b_vauchretien = {
+				}
+			}
+			c_maine = {
+				color={ 49 30 232 }
+				color2={ 255 255 255 }
+				
+				b_le_mans = {
+				}
+				b_beaumont = {
+				}
+				b_evron = {
+				}
+				b_mayenne = {
+				}
+				b_laval = {
+				}
+				b_sable = {
+				}
+				b_craon = {
+				}
+				b_montenay = {
+				}
+			}
+			c_perche = {	#NEW
+				color={ 31 16 240 }
+				color2={ 255 255 255 }
+				
+				b_belleme = {
+				}
+				b_mortagne = {
+				}
+				b_nogent_le_rotrou = {
+				}
+				b_luigny = {
+				}
+				b_senonches = {
+				}
+				b_verneuil = {
+				}
+				b_longny = {
+				}
+			}
+			c_vendome = {
+				color={ 47 28 230 }
+				color2={ 255 255 255 }
+				
+				b_lavardin = {
+				}
+				b_vendome = {
+				}
+				b_romilly = {
+				}
+				b_chateaurenault = {
+				}
+				b_montoire = {
+				}
+				b_oucques = {
+				}
+				b_stavit = {
+				}
+			}
+		}
+		d_flanders = {
+			color={ 255 120 0 }
+			color2={ 255 255 255 }
+			
+			capital = 78
+			
+			culture = dutch
+			
+			c_artois = {
+				color={ 234 110 90 }
+				color2={ 255 255 255 }
+				
+				b_arras = {
+				}
+				b_terwaan = {
+				}
+				b_bethune = {
+				}
+				b_lens = {
+				}
+				b_lille = {
+				}
+				b_bouvines = {
+				}
+				b_beaumetz = {
+				}
+				b_bapaume = {
+				}
+			}
+			c_boulogne = {
+				color={ 224 140 90 }
+				color2={ 255 255 255 }
+				
+				b_boulogne = {
+				}
+				b_montreuil = {
+				}
+				b_saintpol = {
+				}
+				b_hesdin = {
+				}
+				b_fauquembergues = {
+				}
+				b_ternouis = {
+				}
+				b_therouanne = {
+				}
+				b_ardres = {
+				}
+			}
+			c_guines = {
+				color={ 194 145 100 }
+				color2={ 255 255 255 }
+				
+				b_guines = {
+				}
+				b_saintomer = {
+				}
+				b_calais = {
+				}
+				b_dunkerque = {
+				}
+				b_bourbourg = {
+				}
+				b_marck = {
+				}
+				b_gravelines = {
+				}
+				b_coulogne = {
+				}
+			}
+			c_yperen = {
+				color={ 194 115 40 }
+				color2={ 255 255 255 }
+				
+				b_ypres = {
+				}
+				b_rosebeke = {
+				}
+				b_cassel = {
+				}
+				b_roeselare = {
+				}
+				b_poperinge = {
+				}
+				b_menen = {
+				}
+				b_diksmuide = {
+				}
+				b_wervik = {
+				}
+			}
+			c_brugge = {
+				color={ 250 120 0 }
+				color2={ 255 255 255 }
+				
+				b_brugge = {
+				}
+				b_damme = {
+				}
+				b_sluys = {
+				}
+				b_oostende = {
+				}
+				b_male = {
+				}
+				b_nieuwpoort = {
+				}
+				b_torhout = {
+				}
+				b_aardenburg = {
+				}
+			}
+			c_gent = {
+				color={ 234 110 5 }
+				color2={ 255 255 255 }
+				
+				b_gent = {
+				}
+				b_doornik = {
+				}
+				b_oudenaarde = {
+				}
+				b_aalst = {
+				}
+				b_st_niklaas = {
+				}
+				b_dendermonde = {
+				}
+				b_kortrijk = {
+				}
+				b_geraardsbergen = {
+				}
+			}
+		}
+		d_normandy = {
+			color={ 71 24 226 }
+			color2={ 255 255 255 }
+			
+			capital = 97 # Rouen
+			
+			culture = norman
+			
+			c_evreux = {
+				color={ 74 27 229 }
+				color2={ 255 255 255 }
+				
+				b_evreux = {
+				}
+				b_falaise = {
+				}
+				b_lisieux = {
+				}
+				b_alencon = {
+				}
+				b_argentan = {
+				}
+				b_sees = {
+				}
+				b_honfleur = {
+				}
+			}
+			c_avranches = {
+				color={ 77 30 232 }
+				color2={ 255 255 255 }
+				
+				b_mortain = {
+				}
+				b_avranches = {
+				}
+				b_barfleur = {
+				}
+				b_cherbourg = {
+				}
+				b_coutances = {
+				}
+				b_carentan = {
+				}
+				b_barneville-carteret = {
+				}
+			}
+			c_caen = {	#NEW
+				color={ 90 27 240 }
+				color2={ 255 255 255 }
+				
+				b_caen = {
+				}
+				b_bayeux = {
+				}
+				b_domfront = {
+				}
+				b_vire = {
+				}
+				b_clecy = {
+				}
+				b_jurques = {
+				}
+				b_villers-bocage = {
+				}
+			}
+			c_vexin = {
+				color={ 80 33 235 }
+				color2={ 255 255 255 }
+				
+				b_larocheguyon = {
+				}
+				b_mantes = {
+				}
+				b_pontoise = {
+				}
+				b_harcourt = {
+				}
+				b_andely = {
+				}
+				b_ivry = {
+				}
+				b_abbayedemortemer = {
+				}
+			}
+			c_arques = { # actually Rouen
+				color={ 83 36 238 }
+				color2={ 255 255 255 }
+				
+				b_fecamp = {
+				}
+				b_rouen = {
+				}
+				b_lillebonne = {
+				}
+				b_harfleur = {
+				}
+				b_arques = {
+				}
+				b_dieppe = {
+				}
+				b_jumieges = {
+				}
+				b_longueville = {
+				}
+			}
+			c_eu = {
+				color={ 86 39 241 }
+				color2={ 255 255 255 }
+				
+				b_eu = {
+				}
+				b_mortemer = {
+				}
+				b_gournay = {
+				}
+				b_aumale = {
+				}
+				b_forges = {
+				}
+				b_drincourt = {
+				}
+				b_neufchatel-en-bray = {
+				}
+				b_serqueux = {
+				}
+			}
+		}
+		d_orleans = {
+			color={ 126 124 226 }
+			color2={ 255 255 255 }
+			
+			capital = 110 # Blois
+			
+			c_blois = {
+				color={ 90 28 230 }
+				color2={ 255 255 255 }
+				
+				b_blois = {
+				}
+				b_staignan = {
+				}
+				b_beaugency = {
+				}
+				b_chaumontsurloire = {
+				}
+				b_stgeorgesdubois = {
+				}
+				b_montrichard = {
+				}
+				b_fougeressurbievre = {
+				}
+				b_romorantin = {
+				}
+			}
+			c_chartres = {
+				color={ 98 36 238 }
+				color2={ 255 255 255 }
+				
+				b_bretigny = {
+				}
+				b_chartres = {
+				}
+				b_dreux = {
+				}
+				b_nogent = {
+				}
+				b_gallardon = {
+				}
+				b_epernon = {
+				}
+				b_le_coudray = {
+				}
+			}
+			c_dunois = {	#NEW
+				color={ 83 45 215 }
+				color2={ 255 255 255 }
+				
+				b_chateaudun = {
+				}
+				b_freteval = {
+				}
+				b_tiron = {
+				}
+				b_cloyes = {
+				}
+				b_bonneval = {
+				}
+				b_patay = {
+				}
+				b_marchenoir = {
+				}
+			}
+		}
+		d_champagne = {
+			color={ 95 24 226 }
+			color2={ 255 255 255 }
+			
+			capital = 114 # Reims
+			
+			c_troyes = {
+				color={ 99 28 230 }
+				color2={ 255 255 255 }
+				
+				b_troyes = {
+				}
+				b_brienne = {
+				}
+				b_langres = {
+				}
+				b_chaumont = {
+				}
+				b_clairvaux = {
+				}
+				b_rosnay = {
+				} 
+				b_chacenay = {
+				}
+			}
+			c_reims = {
+				color={ 101 30 232 }
+				color2={ 255 255 255 }
+				
+				b_reims = {
+				}
+				b_chatillon = {
+				}
+				b_rethel = {
+				}
+				b_chalons = {
+				}
+				b_attigny = {
+				}
+				b_epernay = {
+				}
+				b_roucy = {
+				}
+				b_dampierre = {
+				}
+			}
+			c_brie = {	#NEW
+				color={ 95 20 240 }
+				color2={ 255 255 255 }
+				
+				b_provins = {
+				}
+				b_meaux = {
+				}
+				b_sezanne = {
+				}
+				b_chateauthierry = {
+				}
+				b_montmirail = {
+				}
+				b_vertus = {
+				}
+				b_nogent_sur_marne = {
+				}
+			}
+		}
+		d_picardie = {
+			color={ 15 101 188 }
+			color2={ 255 255 255 }
+			
+			capital = 95 # Amiens
+			
+			c_vermandois = {
+				color={ 41 147 214 }
+				color2={ 255 255 255 }
+				
+				b_coucy = {
+				}
+				b_stquentin = {
+				}
+				b_laon = {
+				}
+				b_montaigu = {
+				}
+				b_gauchy = {
+				}
+				b_guise = {
+				}
+				b_signy = {
+				}
+			}
+			c_amiens = {
+				color={ 44 151 217 }
+				color2={ 255 255 255 }
+				
+				b_peronne = {
+				}
+				b_amiens = {
+				}
+				b_noyon = {
+				}
+				b_corbie = {
+				}
+				b_montdidier = {
+				}
+				b_breteuil = {
+				}
+				b_nesle = {
+				}
+				b_soissons = {}
+			}
+			c_clermont = {	#NEW
+				color={ 39 140 250 }
+				color2={ 255 255 255 }
+				
+				b_clermont_PIC = {
+				}
+				b_gisors = {
+				}
+				b_beauvais = {
+				}
+				b_tille = {
+				}
+				b_nogent_sur_oise = {
+				}
+				b_chelles = {
+				}
+				b_noailles = {
+				}
+			}
+			c_ponthieu = {	#NEW
+				color={ 35 130 240 }
+				color2={ 255 255 255 }
+				
+				b_abbeville = {
+				}
+				b_saint-valery = {
+				}
+				b_le_treport = {
+				}
+				b_montreuil_PdC = {
+				}
+				b_le_crotoy = {
+				}
+				b_flixecourt = {
+				}
+				b_ault = {
+				}
+			}
+		}
+		d_valois = {
+			color={ 35 141 208 }
+			color2={ 255 255 255 }
+			capital = 112 # Ile de France
+
+			c_ile_de_france = {
+				color={ 38 144 211 }
+				color2={ 255 255 255 }
+
+				holy_site = aztec
+				holy_site = aztec_reformed
+				
+				b_paris = {
+					used_for_dynasty_names = no
+				}
+				b_melun = {
+				}
+				b_stdenis = {
+				}
+				b_etampes = {
+				}
+				b_montfortlamaury = {
+				}
+				b_corbeil = {
+				}
+				b_montlhery = {
+				}
+			}
+			c_orleans = {
+				color={ 94 32 234 }
+				color2={ 255 255 255 }
+				
+				b_orleans = {
+				}
+				b_fleury = {
+				}
+				b_lepuiset = {
+				}
+				b_sully = {
+				}
+				b_meung = {
+				}
+				b_janville = {
+				}
+				b_jargeau = {
+				}
+			}
+			c_sens = {
+				color={ 102 40 242 }
+				color2={ 255 255 255 }
+				
+				b_montargis = {
+				}
+				b_sens = {
+				}
+				b_nemours = {
+				}
+				b_chateaulandon = {
+				}
+				b_nogentsurseine = {
+				}
+				b_joigny = {
+				}
+				b_montereau = {
+				}
+				b_villeneuveleroi = {
+				}
+			}
+			c_senlis = {	#NEW
+				color={ 68 164 235 }
+				color2={ 255 255 255 }
+				
+				b_senlis = {
+				}
+				b_beaumont_IdF = {
+				}
+				b_compiegne = {
+				}
+				b_crepy = {
+				}
+				b_creil = {
+				}
+				b_roissy = {
+				}
+				b_chantilly = {
+				}
+			}
+		}
+		d_burgundy = {
+			# French, or Lower Burgundy
+			color={ 153 67 108 }
+			color2={ 255 255 255 }
+			capital = 136 # Dijon
+			
+			c_chalons = {
+				color={ 161 22 60 }
+				color2={ 255 255 255 }
+				
+				b_brancion = {
+				}
+				b_chalon = {
+				}
+				b_tournus = {
+				}
+				b_louhans = {
+				}
+				b_chamilly = {
+				}
+				b_seurre = {
+				}
+				b_stjeandelosne = {
+				}
+				b_cuisery = {
+				}
+			}
+			
+			c_auxerre = {
+				color={ 97 26 228 }
+				color2={ 255 255 255 }
+				
+				b_auxerre = {
+				}
+				b_druyes = {
+				}
+				b_tonnerre = {
+				}
+				b_pontigny = {
+				}
+				b_cravant = {
+				}
+				b_crisenon = {
+				}
+				b_stsauveurenpuisaye = {
+				}
+				b_mailly = {
+				}
+			}
+			c_macon = {
+				color={ 27 165 229 }
+				color2={ 255 255 255 }
+				
+				b_fuisse = {
+				}
+				b_macon = {
+				}
+				b_cluny = {
+					coat_of_arms=
+					{
+						data=
+						{
+						0 4 12 45 2 2 2 0 0 19 2 1 3 0 0 19 2 1 3 0 0 19 2 1 3
+						}
+						religion="catholic"
+					}
+				}
+				b_davaye = {
+				}
+				b_beaujeu = {
+				}
+				b_lugny = {
+				}
+				b_berze = {
+				}
+				b_villefranchesursaone = {
+				}
+			}
+			c_dijon = {
+				color={ 30 168 232 }
+				color2={ 255 255 255 }
+				
+				b_semur = {
+				}
+				b_dijon = {
+				}
+				b_autun = {
+				}
+				b_vezelay = {
+				}
+				b_avallon = {
+				}
+				b_citeaux = {
+				}
+				b_beaune = {
+				}
+				b_noyers = {
+				}
+			}
+			c_nevers = {
+				color={ 33 171 235 }
+				color2={ 255 255 255 }
+				
+				b_courtenay = {
+				}
+				b_nevers = {
+				}
+				b_lacharite = {
+				}
+				b_donzy = {
+				}
+				b_chateauchinon = {
+				}
+				b_vandenesse = {
+				}
+				b_clamecy = {
+				}
+			}
+			c_charolais = {
+				color={ 36 174 238 }
+				color2={ 255 255 255 }
+				
+				b_montstvincent = {
+				}
+				b_charolles = {
+				}
+				b_paray = {
+				}
+				b_semurenbrionnais = {
+				}
+				b_toulonsurarroux = {
+				}
+				b_perrecy = {
+				}
+				b_digoine = {
+				}
+				b_joncy = {
+				}
+			}
+		}
+	}
+	
+	k_aquitaine = {
+		color={ 150 80 170 }
+		color2={ 255 255 20 }
+		capital = 149 # Bordaeux
+		
+		culture = occitan
+
+		roman = "Aquitania"
+		
+		catholic = 4000 # Crusade target weight
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					NOT = { has_landed_title = k_france }
+					AND = {
+						has_landed_title = k_france
+						has_landed_title = k_burgundy
+						any_demesne_title = {
+							tier = king
+							NOT = { title = k_france }
+							NOT = { title = k_aquitaine }
+							NOT = { title = k_brittany }
+							NOT = { title = k_burgundy }
+						}
+					}
+				}
+			}
+		}
+		
+		d_aquitaine = {
+			color={ 54 10 243 }
+			color2={ 255 255 255 }
+			dignity = 10 # Counted as having 10 more counties than it does
+			capital = 149 # Bordaeux
+			
+			culture = occitan
+			
+			c_bordeaux = {
+				color={ 58 14 247 }
+				color2={ 255 255 255 }
+				
+				b_castillon = {
+				}
+				b_bordeaux = {
+				}
+				b_stemilion = {
+				}
+				b_blaye = {
+				}
+				b_bourg = {
+				}
+				b_lasauve = {
+				}
+				b_lareole = {
+				}
+				b_libourne = {
+				}
+			}
+			c_agen = {
+				color={ 62 18 251 }
+				color2={ 255 255 255 }
+				
+				b_agen = {
+				}
+				b_penne = {
+				}
+				b_cahors = {
+				}
+				b_luzech = {
+				}
+				b_moissac = {
+				}
+				b_figeac = {
+				}
+				b_rocamadour = {
+				}
+				b_blanquefort = {
+				}
+			}
+			c_perigord = {
+				color={ 66 22 255 }
+				color2={ 255 255 255 }
+				
+				b_baneuil = {
+				}
+				b_perigueux = {
+				}
+				b_sarlat = {
+				}
+				b_biron = {
+				}
+				b_auberoche = {
+				}
+				b_bergerac = {
+				}
+				b_chancelade = {
+				}
+				b_bonaguil = {
+				}
+			}
+			c_angouleme = {
+				color={ 70 26 255 }
+				color2={ 255 255 255 }
+				
+				b_jarnac = {
+				}
+				b_angouleme = {
+				}
+				b_bassac = {
+				}
+				b_larochefoucauld = {
+				}
+				b_cognac = {
+				}
+				b_richemont = {
+				}
+				b_fontdouce = {
+				}
+				b_latranchade = {
+				}
+			}
+		}
+		d_toulouse = {
+			color={ 10 16 243 }
+			color2={ 255 255 255 }
+			
+			capital = 214 # Toulouse
+			
+			culture = occitan
+			
+			c_montpellier = {
+				color={ 10 16 243 }
+				color2={ 255 255 255 }
+				
+				b_beaucaire = {
+				}
+				b_montpellier = {
+				}
+				b_maguelone = {
+				}
+				b_nimes = {
+				}
+				b_aiguesmortes = {
+				}
+				b_bagnolssurceze = {
+				}
+				b_saintguilhemledesert = {
+				}
+				b_melgueil = {
+				}
+			}
+			c_narbonne = {
+				color={ 14 20 247 }
+				color2={ 255 255 255 }
+				
+				b_albi = {
+				} 
+				b_narbonne = {
+				} 
+				b_agde = {
+				} 
+				b_beziers = {
+				} 
+				b_puisserguier = {
+				} 
+				b_stponsdethomieres = {
+				} 
+				b_castres = {
+				} 
+				b_queribus = {
+				} 
+			}
+			c_carcassonne = {
+				color={ 16 22 249 }
+				color2={ 255 255 255 }
+				
+				b_saissac = {
+				} 
+				b_carcassonne = {
+				} 
+				b_alet = {
+				} 
+				b_termes = {
+				} 
+				b_lagrasse = {
+				} 
+				b_lastours = {
+				} 
+				b_cabaret = {
+				} 
+				b_minerve = {
+				}
+			}
+			c_toulouse = {
+				color={ 18 24 251 }
+				color2={ 255 255 255 }
+				
+				b_castelnaudary = {
+				} 
+				b_toulouse = {
+				} 
+				b_lavaur = {
+				} 
+				b_montauban = {
+				} 
+				b_lombez = {
+				} 
+				b_hautpoul = {
+				} 
+				b_montgiscard = {
+				} 
+				b_muret = {
+				} 
+			}
+			c_rouergue = {
+				color={ 20 28 253 }
+				color2={ 255 255 255 }
+				
+				b_rodez = {
+				} 
+				b_millau = {
+				} 
+				b_vabres = {
+				} 
+				b_najac = {
+				} 
+				b_villefranche = {
+				} 
+				b_caylus = {
+				} 
+				b_staffrique = {
+				} 
+				b_estaing = {
+				} 
+			}
+			c_foix = {
+				color={ 24 13 246 }
+				color2={ 255 255 255 }
+				
+				b_foix = {
+				} 
+				b_pamiers = {
+				} 
+				b_mirepoix = {
+				} 
+				b_montsegur = {
+				} 
+				b_stbertrand = {
+				}  
+				b_roquefeuil = {
+				} 
+				b_stgaudens = {
+				}  
+				b_usson = {
+				} 
+			}
+		}
+		d_gascogne = {
+			color={ 81 30 243 }
+			color2={ 255 255 255 }
+			
+			capital = 209 # Armagnac
+			
+			culture = occitan
+			
+			c_bearn = {
+				color={ 27 16 249 }
+				color2={ 255 255 255 }
+				
+				b_pau = {
+				}
+				b_morlaas = {
+				} 
+				b_lescar = {
+				}
+				b_tarbes = {
+				}
+				b_mauleonlicharre = {
+				}
+				b_orthez = {
+				}
+				b_oloron = {
+				}
+				b_montaner = {
+				}
+			}
+			c_armagnac = {
+				color={ 30 19 252 }
+				color2={ 255 255 255 }
+				
+				b_castelnau = {
+				}
+				b_auch = {
+				}
+				b_condom = {
+				}
+				b_lectoure = {
+				}
+				b_lisle = {
+				}
+				b_eauze = {
+				}
+				b_mirande = {
+				}
+				b_laplume = {
+				}
+			}
+			c_labourd = {
+				color={ 33 22 255 }
+				color2={ 255 255 255 }
+				
+				b_sauveterre = {
+				}
+				b_bayonne = {
+				}
+				b_stsever = {
+				}
+				b_dax = {
+				}
+				b_aire = {
+				}
+				b_labastideclairence = {
+				}
+				b_sorde = {
+				}
+				b_hasparren = {
+				}
+			}
+			c_albret = {
+				color={ 36 25 255 }
+				color2={ 255 255 255 }
+				
+				b_labrit = {
+				}
+				b_tartas = {
+				}
+				b_bazas = {
+				}
+				b_roquefort = {
+				}
+				b_montdemarsan = {
+				}
+				b_gabarret = {
+				}
+				b_mimizan = {
+				}
+				b_latestedebuch = {
+				}
+			}
+		}
+		d_poitou = {
+			color={ 24 95 226 }
+			color2={ 255 255 255 }
+			
+			capital = 141 # Poitiers
+			
+			culture = occitan
+			
+			c_lusignan = {
+				color={ 28 97 228 }
+				color2={ 255 255 255 }
+				
+				b_lusignan = {
+				}
+				b_charroux = {
+				}
+				b_niort = {
+				}
+				b_melle = {
+				}
+				b_civray = {
+				}
+				b_maillezais = {
+				}
+				b_confolens = {
+				}
+				b_stmaixent = {
+				}
+			}
+			c_saintonge = {
+				color={ 30 99 230 }
+				color2={ 255 255 255 }
+				
+				b_montguyon = {
+				}
+				b_saintes = {
+				}
+				b_stjeandangely = {
+				}
+				b_villeneuve = {
+				}
+				b_tonnay = {
+				}
+				b_aulnay = {
+				}
+				b_royan = {
+				}
+				b_taillebourg = {
+				}
+			}
+			c_poitiers = {
+				color={ 32 101 232 }
+				color2={ 255 255 255 }
+				
+				b_chauvigny = {
+				}
+				b_poitiers = {
+				}
+				b_stsavin = {
+				}
+				b_moncontour = {
+				}
+				b_mirebeau = {
+				}
+				b_parthenay = {
+				}
+				b_loudun = {
+				}
+				b_chatellerault = {
+				}
+			}
+			c_thouars = {
+				color={ 34 103 234 }
+				color2={ 255 255 255 }
+				
+				b_thouars = {
+				}
+				b_larochelle = {
+				}
+				b_lucon = {
+				}
+				b_chatelaillon = {
+				}
+				b_bressuire = {
+				}
+				b_olonne = {
+				}
+				b_mauleon = {
+				}
+				b_fontenay = {
+				}
+			}
+		}
+		d_auvergne = {
+			color={ 24 171 226 }
+			color2={ 255 255 255 }
+			
+			capital = 217 # Auvergne
+			
+			culture = occitan
+			
+			c_auvergne = {
+				color={ 26 173 228 }
+				color2={ 255 255 255 }
+				
+				b_clermont = {
+				}
+				b_montferrand = {
+				}
+				b_brioude = {
+				}
+				b_tournoel = {
+				}
+				b_mozac = {
+				}
+				b_murol = {
+				}
+				b_domeyrat = {
+				}
+			}
+			c_gevaudan = {
+				color={ 28 175 230 }
+				color2={ 255 255 255 }
+				
+				b_grezes = {
+				}
+				b_mende = {
+				}
+				b_lepuy = {
+				}
+				b_apchier = {
+				}
+				b_marvejols = {
+				}
+				b_florac = {
+				}
+				b_stsauveur = {
+				}
+				b_tournel = {
+				}
+			}
+			c_aurillac = {
+				color={ 38 165 220 }
+				color2={ 255 255 255 }
+				
+				b_aurillac = {
+				}
+				b_carlat = {
+				}
+				b_murat = {
+				}
+				b_saint-flour = {
+				}
+				b_la_tour = {
+				}
+				b_issoire = {
+				}
+				b_mauriac = {
+				}
+			}
+		}
+		d_bourbon = {
+			color={ 74 133 186 }
+			color2={ 255 255 255 }
+			
+			capital = 146 # Bourbon
+			
+			c_bourbon = {
+				color={ 28 147 230 }
+				color2={ 255 255 255 }
+				
+				b_bourbon = {
+				}
+				b_moulins = {
+				}
+				b_lancy = {
+				}
+				b_montlucon = {
+				}
+				b_vichy = {
+				}
+				b_souvigny = {
+				}
+				b_montpensier = {
+				}
+			}
+			c_limousin = {
+				color={ 32 151 234 }
+				color2={ 255 255 255 }
+				
+				b_turenne = {
+				}
+				b_limoges = {
+				}
+				b_comborn = {
+				}
+				b_rochechouart = {
+				}
+				b_thiviers = {
+				}
+				b_stleonard = {
+				}
+				b_ventadour = {
+				}
+				b_chalus = {
+				}
+			}
+			c_la_marche = {
+				color={ 36 155 240 }
+				color2={ 255 255 255 }
+				
+				b_crozant = {
+				}
+				b_bellac = {
+				}
+				b_gueret = {
+				}
+				b_aubusson = {
+				}
+				b_boussac = {
+				}
+				b_lasouterraine = {
+				}
+				b_bourganeuf = {
+				}
+				b_jouillat = {
+				}
+			}
+		}
+	}
+	
+	k_brittany = {
+		color={ 165 49 16 }
+		color2={ 255 255 255 }
+		
+		capital = 105 # Vannes
+		
+		culture = breton
+		
+		catholic = 300 # Crusade target weight
+		
+		breton = Breizh
+		norse = Bertangaland
+		welsh = Arymôr
+		irish = Bhriotáin
+		frankish = Bretagne
+		roman = Armorica
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = celtic
+				}
+			}
+		}
+		
+		d_loire = {	
+			color = { 140 20 5 }
+			color2 = {255 255 255}
+			
+			capital = 106 # Nantes
+			
+			culture = breton
+
+			norse = Namsborg
+			norwegian = Namsborg
+			swedish = Namsborg
+			danish = Namsborg
+			
+			c_nantes = {
+				color={ 170 50 23 }
+				color2={ 255 255 255 }
+				
+				breton = Naoned
+				norse = Namsborg
+				norwegian = Namsborg
+				swedish = Namsborg
+				danish = Namsborg
+				
+				b_nantes = {
+					breton = Naoned
+				}
+				b_chateaubriant = {
+					breton = Kastell-Briant
+				}
+				b_redon = {
+					breton = Ridined
+				}
+				b_guerande = {
+					breton = Gwennrann
+				}
+				b_donges = {
+					breton = Dined
+				}
+				b_la_roche-bernard = {
+					breton = "Ar Roc'h-Bernez"
+				}
+				b_st_nazaire = {
+					breton = "Sant-Nazer"
+				}
+			}
+			c_rennes = {
+				color={ 106 42 8 }
+				color2={ 255 255 255 }
+				
+				breton = "Roazhon"
+				
+				b_rennes = {
+					breton = "Roazhon"
+				}
+				b_fougeres = {
+					breton = "Felger"
+				}
+				b_st_michel = {
+					breton = "Sant-Mikael"
+				}
+				b_st_malo = {
+					breton = "Sant-Maloù"
+				}
+				b_dol = {
+				}
+				b_dinan = {
+				}
+				b_st_meen = {
+					breton = "Sant-Méen"
+				}
+				b_porhoet = {
+				}
+			}
+			c_retz = {	#NEW
+				color={ 122 45 10 }
+				color2={ 255 255 255 }
+				
+				b_reze = {
+				}
+				b_machecoul = {
+				}
+				b_clisson = {
+					breton = Klison
+				}
+				b_pornic = {
+				}
+				b_deas = {
+				}
+				b_la_bernerie = {
+				}
+				b_saint_brevin = {
+				}
+			}
+		}
+		d_brittany = {
+			color={ 159 75 34 }
+			color2={ 255 255 255 }
+			
+			capital = 104 # Cornouaille
+			
+			culture = breton
+			
+			c_cornouaille = {
+				color={ 126 27 9 }
+				color2={ 255 255 255 }
+				
+				breton = "Kernev"
+				
+				b_quimper = {
+					breton = "Kemper"
+				}
+				b_quimperle = {
+					breton = "Kemperle"
+				}
+				b_landevennec = {
+					breton = "Landevenneg"
+				}
+				b_lezergue = {
+					breton = "An Erge Vras"
+				}
+				b_concarneau = {
+				}
+				b_chateaulin = {
+				}
+				b_douarnenez = {
+				}
+			}
+			c_french_leon = {
+				color={ 166 67 14 }
+				color2={ 255 255 255 }
+				
+				b_brest = {
+				}
+				b_st_pol_de_leon = {
+					breton = "Kastell-Paol"
+				}
+				b_morlaix = {
+					breton = "Montroulez"
+				}
+				b_roscoff = {
+					breton = "Rosko"
+				}
+				b_landerneau = {
+				}
+				b_plouescat = {
+				}
+				b_breles = {
+				}
+
+			}
+			c_poher = {
+				color={ 133 84 19 }
+				color2={ 255 255 255 }
+				
+				b_corlay = {
+					breton = "Korle"
+				}
+				b_carhaix = {
+					breton = "Karaez"
+				}
+				b_langonnet = {
+					breton = "Langoned"
+				}
+				b_huelgoat = {
+					breton = "An Uhelgoad"
+				}
+				b_plouguer = {
+				}
+				b_chateauneuf_du_faou = {
+				}
+				b_rostrenen = {
+				}
+			}
+			c_vannes = {
+				color={ 140 30 13 }
+				color2={ 255 255 255 }
+
+				breton = Broërec
+				welsh = Guened
+				
+				b_vannes = {
+					breton = "Gwened"
+					welsh = "Guened"
+				}
+				b_josselin = {
+					breton = "Josilin"
+				}
+				b_st_gildas = {
+					breton = "Lokentaz"
+				}
+				b_locmine = {
+					breton = "Logunec'h"
+				}
+				b_hennebont = {
+					breton = "Henbont"
+				}
+				b_pontivy = {
+					breton = "Pondi"
+				}
+				b_auray = {
+					breton = "An Alre"
+				}
+				b_ploermel = {
+					breton = "Ploermael"
+				}
+			}
+		}
+		d_penthievre = {
+			color={ 170 54 26 }
+			color2={ 255 255 255 }
+			
+			capital = 104 # Penthievre
+			
+			culture = breton
+			
+			breton = Penteur
+			welsh = Domnonia
+			
+			c_penthievre = {
+				color={ 176 79 24 }
+				color2={ 255 255 255 }
+				
+				breton = Domnonea
+				welsh = Domnonia
+				
+				b_verdelet = {
+					breton = "Sentiles"
+				}
+				b_st_brieuc = {
+					breton = "Sant-Brieg"
+				}
+				b_monkontour = {
+				}
+				b_peran = {
+					breton = "Sant-Pêran"
+				}
+				b_loudeac = {
+				}
+				b_paimpol = {
+				}
+				b_chatelaudren = {
+					breton = "Kastellaodren"
+				}
+				b_quintin = {
+					breton = "Kintin"
+				}
+			}
+			c_tregor = {
+				color={ 185 56 30 }
+				color2={ 255 255 255 }
+								
+				b_guingamp = {
+					breton = "Gwengamp"
+				}
+				b_treguier = {
+					breton = "Landreger"
+				}
+				b_plougonven = {
+				}
+				b_plourivo = {
+					breton = "Plourivoù"
+				}
+				b_lannion = {
+				}
+				b_pedernec = {
+				}
+				b_locquirec = {
+				}
+			}
+		}
+	}
+	
+	k_burgundy = {
+		color={ 134 0 37 }
+		color2={ 220 220 0 }
+		
+		capital	= 221 # Provence
+		
+		culture = occitan
+
+		roman = "Lugdunensis"
+		
+		catholic = 5000 # Crusade target weight
+		
+		d_provence = {
+			color={ 145 37 20 }
+			color2={ 255 255 255 }
+			
+			capital = 221 # Provence
+			
+			c_provence = {
+				color={ 149 40 70 }
+				color2={ 255 255 255 }
+				
+				b_arles = {
+				}
+				b_aix = {
+				}
+				b_marseille = {
+				}
+				b_grimaud = {
+				}
+				b_frejus = {
+				}
+				b_grasse = {
+				}
+				b_castellane = {
+				}
+				b_tarascon = {
+				}
+			}
+			c_forcalquier = {
+				color={ 151 42 72 }
+				color2={ 255 255 255 }
+				
+				b_forcalquier = {
+				}
+				b_nyons = {
+				}
+				b_embrun = {
+				}
+				b_sisteron = {
+				}
+				b_briancon = {
+				}
+				b_vaison = {
+				}
+				b_gap = {
+				}
+				b_apt = {
+				}
+			}
+			c_venaissin = {
+				color={ 153 44 74 }
+				color2={ 255 255 255 }
+				
+				b_orange = {
+				}
+				b_avignon = {
+				}
+				b_cavaillon = {
+				}
+				b_venasque = {
+				}
+				b_carpentras = {
+				}
+				b_chateauneufdupape = {
+				}
+				b_stpaul = {
+				}
+				b_mondragon = {
+				}
+			}
+			c_nice = {
+				color={ 147 39 69 }
+				color2={ 255 255 255 }
+				
+				b_nizza = {
+				}
+				b_monaco = {
+				}
+				b_mentone = {
+				}
+				b_antibes = {
+				}
+				b_campogrosso = {
+				}
+				b_lantosque = {
+				}
+				b_contes = {
+				}
+			}
+		}
+		d_savoie = {
+			color={ 101 8 34 }
+			color2={ 255 255 255 }
+			
+			capital = 237 # Savoie
+			
+			c_savoie = {
+				color={ 107 15 140 }
+				color2={ 255 255 255 }
+				
+				b_chambery = {
+					italian = "Ciamberi"
+				}
+				b_faucigny = {
+					italian = "Focegno"
+				}
+				b_tarentaise = {
+				}
+				b_conflens = {
+				}
+				b_thonon = {
+				}
+				b_st_jean = {
+					italian = "San Giovanni"
+				}
+				b_cluses = {
+				}
+				b_aix_savoie = {
+				}
+			}
+			c_valais = {
+				color={ 110 18 44 }
+				color2={ 255 255 255 }
+
+				german = "Wallis"
+				italian = "Vallese"
+				
+				b_brig = {
+					frankish = "Brig"
+				}
+				b_monthey = {
+				}
+				b_aigle = {
+					german = "Älen"
+				}
+				b_martigny = {
+				}
+				b_siders = {
+				}
+				b_sitten = {
+					frankish = "Sion"
+				}
+				b_greyerz = {
+				}
+			}
+			c_geneve = {
+				color={ 113 21 47 }
+				color2={ 255 255 255 }
+
+				german = "Genfergau"
+				italian = "Ginevresi"
+				
+				b_geneve = {
+					frankish = "Genève"
+					german = "Genf"
+					italian = "Ginvera"
+				}
+				b_nyon = {
+				}
+				b_aubonne = {
+				}
+				b_yvoire = {
+				}
+				b_annecy = {
+				}
+				b_thonex = {
+				}
+				b_meinier = {
+				}				
+			}
+			c_aosta = {
+				color={ 118 18 50 }
+				color2={ 255 255 255 }
+
+				frankish = "Aoste"
+				german = "Augschtal"
+
+				b_fenis = {
+				}
+				b_aosta = {
+					frankish = "Aoste"
+					german = "Augschtal"
+				}
+				b_st_jacqueme = {
+					italian = "St-Giacomo"
+				}
+				b_st_ours = {
+				}
+				b_aostachatillon = {
+					italian = "Chastiglioni"
+				}
+				b_st_pierre = {
+					italian = "San Pietro"
+				}
+				b_chatel_argent = {
+				}
+				b_arnad = {
+				}
+			}
+		}
+		
+		d_dauphine = {
+			color={ 87 29 45 }
+			color2={ 255 255 255 }
+			
+			capital = 227 # Lyon
+
+			roman = "Lugdunensis"
+			
+			c_dauphine_viennois = {
+				color={ 119 30 54 }
+				color2={ 255 255 255 }
+				
+				b_montelimar = {
+				}
+				b_vienne = {
+				}
+				b_valence = {
+				}
+				b_grenoble = {
+				}
+				b_chartreuse = {
+				}
+				b_albon = {
+				}
+				b_stantoine = {
+				}
+				b_valreas = {
+				}
+			}
+			c_lyon = {
+				color={ 123 34 58 }
+				color2={ 255 255 255 }
+
+				roman = "Lugdunum"
+				
+				b_brindas = {
+				}
+				b_stjeanbaptiste = {
+				}
+				b_lyon = {
+					roman = "Lugdunum"
+				}
+				b_anse = {
+				}
+				b_chessy = {
+				}
+				b_lacenas = {
+				}
+				b_pusignan = {
+				}
+				b_irigny = {
+				}
+			}
+			c_forez = {
+				color={ 127 38 62 }
+				color2={ 255 255 255 }
+				
+				b_couzan = {
+				}
+				b_montbrison = {
+				}
+				b_thiers = {
+				}
+				b_feurs = {
+				}
+				b_roanne = {
+				}
+				b_charlieu = {
+				}
+				b_chalmazel = {
+				}
+				b_stetienne = {
+				}
+			}
+			c_viviers = {
+				color={ 12 18 245 }
+				color2={ 255 255 255 }
+				
+				b_aubenas = {
+				}
+				b_tournon = {
+				}
+				b_viviers = {
+				}
+				b_albalaromaine = {
+				}
+				b_privas = {
+				}
+				b_lecheylard = {
+				}
+				b_largentiere = {
+				}
+				b_joyeuse = {
+				}
+			}
+		}
+		d_franche_comte = {
+			color={ 115 34 45 }
+			color2= { 80 80 200 }
+
+			capital = 135 #Besancon
+
+			c_besancon = {
+				color={ 171 32 70 }
+				color2={ 255 255 255 }
+				
+				b_besancon = {
+				}
+				b_marchaux = {
+				}
+				b_bellevaux = {
+				}
+				b_pontarlier = {
+				}
+				b_arlay = {
+				}
+				b_maiche = {
+				}
+				b_morteau = {
+				}
+			}
+			c_amous = {
+				color= { 171 20 80 }
+				color2={ 255 255 255 }
+
+				b_dole = {
+				}
+				b_saintylie = {
+				}
+				b_jouhe = {
+				}
+				b_chamaves = {
+				}
+				b_amaous = {
+				}
+				b_notredame = {
+				}
+				b_gray = {
+				}
+			}
+			c_escuens = {
+				color={ 130 80 20 }
+				color2= { 255 255 255 }
+
+				b_salins = {
+				}
+				b_poligny = {
+				}
+				b_saint_claude = {
+				}
+				b_belin = {
+				}
+				b_bracon = {
+				}
+				b_guyon = {
+				}
+				b_pin = {
+				}
+				b_frontenay = {
+				}
+				b_nozeroy = {
+				}
+			}
+			c_montbeliard = {
+				color={ 171 30 20 }
+				color2={ 255 255 255 }
+
+				b_montbeliard = {
+				}
+
+				b_layre = {
+				}
+
+				b_arbouans = {
+				}
+
+				b_exincourt = {
+				}
+
+				b_etupes = {
+				}
+
+				b_valentigney = {
+				}
+
+				b_grand_charmont = {
+				}
+
+				b_bavans = {
+				}
+			}
+			c_vesoul = {
+				color={ 140 20 45 }
+				color2={ 255 255 255 }
+
+				b_vesoul = {
+				}
+				b_luxeuil = {
+				}
+				b_belfort = {
+				}
+				b_beaucourt = {
+				}
+				b_lure = {
+				}
+				b_champlitte = {
+				}
+				b_jussey = {
+				}
+			}
+
+		}
+		d_upper_burgundy = {
+			color={ 159 40 10 }
+			color2={ 255 255 255 }
+			
+			capital = 244 # Bourgogne
+			
+			c_neuchatel = {
+				color={ 163 24 62 }
+				color2={ 255 255 255 }
+				
+				b_neuchatel = {
+					german = "Neuenburg"
+				}
+				b_stimier = {
+					german = "Sankt Immer"
+				}
+				b_erguel = {
+					german = "Erguel"
+				}
+				b_estavayer = {
+					german = "Staveyer"
+				}
+				b_avenches = {
+					frankish = "Aventich"
+				}
+				b_colombier = {
+				}
+				b_valangin = {
+				}
+				b_lalocle = {
+				}
+				b_labonneville = {
+					german = "Gutstadt"
+				}
+				b_neuveville = {
+					german = "Neuenstadt"
+				}
+			}
+			c_bern = {
+				color={ 165 26 64 }
+				color2={ 255 255 255 }
+
+					frankish = "Aargovie"
+				
+				b_bern = {
+					frankish = "Berne"
+					italian = "Berna"
+				}
+				b_unterseen = {
+				}
+				b_luzern = {
+					frankish = "Lucerne"
+				}
+				b_biel = {
+					frankish = "Bienne"
+				}
+				b_thun = {
+					frankish = "Thoune"
+				}
+				b_murten = {
+					frankish = "Morat"
+				}
+				b_sursee = {
+				}
+				b_fribourg = {
+				}
+			}
+			c_aargau = {
+				color={ 169 30 68 }
+				color2={ 255 255 255 }
+				
+				b_aarau_augstgau = {
+				}
+				b_st_ursanne = {
+				}
+				b_porrentruy = {
+					german = "Pruntrut"
+				}
+				b_delemont = {
+					german = "Delsberg"
+				}
+				b_moutier = {
+					german = "Münster-im-Grosstal"
+				}
+				b_basel = {
+					frankish = "Bâle"
+				}
+				b_solothurn = {
+					frankish = "Soleure"
+				}
+				b_laufenberg = {
+					frankish = "Laufond"
+				}
+				b_habsburg = {}
+			}
+			c_vaud = {
+				b_lausanne = {
+					german = "Losanen"
+				}
+				b_echallens = {
+				}
+				b_yverdon = {
+					german = "Ifferten"
+				}
+				b_romainmotier = {
+					german = "Welschmünster"
+				}
+				b_gruyere = {
+					german = "Greyers"
+					frankish = "Grevire"
+				}
+				b_payerne = {
+				}
+				b_ouchy = {
+				}
+				b_chillon = {
+				}
+				b_orbe = {
+				}
+				b_grandson = {
+				}
+				b_chateaudoex = {
+				}
+			}
+		}
+	}
+}
+
+e_spain = {
+	color={ 233 200 20 }
+	color2={ 255 255 255 }
+	
+	capital = 197 # Toledo
+	
+	culture = castillan
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				e_spain = {
+					any_direct_de_jure_vassal_title = {
+						owner = {
+							NOT = {
+								religion_group = ROOT
+							}
+						}
+					}
+				}
+				has_dlc = "Holy Fury"
+			}
+
+			custom_tooltip = {
+				text = e_spain_allow_TT
+
+				always = no
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_global_flag = active_reconquista
+			}
+
+			custom_tooltip = {
+				text = active_reconquista_condition_TT
+
+				always = no
+			}
+		}
+	}
+
+	gain_effect = {
+		if = {
+			limit = {
+				NOT = {
+					has_global_flag = reconquista_finished
+				}
+			}
+
+			any_playable_ruler = {
+				narrative_event = { id = HF.49451 }
+			}
+
+			ROOT = {
+				narrative_event = { id = HF.49451 }
+			}
+
+			set_global_flag = reconquista_finished
+		}
+	}
+	
+	k_leon = {
+		color = { 253 158 51 }
+		color2={ 255 255 255 }
+		
+		dignity = 1 # One more county than de jure
+		
+		capital = 190 # Leon
+		
+		culture = castillan
+		
+		# Creation/usurpation trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = christian
+				}
+			}
+			conditional_tooltip = {
+				trigger = {
+					k_leon = {
+						is_titular = yes
+					}
+				}
+				k_leon = {
+					is_titular = no
+				}
+			}
+		}
+		
+		catholic = 250 # Crusade target weight
+		muslim = 25 # Crusade target weight
+	}
+
+	k_badajoz = {
+		color={ 138 243 51 }
+		color2={ 255 255 255 }
+
+		capital = 184 # Badajoz
+
+		visigothic = "Lusitania"
+		roman = "Lusitania"
+		greek = "Lusitania"
+		basque = "Lusitania"
+		castillan = "Lusitania"
+		catalan = "Lusitania"
+		portuguese = "Lusitania"
+
+		muslim = 25 # Crusade target weight
+
+		d_badajoz = {
+			color = { 138 243 51 }
+			color2={ 255 255 255 }
+			
+			capital = 184 # Badajoz
+
+			visigothic = "Extramedura"
+			basque = "Extramedura"
+			castillan = "Extramedura"
+			catalan = "Extramedura"
+			portuguese = "Extramedura"
+			
+			c_plasencia = {
+				color = { 228 230 23 }
+				color2={ 255 255 255 }
+				
+				b_hervas = {
+				}
+				b_plasencia = {
+				}
+				b_jaraiz = {
+				}
+				b_lazarza = {
+				}
+				b_montehermoso = {
+				}
+				b_ventadelmoral = {
+				}
+				b_jarandilla = {
+				}
+				b_talayuela = {
+				}
+			}
+			c_alcantara = {
+				color = { 230 232 25 }
+				color2={ 255 255 255 }
+				
+				b_alcantara = {
+				}
+				b_coria = {
+				}
+				b_moraleja = {
+				}
+				b_brozas = {
+				}
+				b_lamata = {
+				}
+				b_racharachel = {
+				}
+				b_lasnavasdelmadrono = {
+				}
+				b_ceclavin = {
+				}
+			}
+			c_caceres = {
+				color = { 232 234 27 }
+				color2={ 255 255 255 }
+				
+				b_caceres = {
+				}
+				b_guadalupe = {
+				}
+				b_trujillo = {
+				}
+				b_alburquerque = {
+				}
+				b_alia = {
+				}
+				b_arroyodelalluz = {
+				}
+				b_logrosan = {
+				}
+				b_alcuescar = {
+				}
+			}
+			c_badajoz = {
+				color = { 234 236 29 }
+				color2={ 255 255 255 }
+
+				visigothic = "Mérida"
+				basque = "Mérida"
+				castillan = "Mérida"
+				catalan = "Mérida"
+				portuguese = "Mérida"
+				
+				b_jerezdeloscaballeros = {
+				}
+				b_badajoz = {
+				}
+				b_merida = {
+				}
+				b_zafra = {
+				}
+				b_almendralejo = {
+				}
+				b_villalbadelosbarros = {
+				}
+				b_guarena = {
+				}
+				b_fuentedelmaestre = {
+				}
+			}
+		}
+		d_beja = {
+			color = { 182 98 5 }
+			color2={ 255 255 255 }
+			
+			capital = 185 # Mertola
+			
+			c_evora = {
+				color = { 182 68 5 }
+				color2={ 255 255 255 }
+				
+				b_avis = {
+				} 
+				b_evora = {
+				} 
+				b_portalegre = {
+				} 
+				b_marvao = {
+				} 
+				b_castelodevide = {
+				} 
+				b_crato = {
+				} 
+				b_monforte = {
+				} 
+				b_ouguela = {
+				}
+			}
+			c_alcacer_do_sal = {
+				color = { 182 105 5 }
+				color2={ 255 255 255 }
+				
+				b_alcacerdosal = {}
+				b_santiagodocacem = {}
+				b_aljustrel = {}
+				b_castroverde = {}
+				b_ourique = {}
+				b_odemira = {}
+				b_alvalade = {}
+			}
+			c_mertola = {
+				color = { 182 60 5 }
+				color2={ 255 255 255 }
+				
+				b_mertola = {}
+				b_monsaraz = {}
+				b_beja = {}
+				b_serpa = {}
+				b_noudal = {}
+				b_mourao = {}
+				b_portel = {}
+				b_moura = {}
+			}
+			c_egitanea = {
+				color={ 175 105 5 }
+				color2={ 255 255 255 }
+
+				b_rodao = {}
+				b_idanha = {}
+				b_covilha = {}
+				b_castelobranco = {}
+				b_alcains = {}
+				b_penha = {}
+				b_belver = {}
+			}
+		}
+		d_algarve = {
+			color = { 202 88 5 }
+			color2={ 255 255 255 }
+			
+			capital = 163 # Faro
+			
+			c_silves = {
+				color = { 192 80 15 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Shlib"
+				maghreb_arabic = "Shlib"
+				levantine_arabic = "Shlib"
+				egyptian_arabic = "Shlib"
+				andalusian_arabic = "Shlib"
+				
+				b_silves = {
+					bedouin_arabic = "Shlib"
+					maghreb_arabic = "Shlib"
+					levantine_arabic = "Shlib"
+					egyptian_arabic = "Shlib"
+					andalusian_arabic = "Shlib"
+				}
+				b_lagos = {}
+				b_alvor = {}
+				b_aljezur = {}
+				b_arrifana = {}
+				b_monchique = {}
+				b_almodovar = {}
+			}
+			c_faro = {
+				color = { 192 98 5 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Uhshunubah"
+				maghreb_arabic = "Uhshunubah"
+				levantine_arabic = "Uhshunubah"
+				egyptian_arabic = "Uhshunubah"
+				andalusian_arabic = "Uhshunubah"
+				
+				b_faro = {
+					bedouin_arabic = "Harun"
+					maghreb_arabic = "Harun"
+					levantine_arabic = "Harun"
+					egyptian_arabic = "Harun"
+					andalusian_arabic = "Harun"
+				}
+				b_tavira = {}
+				b_loule = {}
+				b_castromarim = {}
+				b_alcoutim = {}
+				b_saobrasdealportel = {}
+				b_olhao = {}
+			}
+		}
+		d_balata = {
+			color = { 193 81 5 }
+			color2={ 255 255 255 }
+
+			capital = 160 # Lisboa
+
+			bedouin_arabic = "Balata"
+			maghreb_arabic = "Balata"
+			levantine_arabic = "Balata"
+			egyptian_arabic = "Balata"
+			andalusian_arabic = "Balata"
+
+			c_lisboa = {
+				color = { 182 88 5 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Lishbuna"
+				maghreb_arabic = "Lishbuna"
+				levantine_arabic = "Lishbuna"
+				egyptian_arabic = "Lishbuna"
+				andalusian_arabic = "Lishbuna"
+				
+				b_lisboa = {
+					bedouin_arabic = "Lishbuna"
+					maghreb_arabic = "Lishbuna"
+					levantine_arabic = "Lishbuna"
+					egyptian_arabic = "Lishbuna"
+					andalusian_arabic = "Lishbuna"
+				}
+				b_santarem = {}
+				b_alcobaca = {}
+				b_sintra = {}
+				b_alenquer = {}
+				b_atouguia = {}
+				b_tomar = {} 
+				b_batalha = {}
+			}
+			c_almada = {
+				color={ 185 90 5 }
+				color2={ 255 255 255 }
+
+				b_almada = {}
+				b_palmela = {}
+				b_setubal = {}
+				b_sesimbra = {}
+				b_alcochete = {}
+				b_pegoes = {}
+				b_montijo = {}
+			}
+		}
+	}
+
+	k_valencia = {
+		color={ 48 167 45 }
+		color2={ 255 255 255 }
+
+		capital = 171 # Valencia
+
+		visigothic = "Carthaginensis"
+		roman = "Carthaginensis"
+		greek = "Carthaginensis"
+
+		muslim = 25 # Crusade target weight
+
+		d_valencia = {
+			color = { 48 167 45 }
+			color2={ 255 255 255 }
+			
+			capital = 171 # Valencia
+			
+			c_castellon = {
+				color = { 255 242 2 }
+				color2={ 255 255 255 }
+				
+				b_castellon = {
+				}
+				b_alpuente = {
+				}
+				b_nules = {
+				}
+				b_vinaros = {
+				}
+				b_morella = {
+				}
+				b_vilarreal = {
+				}
+				b_burriana = {
+				}
+				b_alcalaten = {
+				}
+			}
+			c_valencia = {
+				color = { 255 244 4 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Balansiyya"
+				maghreb_arabic = "Balansiyya"
+				levantine_arabic = "Balansiyya"
+				egyptian_arabic = "Balansiyya"
+				andalusian_arabic = "Balansiyya"
+				
+				b_gandia = {
+				}
+				b_valencia = {
+					bedouin_arabic = "Balansiyya"
+					maghreb_arabic = "Balansiyya"
+					levantine_arabic = "Balansiyya"
+					egyptian_arabic = "Balansiyya"
+					andalusian_arabic = "Balansiyya"
+				}
+				b_jativa = {
+				}
+				b_cuartdepoblet = {
+				}
+				b_alberique = {
+				}
+				b_alacuas = {
+				}
+				b_torrent = {
+				}
+				b_chiva = {
+				}
+			}
+			c_denia = {
+				color = { 255 246 6 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Deniyya"
+				maghreb_arabic = "Deniyya"
+				levantine_arabic = "Deniyya"
+				egyptian_arabic = "Deniyya"
+				andalusian_arabic = "Deniyya"
+				
+				b_denia = {
+					bedouin_arabic = "Deniyya"
+					maghreb_arabic = "Deniyya"
+					levantine_arabic = "Deniyya"
+					egyptian_arabic = "Deniyya"
+					andalusian_arabic = "Deniyya"
+				}
+				b_alicante = {
+				}
+				b_elche = {
+				}
+				b_villena = {
+				}
+				b_orihuela = {
+				}
+				b_castalla = {
+				}
+				b_albatera = {
+				}
+				b_benissa = {
+				}
+			}
+		}
+		d_murcia = {
+			color = { 16 229 33 }
+			color2={ 255 255 255 }
+			
+			capital = 169 # Murcia
+			
+			c_almansa = {
+				color = { 244 225 14 }
+				color2={ 255 255 255 }
+				
+				b_almansa = {
+				}
+				b_albacete = {
+				}
+				b_hellin = {
+				}
+				b_caudete = {
+				}
+				b_villarrobledo = {
+				}
+				b_alcaladeljucar = {
+				}
+				b_pozocanada = {
+				}
+				b_tobarra = {
+				}
+			}
+			c_murcia = {
+				color = { 246 227 16 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Mursiya"
+				maghreb_arabic = "Mursiya"
+				levantine_arabic = "Mursiya"
+				egyptian_arabic = "Mursiya"
+				andalusian_arabic = "Mursiya"
+				
+				b_murcia = {
+					bedouin_arabic = "Mursiya"
+					maghreb_arabic = "Mursiya"
+					levantine_arabic = "Mursiya"
+					egyptian_arabic = "Mursiya"
+					andalusian_arabic = "Mursiya"
+				}
+				b_cartagena = {
+				}
+				b_lorca = {
+				}
+				b_alcantarilla = {
+				}
+				b_medinasiyasa = {
+				}
+				b_molinalaseca = {
+				}
+				b_yecla = {
+				}
+				b_nogalte = {
+				}
+			}
+		}
+	}
+
+	k_castille = { #Spain
+		color={ 243 209 23 }
+		color2={ 200 80 10 }
+		dignity = 2 # Counted as having 2 more counties than it does
+		
+		capital = 199 # Burgos
+		
+		culture = castillan
+		
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_castille = {
+						is_titular = yes
+					}
+				}
+				k_castille = {
+					is_titular = no
+				}
+			}
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = christian
+				}
+			}	
+		}
+		
+		catholic = 250 # Crusade target weight
+		muslim = 25 # Crusade target weight
+		
+		d_castilla = {
+			color = { 242 196 12 }
+			color2={ 255 255 255 }
+			
+			capital = 199 # Burgos
+			
+			c_burgos = {
+				color = { 246 200 16 }
+				color2={ 255 255 255 }
+				
+				b_aguilardecampo = {
+				}
+				b_burgos = {
+				}
+				b_silos = {
+				}
+				b_castrobarte = {
+				}
+				b_mirandadeebro = {
+				}
+				b_arandadeduero = {
+				}
+				b_carrion = {
+				}
+			}
+			c_valladolid = {
+				color = { 248 202 18 }
+				color2={ 255 255 255 }
+				
+				b_valladolid = {
+				}
+				b_tordesillas = {
+				}
+				b_segovia = {
+				}
+				b_medinadelcampo = {
+				}
+				b_simancas = {
+				}
+				b_penafiel = {
+				}
+				b_iscar = {
+				}
+				b_avila = {
+				}
+			}
+			c_soria = {
+				color = { 250 204 20 }
+				color2={ 255 255 255 }
+				
+				b_soria = {
+				}
+				b_almazan = {
+				}
+				b_gormaz = {
+				}
+				b_castromoro = {
+				}
+				b_medinacelli = {
+				}
+				b_sanleonardodeyague = {
+				}
+				b_covaleda = {
+				}
+			}
+			c_osma = {
+				color={ 252 190 25 }
+				color2={ 255 255 255 }
+
+				b_osma = {}
+				b_ucero = {}
+				b_el_burgo = {}
+				b_duero = {}
+				b_uxama = {}
+				b_san_esteban = {}
+				b_calatanazor = {}
+			}
+			c_asturias_de_santillana = {
+				color = { 232 205 25 }
+				color2={ 255 255 255 }
+				
+				b_santander = {
+				}
+				b_santillanadelmar = {
+				}
+				b_laredo = {
+				}
+				b_castrourdiales = {
+				}
+				b_santona = {
+				}
+				b_reinosa = {
+				}
+				b_suances = {
+				}
+				b_camargo = {
+				}
+				b_sanvicente = {
+				}
+			}
+		}
+	}
+	
+	k_aragon = {
+		color = { 166 98 22 }
+		color2={ 230 0 0 }
+		
+		capital = 202 # Zaragoza
+		
+		culture = castillan
+
+		roman = "Tarraconensis"
+		
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_aragon = {
+						is_titular = yes
+					}
+				}
+				k_aragon = {
+					is_titular = no
+				}
+			}
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = christian
+				}
+			}		
+		}
+		
+		catholic = 250 # Crusade target weight
+		muslim = 25 # Crusade target weight
+	
+		d_aragon = {
+			color = { 160 90 20 }
+			color2={ 255 255 255 }
+			
+			capital = 202 # Zaragoza
+			
+			c_albarracin = {
+				color = { 166 78 72 }
+				color2={ 255 255 255 }
+				
+				b_albarracin = {
+				}
+				b_teruel = {
+				}
+				b_hijar = {
+				}
+				b_utrillas = {
+				}
+				b_calanda = {
+				}
+				b_montalban = {
+				}
+				b_alcaniz = {
+				}
+				b_calamocha = {
+				}
+			}
+			c_alto_aragon = {
+				color = { 186 70 72 }
+				color2={ 255 255 255 }
+				
+				b_jaca = {
+				}
+				b_huesca = {
+				}
+				b_barbastro = {
+				}
+				b_loarre = {
+				}
+				b_ayerbe = {
+				}
+				b_almudevar = {
+				}
+				b_uncastillo = {
+				}
+				b_alquezar = {
+				}
+			}
+			c_zaragoza = {
+				color = { 170 70 32 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Saraqusta"
+				maghreb_arabic = "Saraqusta"
+				levantine_arabic = "Saraqusta"
+				egyptian_arabic = "Saraqusta"
+				andalusian_arabic = "Saraqusta"
+				
+				b_alagon = {
+				}
+				b_zaragoza = {
+					bedouin_arabic = "Saraqusta"
+					maghreb_arabic = "Saraqusta"
+					levantine_arabic = "Saraqusta"
+					egyptian_arabic = "Saraqusta"
+					andalusian_arabic = "Saraqusta"
+				}
+				b_veruela = {
+				}
+				b_caspe = {
+				}
+				b_borja = {
+				}
+				b_medianadearagon = {
+				}
+				b_ejea = {
+				}
+				b_epila = {
+				}
+			}
+			c_calatayud = {
+				color = { 190 80 30 }
+				color2={ 255 255 255 }
+				
+				b_calatayud = {
+				}
+				b_piedra = {
+				}
+				b_alhamadearagon = {
+				}
+				b_nuevalos = {
+				}
+				b_daroca = {
+				}
+				b_munebrega = {
+				}
+				b_calmarza = {
+				}
+				b_cimballa = {
+				}
+			}
+		}
+		d_barcelona = {
+			color = { 166 100 72 }
+			color2={ 255 255 255 }
+			
+			capital = 204 # Barcelona
+			
+			culture = catalan
+
+			roman = "Tarraconensis"
+			
+			c_barcelona = {
+				color = { 166 110 72 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Barshiluna"
+				maghreb_arabic = "Barshiluna"
+				levantine_arabic = "Barshiluna"
+				egyptian_arabic = "Barshiluna"
+				andalusian_arabic = "Barshiluna"
+				
+				b_berga = {
+				}
+				b_barcelona = {
+					bedouin_arabic = "Madinat Barshiluna"
+					maghreb_arabic = "Madinat Barshiluna"
+					levantine_arabic = "Madinat Barshiluna"
+					egyptian_arabic = "Madinat Barshiluna"
+					andalusian_arabic = "Madinat Barshiluna"
+				}
+				b_vic = {
+				}
+				b_manresa = {
+				}
+				b_osona = {
+				}
+				b_igualada = {
+				}
+				b_vallparadis = {
+				}
+				b_provencana = {
+				}
+			}
+			c_urgell = {
+				color = { 196 110 60 }
+				color2={ 255 255 255 }
+				
+				b_pallars = {
+				}
+				b_urgell = {
+				}
+				b_suert = {
+				}
+				b_viella = {
+				}
+				b_puigcerda = {
+				}
+				b_valledebohi = {
+				}
+				b_elpuidesegur = {
+				}
+				b_tremp = {
+				}
+			}
+			c_rosello = {
+				color = { 210 140 50 }
+				color2={ 255 255 255 }
+				
+				b_cotlliure = {
+				}
+				b_perpinya = {
+				}
+				b_elna = {
+				}
+				b_cuixa = {
+				}
+				b_prada = {
+				}
+				b_oltrera = {
+				}
+				b_canigo = {
+				}
+				b_ceret = {
+				}
+			}
+			c_empuries = {
+				color = { 150 70 20 }
+				color2={ 255 255 255 }
+				
+				b_empuries = {
+				}
+				b_labisbaldemporda = {
+				}
+				b_girona = {
+				}
+				b_figueras = {
+				}
+				b_cerdana = {
+				}
+				b_besalu = {
+				}
+				b_banyoles = {
+				}
+				b_castelldaro = {
+				}
+			}
+			c_lleida = {
+				color = { 140 90 20 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Larida"
+				maghreb_arabic = "Larida"
+				levantine_arabic = "Larida"
+				egyptian_arabic = "Larida"
+				andalusian_arabic = "Larida"
+				
+				b_lleida = {
+					bedouin_arabic = "Larida"
+					maghreb_arabic = "Larida"
+					levantine_arabic = "Larida"
+					egyptian_arabic = "Larida"
+					andalusian_arabic = "Larida"
+				}
+				b_cervera = {
+				}
+				b_solsona = {
+				}
+				b_agramunt = {
+				}
+				b_tarrega = {
+				}
+				b_balaguer = {
+				}
+				b_borgesblanques = {
+				}
+				b_verdu = {
+				}
+			}
+			c_tarragona = {
+				color = { 186 90 45 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Turtusha"
+				maghreb_arabic = "Turtusha"
+				levantine_arabic = "Turtusha"
+				egyptian_arabic = "Turtusha"
+				andalusian_arabic = "Turtusha"
+				roman = "Tarraco"
+				
+				b_tarragona = {
+					roman = "Tarraco"
+				}
+				b_spantortosa = {
+					bedouin_arabic = "Turtusha"
+					maghreb_arabic = "Turtusha"
+					levantine_arabic = "Turtusha"
+					egyptian_arabic = "Turtusha"
+					andalusian_arabic = "Turtusha"
+				}
+				b_cambrils = {
+				}
+				b_reus = {
+				}
+				b_montblanc = {
+				}
+				b_vendrell = {
+				}
+				b_amposta = {
+				}
+				b_sancugat = {
+				}
+			}
+		}
+		d_mallorca = {
+			color = { 68 126 72 }
+			color2={ 255 255 255 }
+			
+			capital = 827 # Mallorca
+			
+			c_mallorca = {
+				color = { 255 249 3 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Mayurqa"
+				maghreb_arabic = "Mayurqa"
+				levantine_arabic = "Mayurqa"
+				egyptian_arabic = "Mayurqa"
+				andalusian_arabic = "Mayurqa"
+				
+				b_alcudia = {
+				}
+				b_palma = {
+					bedouin_arabic = "Madinat Mayurqa"
+					maghreb_arabic = "Madinat Mayurqa"
+					levantine_arabic = "Madinat Mayurqa"
+					egyptian_arabic = "Madinat Mayurqa"
+					andalusian_arabic = "Madinat Mayurqa"
+				}
+				b_algaida = {
+				}
+				b_felanitx = {
+				}
+				b_santaponsa = {
+				}
+				b_eivissa = {
+				}
+				b_manacor = {
+				}
+				b_formentera = {
+				}
+			}
+			c_menorca = {
+				color = { 255 252 6 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Manurqa"
+				maghreb_arabic = "Manurqa"
+				levantine_arabic = "Manurqa"
+				egyptian_arabic = "Manurqa"
+				andalusian_arabic = "Manurqa"
+				
+				b_ciutadella = {
+					bedouin_arabic = "Madinat al-Jazirah"
+					maghreb_arabic = "Madinat al-Jazirah"
+					levantine_arabic = "Madinat al-Jazirah"
+					egyptian_arabic = "Madinat al-Jazirah"
+					andalusian_arabic = "Madinat al-Jazirah"
+				} 
+				b_mahon = {
+				}
+				b_alaior = {
+				}
+				b_santaagueda = {
+				}
+				b_esmercadal = {
+				}
+				b_santlluis = {
+				}
+				b_ferreries = {
+				}
+				b_escastell = {
+				}
+			}
+		}
+	}
+	
+	k_navarra = {
+		color = { 150 120 5 }
+		capital = 152 # Navarra
+		
+		culture = basque
+
+		roman = "Vasconia"
+		
+		# Creation/usurpation trigger
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					AND = {
+						culture = basque
+						religion_group = christian
+					}
+				}
+			}
+		}
+		
+		d_navarra = {
+			color = { 230 198 90 }
+			color2={ 255 255 255 }
+			
+			capital = 152 # Navarra
+			
+			c_viscaya = {
+				color = { 244 198 14 }
+				color2={ 255 255 255 }
+				
+				b_irun = {
+				}
+				b_sansebastian = {
+				}
+				b_eibar = {
+				}
+				b_onate = {
+				}
+				b_tolosa = {
+				}
+				b_bilbao = {
+				}
+				b_vitoria = {
+				}
+				b_guernica = {
+				}
+			}
+			
+			c_navarra = {
+				color = { 255 200 2 }
+				color2={ 255 255 255 }
+				
+				b_pamplona = {
+				}
+				b_leyre = {
+				}
+				b_tudela = {
+				} 
+				b_tafalla = {
+				}
+				b_olite = {
+				}
+				b_carcastillo = {
+				}
+				b_sanguesa = {
+				}
+				b_estella = {
+				}
+			}
+			c_najera = {
+				color = { 255 202 3 }
+				color2={ 255 255 255 }
+	
+				b_haro = {
+				}
+				b_logrone = {
+				}
+				b_calahorra = {
+				}
+				b_najera = {
+				}
+				b_arnedo = {
+				}
+				b_alfara = {
+				}
+				b_zizurmayor = {
+				}
+				b_santodomingodelacalzada = {
+				}
+			}
+		}
+	}
+	
+	k_asturias = {
+		color = { 233 188 91 }
+		color2={ 255 255 255 }
+		
+		dignity = 10
+		
+		capital = 155 # Asturias de Oviedo
+		
+		culture = castillan
+		
+		# Creation/usurpation trigger
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_asturias = {
+						is_titular = yes
+					}
+				}
+				k_asturias = {
+					is_titular = no
+				}
+			}
+		}
+		
+		catholic = 250 # Crusade target weight
+		muslim = 25 # Crusade target weight
+		
+		d_asturias = {
+			color = { 233 188 91 }
+			color2={ 255 255 255 }
+			
+			capital = 155 # Asturias
+			
+			c_asturias_de_oviedo = {
+				color = { 233 158 51 }
+				color2={ 255 255 255 }
+				
+				b_oviedo = {
+				}
+				b_gijon = {
+				}
+				b_cangasdeonis = {
+				}
+				b_tineo = {
+				}
+				b_cangasdelnarcea = {
+				}
+				b_villaviciosa = {
+				}
+				b_luarca = {
+				}
+				b_norena = {
+				}
+			}
+			c_astorga = {
+				color = { 243 158 51 }
+				color2={ 255 255 255 }
+				
+				b_ponferrada = {
+				}
+				b_bembibre = {
+				}
+				b_ribadelago = {
+				}
+				b_cacabelos = {
+				}
+				b_fabero = {
+				}
+				b_camponaraya = {
+				}
+				b_toreno = {
+				}
+				b_astorga = {
+				}
+			}
+		}
+		d_leon = {
+			color = { 253 158 51 }
+			color2={ 255 255 255 }
+			
+			capital = 190 # Leon
+			
+			c_leon = {
+				color = { 253 158 51 }
+				color2={ 255 255 255 }
+				
+				b_leon = {
+				}
+				b_valenciadecampos = {
+				}
+				b_villablino = {
+				}
+				b_sanpedrodeperix = {
+				}
+				b_saldana = {
+				}
+				b_sahagun = {
+				}
+				b_larobla = {
+				}
+				b_cistierna = {
+				}
+			}
+			c_palencia = { 
+				color={ 253 148 40 }
+				color2={ 255 255 255 }
+
+				b_palencia = {}
+				b_saint_antolin = {}
+				b_san_salvador = {}
+				b_paredes = {}
+				b_olmeda_palencia = {}
+				b_monte_el_viejo = {}
+				b_vaccaei = {}
+			}
+			c_zamora = {
+				color = { 253 138 51 }
+				color2={ 255 255 255 }
+				
+				b_zamora = {
+				}
+				b_benavente = {
+				}
+				b_fermoselle = {
+				}
+				b_toro = {
+				}
+				b_sanabria = {
+				}
+				b_corrales = {
+				}
+				b_fuentesauco = {
+				}
+				b_polvorosa = {
+				}
+			}
+			c_salamanca = {
+				color = { 253 128 31 }
+				color2={ 255 255 255 }
+				
+				b_salbejar = {
+				}
+				b_salamanca = {
+				}
+				b_ciudadrodrigo = {
+				}
+				b_bracamonte = {
+				}
+				b_albadetormes = {
+				}
+				b_terradillos = {
+				}
+				b_carbajosadelasagrada = {
+				}
+				b_lumbrales = {
+				}
+			}
+		}
+	}
+	
+	k_spanish_galicia = {
+		color={ 255 224 94 }
+		capital = 156 # Coruña
+		
+		culture = portuguese
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = christian
+				}
+			}
+			conditional_tooltip = {
+				trigger = {
+					k_spanish_galicia = {
+						is_titular = yes
+					}
+				}
+				k_spanish_galicia = {
+					is_titular = no
+				}
+			}	
+		}
+		
+		catholic = 250 # Crusade target weight
+		muslim = 25 # Crusade target weight
+		
+		d_galicia = {
+			color={ 255 224 94 }
+			color2={ 255 255 255 }
+			
+			capital = 156 # Coruna
+			
+			c_coruna = {
+				color = { 183 118 51 }
+				color2={ 255 255 255 }
+				
+				b_corunna = {
+				}
+				b_mondonedo = {
+				}
+				b_ferrol = {
+				}
+				b_villalba = {
+				}
+				b_viveiro = {
+				}
+				b_burela = {
+				}
+				b_triacastela = {
+				}
+			}
+			c_santiago = {
+				color = { 243 158 51}
+				color2={ 255 255 255 }
+				
+				holy_site = catholic
+				
+				b_santiago = {
+				}
+				b_vigo = {
+				}
+				b_pontevedra = {
+				}
+				b_tuy = {
+				}
+				b_verin = {
+				}
+				b_padron = {
+				}
+				b_vilagarcia = {
+				}
+			}
+			c_lugo = {
+				color={ 200 130 51 }
+				color2={ 255 255 255 }
+
+				b_lugo = {}
+				b_orense = {}
+				b_ribadeo = {}
+				b_navilubio = {}
+				b_mino = {}
+				b_burgas_orense = {}
+				b_sil = {}
+			}
+		}
+	}
+	
+	k_portugal = {
+		color={ 182 88 5 }
+		color2={ 255 255 255 }
+		
+		capital = 160 # Lisboa
+		
+		culture = portuguese
+
+		roman = "Lusitania"
+		
+		catholic = 250 # Crusade target weight
+		muslim = 25
+		west_african_pagan_reformed = 25
+		
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_portugal = {
+						is_titular = yes
+					}
+				}
+				k_portugal = {
+					is_titular = no
+				}
+			}
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = christian
+				}
+			}		
+		}
+		
+		d_porto = {
+			color = { 182 108 45 }
+			color2={ 255 255 255 }
+			
+			capital = 158 # porto
+			
+			culture = portuguese
+			
+			c_porto = {
+				color = { 182 88 5 }
+				color2={ 255 255 255 }
+				
+				b_braga = {
+				}
+				b_porto = {
+				}
+				b_guimaraes = {
+				}
+				b_vianadocastelo = {
+				}
+				b_pontedelima = {
+				}
+				b_barcelos = {
+				}
+				b_arcosdevaldevez = {
+				}
+				b_moncao = {
+				}
+			}
+			c_braganza = {
+				color = { 182 98 5 }
+				color2={ 255 255 255 }
+				
+				b_braganza = {
+				}
+				b_chaves = {
+				}
+				b_vilareal = {
+				}
+				b_torredemoncorvo = {
+				}
+				b_mogadouro = {
+				}
+				b_castelomelhor = {
+				}
+				b_castelorodrigo = {
+				}
+				b_azinhoso = {
+				}
+			}
+			c_castelo_branco = {
+				color = { 182 78 5 }
+				color2={ 255 255 255 }
+				
+				b_guarda = {}
+				b_lamego = {}
+				b_trancoso = {}
+				b_sabugal = {}
+				b_pinhel = {}
+				b_almeida = {}
+				b_acores = {}
+			}
+			c_coimbra = {
+				color = { 182 88 25 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Qulumriyah"
+				maghreb_arabic = "Qulumriyah"
+				levantine_arabic = "Qulumriyah"
+				egyptian_arabic = "Qulumriyah"
+				andalusian_arabic = "Qulumriyah"
+				
+				b_coimbra = {
+					bedouin_arabic = "Qulumriyah"
+					maghreb_arabic = "Qulumriyah"
+					levantine_arabic = "Qulumriyah"
+					egyptian_arabic = "Qulumriyah"
+					andalusian_arabic = "Qulumriyah"
+				}
+				b_viseu = {
+				}
+				b_aveiro = {
+				}
+				b_pedondo = {
+				}
+				b_cantanhede = {
+				}
+				b_condeixa = {
+				}
+				b_montereal = {
+				}
+				b_penela = {
+				}
+			}
+		}
+	}
+	
+	k_andalusia = {
+		color = { 31 138 40 }
+		color2={ 255 255 255 }
+		
+		capital = 181 # Cordoba
+		
+		culture = andalusian_arabic
+		
+		roman = "Baetica"
+		greek = "Baetica"
+		visigothic = "Baetica"
+		basque = "Granada"
+		castillan = "Granada"
+		catalan = "Granada"
+		portuguese = "Granada"
+
+		muslim = 50 # Crusade target weight
+		west_african_pagan_reformed = 50
+		aztec_reformed = 2000
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = arabic
+				}
+			}
+		}
+		
+		d_cordoba = {
+			color = { 60 180 12 }
+			color2={ 255 255 255 }
+			
+			capital = 181 # Cordoba
+			
+			c_cordoba = {
+				color = { 246 216 16 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Qurtubah"
+				maghreb_arabic = "Qurtubah"
+				levantine_arabic = "Qurtubah"
+				egyptian_arabic = "Qurtubah"
+				andalusian_arabic = "Qurtubah"
+
+				holy_site = sunni
+				holy_site = aztec
+				holy_site = aztec_reformed
+				
+				b_cordoba = {
+					bedouin_arabic = "Qurtubah"
+					maghreb_arabic = "Qurtubah"
+					levantine_arabic = "Qurtubah"
+					egyptian_arabic = "Qurtubah"
+					andalusian_arabic = "Qurtubah"
+				}
+				b_alcolea = {
+				}
+				b_cabra = {
+				}
+				b_lucena = {
+				}
+				b_martos = {
+				}
+				b_belalcazar = {
+				}
+				b_canetedelastorres = {
+				}
+			}
+			c_la_mancha = {
+				color = { 250 220 20 }
+				color2={ 255 255 255 }
+				
+				b_alarcon = {
+				}
+				b_laroda = {
+				}
+				b_tarazona = {
+				}
+				b_quintanardelrey = {
+				}
+				b_lagineta = {
+				}
+				b_barrax = {
+				}
+				b_munera = {
+				}
+				b_jorquera = {
+				}
+			}
+			c_calatrava = {
+				color = { 254 224 24 }
+				color2={ 255 255 255 }
+				
+				b_calatrava = {
+				}
+				b_villareal = {
+				}
+				b_caracuel = {
+				}
+				b_alcazardesanjuan = {
+				}
+				b_alarcos = {
+				}
+				b_medellin = {
+				}
+				b_almadeo = {
+				}
+				b_almodovardelcampo = {
+				}
+			}
+			c_jaen = {
+				color={ 255 215 25 }
+				color2={ 255 255 255 }
+
+				b_jaen = {}
+				b_quesada = {}
+				b_huescar = {}
+				b_segura = {}
+				b_tiscar = {}
+				b_andujar = {}
+				b_baeza = {}
+			}
+		}	
+		d_granada = {
+			color = { 40 150 40 }
+			color2={ 255 255 255 }
+			
+			capital = 180 # Granada
+			
+			c_granada = {
+				color = { 245 242 15 }
+				color2={ 255 255 255 }
+				
+				b_granada = {
+				}
+				b_elvira = {
+				}
+				b_moclin = {
+				}
+				b_iznajar = {
+				}
+				b_guadix = {
+				}
+				b_huelma = {
+				}
+				b_antequara = {
+				}
+			}
+			c_almeria = {
+				color = { 248 245 18 }
+				color2={ 255 255 255 }
+				
+				b_pechina = {
+				}
+				b_almeria = {
+				}
+				b_baza = {
+				}
+				b_berja = {
+				}
+				b_motril = {
+				}
+				b_albox = {
+				}
+				b_purchena = {
+				}
+				b_vera = {
+				}
+			}
+			c_malaga = {
+				color = { 251 248 21 }
+				color2={ 255 255 255 }
+				
+				b_antequera = {
+				}
+				b_malaga = {
+				}
+				b_benalmadena = {
+				}
+				b_tamisa = {
+				}
+				b_coin = {
+				}
+				b_suel = {
+				}
+				b_cartajima = {
+				}
+				b_velezmalaga = {
+				}
+			}
+		}
+		d_sevilla = {
+			color = { 150 218 21 }
+			color2={ 255 255 255 }
+			
+			capital = 182 # Sevilla
+			
+			c_sevilla = {
+				color = { 232 200 25 }
+				color2={ 255 255 255 }
+				
+				b_carmona = {
+				}
+				b_sevilla = {
+				}
+				b_ecija = {
+				}
+				b_sevimoron = {
+				}
+				b_alcaladeguadaira = {
+				}
+				b_doshermanas = {
+				}
+				b_laalgaba = {
+				}
+				b_utrera = {
+				}
+			}
+			c_cadiz = {
+				color = { 236 204 29 }
+				color2={ 255 255 255 }
+				
+				b_jerez = {
+				}
+				b_cadiz = {
+				}
+				b_medinasidonia = {
+				}
+				b_arcos = {
+				}
+				b_sanjosedelvalle = {
+				}
+				b_sanlucadebarrameda = {
+				}
+				b_sanfernando = {
+				}
+				b_alcaladelosgazules = {
+				}
+			}
+			c_algeciras = {
+				color = { 240 208 33 }
+				color2={ 255 255 255 }
+				
+				b_gibraltar = {
+				}
+				b_algericas = {
+				}
+				b_ronda = {
+				}
+				b_sanroque = {
+				}
+				b_tarifa = {
+				}
+				b_estepona = {
+				}
+				b_jimenadelafrontera = {
+				}
+				b_casares = {
+				}
+			}
+			c_aracena = {
+				color = { 244 212 37 }
+				color2={ 255 255 255 }
+				
+				b_aracena = {
+				}
+				b_italica = {
+				}
+				b_almonasterlareal = {
+				}
+				b_calanas = {
+				}
+				b_cortegana = {
+				}
+				b_facanias = {
+				}
+				b_alajar = {
+				}
+				b_galaroza = {
+				}
+			}
+			c_niebla = {
+				color = { 248 216 41 }
+				color2={ 255 255 255 }
+				
+				b_niebla = {}
+				b_nerva = {}
+				b_almonte = {}
+				b_lascrocinas = {}
+				b_pilas = {}
+				b_ostilia = {}
+				b_aroche = {}
+			}
+			c_huelva = {
+				color={ 205 98 5 }
+				color2={ 255 255 255 }
+
+				b_huelva = {}
+				b_lepe = {}
+				b_ayamonte = {}
+				b_gibraleon = {}
+				b_moguer = {}
+				b_aljaraque = {}
+				b_portichuelo = {}
+			}
+		}
+		d_toledo = {
+			color = { 212 151 12 }
+			color2={ 255 255 255 }
+			
+			capital = 197 # Toledo
+			
+			c_toledo = {
+				color = { 245 204 15 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Tulaytulah"
+				maghreb_arabic = "Tulaytulah"
+				levantine_arabic = "Tulaytulah"
+				egyptian_arabic = "Tulaytulah"
+				andalusian_arabic = "Tulaytulah"
+				
+				b_madrid = {
+				}
+				b_toledo = {
+					bedouin_arabic = "Tulaytulah"
+					maghreb_arabic = "Tulaytulah"
+					levantine_arabic = "Tulaytulah"
+					egyptian_arabic = "Tulaytulah"
+					andalusian_arabic = "Tulaytulah"
+				}
+				b_orgaz = {
+				}
+				b_tolemora = {
+				}
+				b_talavera = {
+				}
+				b_consuegra = {
+				}
+				b_fuensalida = {
+				}
+				b_illescas = {
+				}
+			}
+			c_molina = {
+				color = { 248 207 18 }
+				color2={ 255 255 255 }
+				
+				b_hinojosa = {
+				}
+				b_molina = {
+				}
+				b_elpedregal = {
+				}
+				b_pinilla = {
+				}
+				b_cabanillasdelcampo = {
+				}
+				b_elcasar = {
+				}
+				b_maranchon = {
+				}
+				b_olmeda = {
+				}
+			}
+			c_cuenca = {
+				color = { 251 210 21 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Kunka"
+				maghreb_arabic = "Kunka"
+				levantine_arabic = "Kunka"
+				egyptian_arabic = "Kunka"
+				andalusian_arabic = "Kunka"
+				
+				
+				b_cuenca = {
+					bedouin_arabic = "Kunka"
+					maghreb_arabic = "Kunka"
+					levantine_arabic = "Kunka"
+					egyptian_arabic = "Kunka"
+					andalusian_arabic = "Kunka"
+				}
+				b_ucles = {
+				}
+				b_laspedroneras = {
+				}
+				b_villanuevadelajara = {
+				}
+				b_tarancon = {
+				}
+				b_sisante = {
+				}
+				b_motadelcuervo = {
+				}
+			}
+			c_alcala = {
+				color={ 255 200 30 }
+				color2={ 255 255 255 }
+
+				b_alcala = {}
+				b_siguenza = {}
+				b_guadalajara = {}
+				b_burgo_de_santiuste = {}
+				b_villavieja = {}
+				b_segontia = {}
+				b_complutum = {}
+			}
+		}
+	}
+}
+
+e_arabia = {
+	color={ 32 150 85 }
+	color2={ 255 255 255 }
+	
+	capital = 728 # Damascus
+	
+	culture = bedouin_arabic
+	
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = arabic
+			}
+		}
+	}
+	
+	short_name = yes
+
+	k_israel = {
+		color = { 20 138 255 }
+		
+		capital = 774 # Jerusalem
+
+		roman = "Judea"
+
+		title = "KING"
+		title_female = "QUEEN"
+
+		dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+		allow = {
+			always = no # Only created through special event
+		}
+	}
+
+	k_arabia = {
+		color={ 124 199 50 }
+		color2={ 255 255 255 }
+		
+		capital = 719 # Mecca
+		
+		culture = bedouin_arabic
+		
+		muslim = 4000 # Crusade target weight
+		zoroastrian_group = 500 # Crusade target weight
+	
+		d_arabia_petrae = {
+			color={ 121 196 2 }
+			color2={ 255 255 255 }
+			
+			capital = 783 # Maan
+			
+			#c_ar_ar = { # Shaka
+			#	color={ 97 208 137 }
+			#	color2={ 255 255 255 }
+			#	
+			#	b_shaka = {
+			#	}
+			#	b_ammaryah = {
+			#	}
+			#	b_dumat_al_jundal = {
+			#	}
+			#	b_umm_kunsur = {
+			#	}
+			#	b_ruthiyah = {
+			#	}
+			#	b_qasa = {
+			#	}
+			#	b_uwayquilah = {
+			#	}
+			#	b_judaidah = {
+			#	}
+			#}
+			c_maan = {
+				color={ 127 202 8 }
+				color2={ 255 255 255 }
+			
+				b_maan = {
+				}
+				b_mutah = {
+				}
+				b_shubak = {
+				}
+				b_maanaljafr = {
+				}
+				b_buseira = {
+				}
+				b_maanalhasa = {
+				}
+				b_afra = {
+				}
+				b_bubeita = {
+				}
+			}
+			c_tabuk = {
+				color={ 130 205 11 }
+				color2={ 255 255 255 }
+			
+				b_tabuk = {
+				}
+				b_duba = {
+				}
+				b_mariyiat = {
+				}
+				b_muwaylih = {
+				}
+				b_abu_ujayyijat = {
+				}
+				b_gabouk = {
+				}
+				b_shaghab = {
+				}
+				b_sharmah = {
+				}
+			}
+			#c_petra = {
+			#	color={ 133 208 14 }
+			#	color2={ 255 255 255 }
+			#
+			#	b_tophel = {
+			#	}
+			#	b_petra = {
+			#	}
+			#	b_wadi_musa = {
+			#	}
+			#	b_bozrah = {
+			#	}
+			#	b_shoubak = {
+			#	}
+			#	b_abdelliya = {
+			#	}
+			#	b_hamza = {
+			#	}
+			#	b_husseiniya = {
+			#	}
+			#}
+			c_al_jawf = {
+				color={ 154 253 47 }
+				color2={ 255 255 255 }
+			
+				b_al_jawf = {
+				}
+				b_sakakah = {
+				}
+				b_aladan = {
+				}
+				b_dumat_al_jandal = {
+				}
+				b_radifah = {
+				}
+				b_tuwayr = {
+				}
+				b_tyer = {
+				}
+				b_qurayyat = {
+				}
+			}
+			c_al_aqabah = {
+				color={ 124 199 5 }
+				color2={ 255 255 255 }
+			
+				b_aqabah = {
+				}
+				b_reeshah = {
+				}
+				b_quwairah = {
+				}
+				b_mazraa = {
+				}
+				b_feifa = {
+				}
+				b_samar = {
+				}
+				b_elifaz = {
+				}
+				b_yotvata = {
+				}
+			}
+			c_hijaz = {
+				color={ 158 253 51 }
+				color2={ 255 255 255 }
+			
+				b_al_ola = {
+				}
+				b_tayma = {
+				}
+				b_leuke_kome = {
+				}
+				b_higra = {
+				}
+				b_madain_salih = {
+				}
+				b_mughayra = {
+				}
+				b_samur = {
+				}
+				b_tawala = {
+				}
+			}
+		}
+		d_medina = {
+			color={ 150 249 43 }
+			color2={ 255 255 255 }
+			
+			capital = 719 # Mecca
+			
+			muslim = 500 # Crusade target weight
+			
+			c_medina = {
+				color={ 162 253 55 }
+				color2={ 255 255 255 }
+				
+				muslim = 500 # Crusade target weight
+
+				holy_site = sunni
+				holy_site = shiite
+				holy_site = ibadi
+				
+				b_medina = {
+				}
+				b_kuba = {
+				}
+				b_farsh = {
+				}
+				b_sidi_hamzah = {
+				}
+				b_milha = {
+				}
+				b_batn_nakhl = {
+				}
+				b_al_usayla = {
+				}
+			}
+			c_mecca = {
+				color={ 166 253 59 }
+				color2={ 255 255 255 }
+				
+				muslim = 1000 # Crusade target weight
+
+				holy_site = sunni
+				holy_site = shiite
+				holy_site = pagan
+				holy_site = yazidi
+				holy_site = ibadi
+				
+				b_mecca = {
+				}
+				b_taif = {
+				}
+				b_al_johfa = {
+				}
+				b_turubah = {
+				}
+				b_jmumum = {
+				}
+				b_qarn = {
+				}
+				b_al_ukaz = {
+				}
+			}
+			c_khaybar = {
+				color={ 172 253 45 }
+				color2={ 255 255 255 }
+				
+				b_khaybar = {
+				}
+				b_badr = {
+				}
+				b_rabig = {
+				}
+				b_yanbu = {
+				}
+				b_haura = {
+				}
+				b_soridan = {
+				}
+				b_algiar = {
+				}
+			}
+			c_jeddah = {
+				color={ 176 243 59 }
+				color2={ 255 255 255 }
+				
+				b_jeddah = {
+				}
+				b_khulays = {
+				}
+				b_as_sirrayn = {
+				}
+				b_al_lith = {
+				}
+				b_qunfudhah = {
+				}
+				b_bahrah = {
+				}
+				b_usfan = {
+				}
+			}
+			c_asir = {
+				color={ 170 253 63 }
+				color2={ 255 255 255 }
+			
+				b_tabala = {
+				}
+				b_kuthba = {
+				}
+				b_kamaran = {
+				}
+				b_bahah = {
+				}
+				b_sadah = {
+				}
+				b_hajjah = {
+				}
+				b_dam = {
+				}
+			}
+			c_tihama = {
+				color={ 170 253 63 }
+				color2={ 255 255 255 }
+				
+				b_hali = {
+				}
+				b_as_suqaiq = {
+				}
+				b_attar = {
+				}
+				b_bays = {
+				}
+				b_harad = {
+				}
+				b_hamr = {
+				}
+				b_abs = {
+				}
+			}
+		}
+		d_oman = {
+			color={ 93 196 2 }
+			color2={ 255 255 255 }
+			
+			capital = 868 # Muscat
+		
+			c_dhu_zabi = { # Julfar
+				color={ 96 199 5 }
+				color2={ 255 255 255 }
+			
+				b_sohar = {
+				}
+				b_dibba = {
+				}
+				b_qutuf = {
+				}
+				b_dhuzabi = {
+				}
+				b_khorfakkan = {
+				}
+				b_dubai = {
+				}
+				b_julfar = {
+				}
+				b_sharjah = {
+				}
+			}
+			c_hajar = { # Suhar/Suhár
+				color={ 98 201 7 }
+				color2={ 255 255 255 }
+				
+				holy_site = ibadi
+				
+				b_suhar = {
+				}
+				b_alhamra = {
+				}
+				b_ibri = {
+				}
+				b_jabrin = {
+				}
+				b_haran = {
+				}
+				b_masruq = {
+				}
+				b_yanqui = {
+				}
+			}
+			c_muscat = {
+				color={ 100 203 9 }
+				color2={ 255 255 255 }
+			
+				b_muscat = {
+				}
+				b_sur = {
+				}
+				b_samail = {
+				}
+				b_adam = {
+				}
+				b_ibra = {
+				}
+				b_sabt = {
+				}
+				b_lizq = {
+				}
+				b_shiya = {
+				}
+			}
+			c_duqm = { # Nizwa
+				color={ 102 205 11 }
+				color2={ 255 255 255 }
+			
+				b_duqm = {
+				}
+				b_aljazir = {
+				}
+				b_bank = {
+				}
+				b_harima = {
+				}
+				b_nimr = {
+				}
+				b_mahut = {
+				}
+				b_hubara = {
+				}
+				b_masirah = {
+				}
+				b_nizwa = {
+				}
+			}
+		}
+		d_nefoud = {
+			color={ 17 228 10 }
+			color2={ 255 255 255 }
+			
+			capital = 863 # Hajr
+			
+			c_rafha = {
+				color={ 174 253 67 }
+				color2={ 255 255 255 }
+			
+				b_rafha = {
+				}
+				b_aljumaymah = {
+				}
+				b_timiat = {
+				}
+				b_markuz = {
+				}
+				b_lawqah = {
+				}
+				b_duwayd = {
+				}
+				b_uwayqilah = {
+				}
+				b_ashshir = {
+				}
+			}
+			c_hail = {
+				color={ 178 253 71 }
+				color2={ 255 255 255 }
+			
+				b_hail = {
+				}
+				b_asshinan = {
+				}
+				b_alghazalah = {
+				}
+				b_baqa = {
+				}
+				b_iqdah = {
+				}
+				b_mawqaq = {
+				}
+				b_murayfiq = {
+				}
+				b_saban = {
+				}
+			}
+			c_hajr = {
+				color={ 182 253 75 }
+				color2={ 255 255 255 }
+			
+				b_alhudaydah = {
+				}
+				b_assalif = {
+				}
+				b_almaqah = {
+				}
+				b_abha = {
+				}
+				b_khamismushait = {
+				}
+				b_bisha = {
+				}
+				b_baljurashi = {
+				}
+				b_jizan = {
+				}
+			}
+			c_halaban = {
+				color={ 186 253 79 }
+				color2={ 255 255 255 }
+			
+				b_afif = {
+				}
+				b_badaiidyan = {
+				}
+				b_alqaiyah = {
+				}
+				b_aljammaniyah = {
+				}
+				b_albijadiyah = {
+				}
+				b_almaklah = {
+				}
+				b_albaharah = {
+				}
+				b_arradum = {
+				}
+			}
+			c_dariya = {
+				color={ 181 255 99 }
+				color2={ 255 255 255 }
+				
+				b_dariya = {
+				}
+				b_fayd = {
+				}
+				b_al_ajfur = {
+				}
+				b_an_nibaj = {
+				}
+				b_al_qaryatan = {
+				}
+				b_at_talabiya = {
+				}
+				b_zubala = {
+				}
+			}
+		}
+		d_amman = { # Al Bahrain
+			color = { 32 127 30 }
+			color2={ 255 255 255 }
+			
+			capital = 652 # Al Hasa
+			
+			c_kuwait = {
+				color={ 80 170 5 }
+				color2={ 255 255 255 }
+				
+				b_kuwait = {
+				}
+				b_ikaros = {
+				}
+				b_alwafra = {
+				}
+				b_khinan = {
+				}
+				b_arrawdatayn = {
+				}
+				b_ashshuaybah = {
+				}
+				b_anthemusias = {
+				}
+				b_alfalalheel = {
+				}
+			}
+			c_damman = { # Qatif
+				color = { 30 132 37 }
+				color2={ 255 255 255 }
+				
+				b_avan = {
+				}
+				b_najmah = {
+				}
+				b_qatif = {
+				}
+				b_damman = {
+				} 
+				b_jubail = {
+				}
+				b_alaba = {
+				}
+				b_alhinnah = {
+				}
+				b_abuhadriya = {
+				}
+			}
+			c_al_hasa = {
+				color = { 30 112 20 }
+				color2={ 255 255 255 }
+
+				holy_site = qarmatian
+				
+				b_alhasa = {
+				}
+				b_holuf = {
+				}
+				b_foda = {
+				}
+				b_khobar = {
+				}
+				b_almubarraz = {
+				}
+				b_aloyoon = {
+				}
+				b_alomran = {
+				}
+				b_ghunan = {
+				}
+				b_abqaiq = {
+				}
+			}
+			c_bahrein = {
+				color = { 20 99 30 }
+				color2={ 255 255 255 }
+				
+				b_batn_ardasir = {
+				}
+				b_al_masqar = {
+				}
+				b_murwab = {
+				}
+				b_zubarah = {
+				}
+				b_al_naman = {
+				}
+				b_al_khuwayr = {
+				}
+				b_turaynah = { # Fictional, for prosperity
+				}
+			}
+			c_uwal = {
+				color = { 30 89 35 }
+				color2={ 255 255 255 }
+				
+				b_muharraq = {
+				}
+				b_manama = {
+				}
+				b_umm_al_nasan = {
+				}
+				b_sitra = {
+				}
+				b_jidda = {
+				}
+				b_ummalsabaan = {
+				}
+				b_hamala = {
+				}
+				b_aldur = {
+				}
+			}
+		}
+	}
+	
+	k_yemen = {
+		color={ 218 234 33 }
+		color2={ 255 255 255 }
+		
+		capital = 859 # Taizz
+		
+		culture = bedouin_arabic
+		
+		ashkenazi = "Himyar"
+		sephardi = "Himyar"
+		
+		muslim = 3000 # Crusade target weight
+		zoroastrian_group = 300 # Crusade target weight
+		
+		d_sanaa = {
+			color={ 215 180 20 }
+			color2={ 255 255 255 }
+			
+			capital = 860 # Sanaa
+			
+			c_sanaa = {
+				color={ 215 180 20 }
+				color2={ 255 255 255 }
+			
+				b_sanaa = {
+				}
+				b_marib = {
+				}
+				b_qataba = {
+				}
+				b_dhamar = {
+				}
+				b_jabalannabishuayb = {
+				}
+				b_jabaltiyal = {
+				}
+				b_hodeida = {
+				}
+				b_harib = {
+				}
+			}
+			c_najran = {
+				color={ 185 180 20 }
+				color2={ 255 255 255 }
+				
+				b_najran = {
+				}
+				b_sada = {
+				}
+				b_huth = {
+				}
+				b_ribakhah = { # Fictional - For Prosperity
+				}
+				b_hasakat = { # Fictional - For Prosperity
+				}
+				b_az_zawwah = { # Fictional - For Prosperity
+				}
+				b_dahal_jalal = { # Fictional - For Prosperity
+				}
+			}
+			c_al_ahqaf = {
+				color={ 199 170 29 }
+				color2={ 255 255 255 }
+				
+				b_al_ahqaf = {
+				}
+				b_al_abr = {
+				}
+				b_sabwa = {
+				}
+				b_katabiya = { # Fictional - For Prosperity
+				}
+				b_alan = { # Fictional - For Prosperity
+				}
+				b_al_jayat = { # Fictional - For Prosperity
+				}
+				b_bujan = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_taizz = {
+			color={ 195 220 40 }
+			color2={ 255 255 255 }
+			
+			capital = 859 # Taizz
+			
+			c_taizz = {
+				color={ 195 220 40 }
+				color2={ 255 255 255 }
+			
+				b_ibb = {
+				}
+				b_mocha = {
+				}
+				b_taizz = {
+				}
+				b_zafar = {
+				}
+				b_perim = {
+				}
+				b_shuqra = {
+				}
+				b_jibla = {
+				}
+				b_dhisufal = {
+				}
+			}
+			c_aden = {
+				color={ 175 220 46 }
+				color2={ 255 255 255 }
+			
+				b_aden = {
+				}
+				b_lahej = {
+				}
+				b_dhala = {
+				}
+				b_alawbhali = {
+				}
+				b_jaar = {
+				}
+				b_alkawd = {
+				}
+				b_almilah = {
+				}
+				b_alarbadi = {
+				}
+			}
+			c_zabid = {
+				color={ 220 200 40 }
+				color2={ 255 255 255 }
+				
+				b_zabid = {
+				}
+				b_fasal = {
+				}
+				b_al_mahjam = {
+				}
+				b_mukha = {
+				}
+				b_mawr = {
+				}
+				b_ghalafiqa = {
+				}
+				b_hays = {
+				}
+			}
+			c_bayda = {
+				color={ 185 230 20 }
+				color2={ 255 255 255 }
+			
+				b_bayda = {
+				}
+				b_habban = {
+				}
+				b_ashshubaykah = {
+				}
+				b_timna = {
+				}
+				b_ataq = {
+				}
+				b_zinjibar = {
+				}
+				b_alkhabr = {
+				}
+				b_yashbum = {
+				}
+			}
+		}
+		d_socotra = {
+			color={ 142 255 85 }
+			color2={ 255 255 255 }
+			
+			capital = 1369 # Socotra
+			
+			dignity = 10
+			
+			c_socotra = {
+				color={ 142 255 55 }
+				color2={ 255 255 255 }
+			
+				b_qualnsiyah = {
+				}
+				b_tamrida = {
+				}
+				b_qadub = {
+				}
+				b_steroh = {
+				}
+				b_asma = {
+				}
+				b_siqirah = {
+				}
+				b_qashiu = {
+				}
+			}
+		}
+		d_hadramut = {
+			color={ 206 190 55 }
+			color2={ 255 255 255 }
+			
+			capital = 856 # Hadramawt
+			
+			bedouin_arabic = "Hadramawt"
+			maghreb_arabic = "Hadramawt"
+			levantine_arabic = "Hadramawt"
+			egyptian_arabic = "Hadramawt"
+			andalusian_arabic = "Hadramawt"
+			
+			c_kathiri = {
+				color={ 140 255 53 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Hadramawt"
+				maghreb_arabic = "Hadramawt"
+				levantine_arabic = "Hadramawt"
+				egyptian_arabic = "Hadramawt"
+				andalusian_arabic = "Hadramawt"
+				
+				b_shabwa = {
+				}
+				b_lodar = {
+				}
+				b_qana = {
+				}
+				b_seiyun = {
+				}
+				b_mukalla = {
+				}
+				b_shihar = {
+				}
+				b_nisab = {
+				}
+				b_azzan = {
+				}
+			}
+			c_dhofar = {
+				color={ 104 207 13 }
+				color2={ 255 255 255 }
+
+				holy_site = jewish
+				holy_site = samaritan
+				holy_site = karaite
+				
+				b_salalah = {
+				}
+				b_thamarit = {
+				}
+				b_raysut = {
+				}
+				b_amal = {
+				}
+				b_shisr = {
+				}
+				b_dawkah = {
+				}
+				b_durrah = {
+				}
+				b_harzan = {
+				}
+			}
+			c_mahra = {
+				color={ 106 214 15 }
+				color2={ 255 255 255 }
+			
+				b_ghaydah = {
+				}
+				b_nishtun = {
+				}
+				b_damqwat = {
+				}
+				b_qishn = {
+				}
+				b_haswayn = {
+				}
+				b_itab = {
+				}
+				b_alkurah = {
+				}
+				b_alhalya = {
+				}
+			}
+		}
+	}
+	
+	k_egypt = {
+		color={ 10 255 80 }
+		color2={ 255 255 255 }
+		
+		capital	= 796 # Cairo
+		
+		culture = egyptian_arabic
+		
+		catholic = 450 # Crusade target weight
+		orthodox = 20 # Crusade target weight
+		muslim = 400 # Crusade target weight
+		zoroastrian_group = 100 # Crusade target weight
+		zun_pagan_reformed = 100 # Crusade target weight
+		jewish_group = 500 # Crusade target weight
+		hellenic_pagan_reformed = 1000 # Crusade target weight
+		
+		coptic = "Kemet"
+
+		d_alexandria = {
+			color={ 100 219 134 }
+			color2={ 255 255 255 }
+			
+			capital = 802 # Alexandria
+			
+			coptic = "Rakote"
+			
+			c_alexandria = {
+				color={ 102 221 136 }
+				color2={ 255 255 255 }
+
+				holy_site = miaphysite
+				holy_site = monophysite
+				holy_site = hellenic_pagan
+				holy_site = hellenic_pagan_reformed
+				
+				coptic = "Rakote"
+				egyptian_arabic = "al-Iskandariyya"
+				bedouin_arabic = "al-Iskandariyya"
+				maghreb_arabic = "al-Iskandariyya"
+				levantine_arabic = "al-Iskandariyya"
+				andalusian_arabic = "al-Iskandariyya"
+				
+				b_alexandria = {
+					pentarchy = yes
+					coptic = "Rakote"
+					egyptian_arabic = "al-Iskandariyya"
+					bedouin_arabic = "al-Iskandariyya"
+					maghreb_arabic = "al-Iskandariyya"
+					levantine_arabic = "al-Iskandariyya"
+					andalusian_arabic = "al-Iskandariyya"
+				}
+				b_abukir = {
+				}
+				b_damanhur = {
+				}
+				b_hammam = {
+				}
+				b_naucratis = {
+				}
+				b_burgelarab = {
+				}
+				b_marabout = {
+				}
+				b_elkanoun = {
+				}
+			}
+			c_gabiyaha = {
+				color={ 6 255 77 }
+				color2={ 255 255 255 }
+				
+				coptic = "Rashit"
+				egyptian_arabic = "al-Mallidis"
+				bedouin_arabic = "al-Mallidis"
+				maghreb_arabic = "al-Mallidis"
+				levantine_arabic = "al-Mallidis"
+				andalusian_arabic = "al-Mallidis"
+				
+				b_rosetta = {
+					coptic = "Rashit"
+				}
+				b_fuwa = {
+				}
+				b_hermopolis = {
+					egyptian_arabic = "Damanhur"
+					bedouin_arabic = "Damanhur"
+					maghreb_arabic = "Damanhur"
+					levantine_arabic = "Damanhur"
+					andalusian_arabic = "Damanhur"
+				}
+				b_buto = {
+				}
+				b_disuq = {
+				}
+				b_mutubis = {
+				}
+				b_edkhou = {
+				}
+			}
+			c_gizeh = {
+				color={ 110 229 144 }
+				color2={ 255 255 255 }
+				
+				egyptian_arabic = "al-Giziya"
+				bedouin_arabic = "al-Giziya"
+				maghreb_arabic = "al-Giziya"
+				levantine_arabic = "al-Giziya"
+				andalusian_arabic = "al-Giziya"
+				coptic = "Tiperses"
+				
+				b_gizeh = {
+					egyptian_arabic = "al-Giziya"
+					bedouin_arabic = "al-Giziya"
+					maghreb_arabic = "al-Giziya"
+					levantine_arabic = "al-Giziya"
+					andalusian_arabic = "al-Giziya"
+					coptic = "Tiperses"
+				}
+				b_aburowash = {
+				}
+				b_dashur = {
+				}
+				b_zawyetalayran = {
+				}
+				b_abughorob = {
+				}
+				b_abusir = {
+				}
+				b_saqqara = {
+				}
+				b_ellisht = {
+				}
+			}
+			c_kharibta = {
+				color={ 95 228 115 }
+				color2={ 255 255 255 }
+
+				egyptian_arabic = "al-Badaqun"
+				bedouin_arabic = "al-Badaqun"
+				maghreb_arabic = "al-Badaqun"
+				levantine_arabic = "al-Badaqun"
+				andalusian_arabic = "al-Badaqun"
+				coptic = "Arbat"
+
+				b_kharibta = {
+					egyptian_arabic = "Khiribta"
+					bedouin_arabic = "Khiribta"
+					maghreb_arabic = "Khiribta"
+					levantine_arabic = "Khiribta"
+					andalusian_arabic = "Khiribta"
+					coptic = "Arbat"
+				}
+				b_scetis = {
+					egyptian_arabic = "Wadi El Natrun"
+					bedouin_arabic = "Wadi El Natrun"
+					maghreb_arabic = "Wadi El Natrun"
+					levantine_arabic = "Wadi El Natrun"
+					andalusian_arabic = "Wadi El Natrun"
+					coptic = "Sihet"
+				}
+				b_naucratis_egypt = {
+					egyptian_arabic = "Piemro"
+					bedouin_arabic = "Piemro"
+					maghreb_arabic = "Piemro"
+					levantine_arabic = "Piemro"
+					andalusian_arabic = "Piemro"
+				}
+				b_atfih = {
+					coptic = "Petpeh"
+				}
+				b_nikiou = {}
+				b_merimda = {}
+				b_shatnuf = {}
+			}
+		}
+		d_damietta = {
+			color={ 3 255 74 }
+			color2={ 255 255 255 }
+			
+			capital = 798 # Damietta
+			
+			coptic = "Tamiat"
+			greek = "Tamiathis"
+			
+			c_delta = {
+				color={ 9 255 80 }
+				color2={ 255 255 255 }
+				
+				coptic = "Tamiat"
+				greek = "Tamiathis"
+				egyptian_arabic = "ad-Dingawiya"
+				bedouin_arabic = "ad-Dingawiya"
+				maghreb_arabic = "ad-Dingawiya"
+				levantine_arabic = "ad-Dingawiya"
+				andalusian_arabic = "ad-Dingawiya"
+				
+				b_damietta = {
+					coptic = "Tamiat"
+					greek = "Tamiathis"
+				}
+				b_burlus = {
+				}
+				b_saramsah = {
+				}
+				b_burah = {
+				}
+				b_fareskur = {
+				}
+				b_baramun = {
+				}
+				b_tanis = {
+				}
+				b_shirbin = {
+				}
+				b_xois = {
+				}
+			}
+			c_pelusia = {
+				color={ 12 255 83 }
+				color2={ 255 255 255 }
+				
+				coptic = "Jani"
+				egyptian_arabic = "ad-Daqahliya"
+				bedouin_arabic = "ad-Daqahliya"
+				maghreb_arabic = "ad-Daqahliya"
+				levantine_arabic = "ad-Daqahliya"
+				andalusian_arabic = "ad-Daqahliya"
+				
+				b_pelusia = {
+				}
+				b_alsalihiyah = {
+				}
+				b_sile = {
+				}
+				b_ismaillia = {
+				}
+				b_said = {
+				}
+				b_pithom = {
+				}
+				b_serapeum = {
+				}
+			}
+			c_manupura = {
+				color={ 15 255 86 }
+				color2={ 255 255 255 }
+				
+				coptic = "Dishairi"
+				egyptian_arabic = "al-Garbiya"
+				bedouin_arabic = "al-Garbiya"
+				maghreb_arabic = "al-Garbiya"
+				levantine_arabic = "al-Garbiya"
+				andalusian_arabic = "al-Garbiya"
+				
+				b_malhalla = {
+					coptic = "Dishairi"
+				}
+				b_athribis = {
+				}
+				b_busiris = {
+				}
+				b_mansoura = {
+				}
+				b_tanta = {
+				}
+				b_sais = {
+				}
+				b_samannud = {
+				}
+			}
+		}
+		d_cairo = {
+			color={ 20 232 115 }
+			color2={ 255 255 255 }
+			
+			capital = 796 # Cairo
+			
+			zun_pagan_reformed = 50 # Crusade target weight
+			
+			coptic = "Kahiree"
+			
+			c_cairo = {
+				color={ 24 236 119 }
+				color2={ 255 255 255 }
+
+				holy_site = zun_pagan
+				holy_site = zun_pagan_reformed
+				
+				coptic = "Kahiree"
+				
+				b_cairo = {
+					coptic = "Kahiree"
+				}
+				b_fustat = {
+				}
+				b_memphis = {
+				}
+				b_helwan = {
+				}
+				b_heliopolis = {
+				}
+				b_maadi = {
+				}
+				b_tekkekyahudiyya = {
+				}
+				b_merimdabenisalama = {
+				}
+			}
+			c_sarqihya = {
+				color={ 28 240 123 }
+				color2={ 255 255 255 }
+				
+				coptic = "Phelbes"
+				egyptian_arabic = "al-Sarqiya"
+				bedouin_arabic = "al-Sarqiya"
+				maghreb_arabic = "al-Sarqiya"
+				levantine_arabic = "al-Sarqiya"
+				andalusian_arabic = "al-Sarqiya"
+				
+				b_sarqinya = {
+					coptic = "Phelbes"
+				}
+				b_bubastis = {
+				}
+				b_zagazig = {
+				}
+				b_qantir = {
+				}
+				b_agruda = {
+				}
+				b_alhaifar = {
+				}
+				b_minya = {}
+			}
+			c_akhmim = {
+				color={ 32 244 105 }
+				color2={ 255 255 255 }
+
+				coptic = "Khmin"
+				egyptian_arabic = "al-Ihmimiya"
+				bedouin_arabic = "al-Ihmimiya"
+				maghreb_arabic = "al-Ihmimiya"
+				levantine_arabic = "al-Ihmimiya"
+				andalusian_arabic = "al-Ihmimiya"
+
+				b_akhmim = {
+					coptic = "Khmin"
+					egyptian_arabic = "al-Ihmimiya"
+					bedouin_arabic = "al-Ihmimiya"
+					maghreb_arabic = "al-Ihmimiya"
+					levantine_arabic = "al-Ihmimiya"
+					andalusian_arabic = "al-Ihmimiya"
+				}
+				b_al_minya = {}
+				b_cynopolis = {
+					egyptian_arabic = "El Kays"
+					bedouin_arabic = "El Kays"
+					maghreb_arabic = "El Kays"
+					levantine_arabic = "El Kays"
+					andalusian_arabic = "El Kays"
+				}
+				b_antinoe = {
+					coptic = "Antinow"
+				}
+				b_hibeh = {
+					coptic = "Teudjo"
+				}
+				b_besa = {}
+				b_sharuna = {}
+			}
+			c_kolzum = {
+				color={ 40 220 100 }
+				color2={ 255 255 255 }
+
+				egyptian_arabic = "al-Kulzum"
+				bedouin_arabic = "al-Kulzum"
+				maghreb_arabic = "al-Kulzum"
+				levantine_arabic = "al-Kulzum"
+				andalusian_arabic = "al-Kulzum"
+
+				b_kolzum = {
+					egyptian_arabic = "al-Kulzum"
+					bedouin_arabic = "al-Kulzum"
+					maghreb_arabic = "al-Kulzum"
+					levantine_arabic = "al-Kulzum"
+					andalusian_arabic = "al-Kulzum"
+				}
+				b_sokhna = {}
+				b_taufiq = {
+				}
+				b_shallufa = {
+				}
+				b_suez = {
+				}
+				b_clysma = {}
+				b_mount_anthony = {}
+			}
+		}
+		d_aswan = {
+			color={ 41 188 120 }
+			color2={ 255 255 255 }
+			
+			capital = 794 # Aswan
+			
+			coptic = "Sowan"
+			
+			c_aswan = {
+				color={ 43 190 122 }
+				color2={ 255 255 255 }
+				
+				coptic = "Sowan"
+				
+				b_aswan = {
+					coptic = "Sowan"
+				}
+				b_elefantina = {
+				}
+				b_shellal = {
+				}
+				b_bigeh = {
+				}
+				b_veset = {
+				}
+				b_philae = {
+				}
+				b_kalabsha = {
+				}
+			}
+			c_quena = {
+				color={ 32 244 127 }
+				color2={ 255 255 255 }
+				
+				coptic = "Ena"
+				egyptian_arabic = "al-Qusiya"
+				bedouin_arabic = "al-Qusiya"
+				maghreb_arabic = "al-Qusiya"
+				levantine_arabic = "al-Qusiya"
+				andalusian_arabic = "al-Qusiya"
+				
+				b_quena = {
+					coptic = "Ena"
+				}
+				b_qus = {
+				}
+				b_qift = {
+				}
+				b_luxor = {
+				}
+				b_shiblanjah = { # Fictional, for prosperity
+				}
+				b_khalaf = { # Fictional, for prosperity
+				}
+				b_bilbeis = { # Fictional, for prosperity
+				}
+			}
+			c_alqusair = {
+				color={ 32 244 127 }
+				color2={ 255 255 255 }
+
+				greek = "Leucus Limen"
+				coptic = "Leucus Limen"
+				
+				b_kosseir = {}
+				b_safaga = {}
+				b_abughusun = {}
+				b_ummrus = {}
+				b_asfoun = {} # Fictional, for prosperity
+				b_bureid = {} # Fictional, for prosperity
+				b_jamsah = {} # Fictional, for prosperity
+			}
+		}
+		d_sinai = {
+			color={ 88 99 2 }
+			color2={ 255 255 255 }
+			
+			capital = 788 # Farama
+			
+			coptic = "Mafkat"
+			
+			c_farama = {
+				color={ 141 198 5 }
+				color2={ 255 255 255 }
+				
+				coptic = "Peremoun"
+				egyptian_arabic = "al-Farama"
+				maghreb_arabic = "al-Farama"
+				levantine_arabic = "al-Farama"
+				bedouin_arabic = "al-Farama"
+				andalusian_arabic = "al-Farama"
+				ashkenazi = "Sin"
+				sephardi = "Sin"
+				greek = "Pelousion"
+				
+				b_farama = {
+					coptic = "Peremoun"
+					egyptian_arabic = "al-Farama"
+					maghreb_arabic = "al-Farama"
+					levantine_arabic = "al-Farama"
+					bedouin_arabic = "al-Farama"
+					andalusian_arabic = "al-Farama"
+					greek = "Pelousion"
+				}
+				b_sin = {
+				}
+				b_seyan = {
+				}
+				b_romani = {
+				}
+				b_birqatia = {
+				}
+				b_birelabd = {
+				}
+				b_zaaraniq = {
+				}
+				b_mustabiq = {
+				}
+			}
+			c_sinai = {
+				color={ 143 201 8 }
+				color2={ 255 255 255 }
+
+				holy_site = jewish
+				holy_site = samaritan
+				holy_site = karaite
+				
+				coptic = "Mafkat"
+				
+				b_attur = {
+				}
+				b_sharmelsheikh = {
+				}
+				b_mamlah = {
+				}
+				b_nuweiba = {
+				}
+				b_sinbarqa = {
+				}
+				b_dahab = {
+				}
+				b_jabalsamra = {
+				}
+				b_nabq = {
+				}
+			}
+			c_eilat = {
+				color={ 145 203 10 }
+				color2={ 255 255 255 }
+				
+				coptic = "Rashrash"
+				
+				b_eilat = {
+				}
+				b_yahel = {
+				}
+				b_lotan = {
+				}
+				b_ketura = {
+				}
+				b_sapir = {
+				}
+				b_urim = {
+				}
+				b_tzofar = {
+				}
+				b_eliot = {
+				}
+			}
+			c_el-arish = {
+				color={ 147 205 12 }
+				color2={ 255 255 255 }
+				
+				coptic = "Tjaru"
+				
+				b_arish = {
+				}
+				b_tukkot = {
+				}
+				b_kharruba = {
+				}
+				b_masyada = {
+				}
+				b_birelhamma = {
+				}
+				b_mitmatna = {
+				}
+				b_abuaweigila = {
+				}
+				b_zuwayid = {
+				}
+			}
+		}
+		d_faiyum = {
+			color={ 110 240 145 }
+			color2={ 255 255 255 }
+
+			capital = 2001 # Faiyum
+
+			coptic = "Phiom"
+			roman = "Arsinoe"
+
+			c_faiyum = {
+				color={ 115 224 142 }
+				color2={ 255 255 255 }
+
+				coptic = "Phiom"
+				roman = "Arsinoe"
+				egyptian_arabic = "al-Fayyumiya"
+				bedouin_arabic = "al-Fayyumiya"
+				maghreb_arabic = "al-Fayyumiya"
+				levantine_arabic = "al-Fayyumiya"
+				andalusian_arabic = "al-Fayyumiya"
+
+				b_faiyum = {
+					coptic = "Phiom"
+					egyptian_arabic = "al-Fayyumiya"
+					bedouin_arabic = "al-Fayyumiya"
+					maghreb_arabic = "al-Fayyumiya"
+					levantine_arabic = "al-Fayyumiya"
+					andalusian_arabic = "al-Fayyumiya"
+				}
+				b_ahnas = {
+					coptic = "Ahnes"
+				}
+				b_bahnasa = {
+					egyptian_arabic = "al-Bahnasa"
+					bedouin_arabic = "al-Bahnasa"
+					maghreb_arabic = "al-Bahnasa"
+					levantine_arabic = "al-Bahnasa"
+					andalusian_arabic = "al-Bahnasa"
+					coptic = "Pemdje"
+				}
+				b_beni_suef = {
+					coptic = "Panisof"
+				}
+				b_heracleus = {}
+				b_arsinoe_faiyum = {}
+				b_wadi_el_rayan = {}
+			}
+			c_buhairya = {
+				color={ 108 227 142 }
+				color2={ 255 255 255 }
+				
+				coptic = "Ptimenhour"
+				
+				b_buhairya = {
+					coptic = "Ptimenhour"
+				}
+				b_budhkula = {
+				}
+				b_abuminqar = {
+				}
+				b_el_harrah = {}
+				b_ain_et_tibniya = {}
+				b_ibshawai = { # Fictional, for prosperity
+				}
+				b_sineita = { # Fictional, for prosperity
+				}
+			}
+			c_farafra = {
+				color={ 104 234 148 }
+				color2={ 255 255 255 }
+
+				coptic = "Trinitheos"
+
+				b_farafra = {
+					coptic = "Trinitheos"
+				}
+				b_mut = {}
+				b_ain_della = {}
+				b_wadi_hinnis = {}
+				b_white_desert = {
+					egyptian_arabic = "Sahara El Beyda"
+				}
+				b_ain_bishay = {}
+				b_qasrfarfra = {}
+			}
+		}
+		d_asyut = {
+			color={ 30 250 124 }
+			color2={ 255 255 255 }
+
+			coptic = "Sioout"
+			greek = "Lycopolis"
+			roman = "Oasis Magna"
+
+			c_asyut = {
+				color={ 36 248 131 }
+				color2={ 255 255 255 }
+				
+				coptic = "Sioout"
+				greek = "Lycopolis"
+				roman = "Lycopolis"
+				egyptian_arabic = "al-Asyutiya"
+				bedouin_arabic = "al-Asyutiya"
+				maghreb_arabic = "al-Asyutiya"
+				levantine_arabic = "al-Asyutiya"
+				andalusian_arabic = "al-Asyutiya"
+				
+				b_asyut = {
+					coptic = "Sioout"
+					greek = "Lycopolis"
+					roman = "Lycopolis"
+					egyptian_arabic = "al-Asyutiya"
+					bedouin_arabic = "al-Asyutiya"
+					maghreb_arabic = "al-Asyutiya"
+					levantine_arabic = "al-Asyutiya"
+					andalusian_arabic = "al-Asyutiya"
+				}
+				b_kusai = {
+				}
+				b_durunka = {
+				}
+				b_wannina = {
+				}
+				b_beitkhallaf = {
+				}
+				b_meir = {
+				}
+				b_suhaj = {
+				}
+			}
+			c_kharga = {
+				color={ 108 227 142 }
+				color2={ 255 255 255 }
+
+				coptic = "Wah Empsoy"
+				roman = "Oasis Magna"
+				
+				b_elkharga = {
+					coptic = "Wah Empsoy"
+					roman = "Oasis Magna"
+				}
+				b_baris = {}
+				b_ismant = {}
+				b_zuhrah = {} # Fictional, for prosperity
+				b_gahdam = {} # Fictional, for prosperity
+				b_banja = {} # Fictional, for prosperity
+				b_panopolis = {} # Fictional, for prosperity
+			}
+			c_esna = {
+				color={ 33 242 122 }
+				color2={ 255 255 255 }
+
+				coptic = "Sne"
+				greek = "Latopolis"
+				roman = "Latopolis"
+				egyptian_arabic = "Isna"
+				bedouin_arabic = "Isna"
+				maghreb_arabic = "Isna"
+				levantine_arabic = "Isna"
+				andalusian_arabic = "Isna"
+
+				b_esna = {
+					coptic = "Sne"
+					greek = "Latopolis"
+					roman = "Latopolis"
+					egyptian_arabic = "Isna"
+					bedouin_arabic = "Isna"
+					maghreb_arabic = "Isna"
+					levantine_arabic = "Isna"
+					andalusian_arabic = "Isna"
+				}
+				b_armant = {
+					greek = "Hermonthis"
+				}
+				b_edfu = {}
+				b_hiw = {}
+				b_egypthebes = {
+				}
+				b_egypabydos = {
+					coptic = "Ebot"
+				}
+				b_khnum = {}
+			}
+		}
+		d_paraetonium = {
+			color={ 40 240 40 }
+			color2={ 255 255 255 }
+
+			capital = 2005 # Paraetonium
+
+			egyptian_arabic = "al-Baretoun"
+			bedouin_arabic = "al-Baretoun"
+			maghreb_arabic = "al-Baretoun"
+			levantine_arabic = "al-Baretoun"
+			andalusian_arabic = "al-Baretoun"
+			greek = "Paraitonion"
+			coptic = "Paraitonion"
+
+			c_paraetonium = {
+				color={ 40 240 40 }
+				color2={ 255 255 255 }
+
+				egyptian_arabic = "al-Baretoun"
+				bedouin_arabic = "al-Baretoun"
+				maghreb_arabic = "al-Baretoun"
+				levantine_arabic = "al-Baretoun"
+				andalusian_arabic = "al-Baretoun"
+				greek = "Paraitonion"
+				coptic = "Paraitonion"
+
+				b_paraetonium = {
+					egyptian_arabic = "al-Baretoun"
+					bedouin_arabic = "al-Baretoun"
+					maghreb_arabic = "al-Baretoun"
+					levantine_arabic = "al-Baretoun"
+					andalusian_arabic = "al-Baretoun"
+					greek = "Paraitonion"
+					coptic = "Paraitonion"
+				}
+				b_apis = {}
+				b_zygis = {}
+				b_phocusa = {}
+				b_selinais = {}
+				b_leuce = {}
+				b_al_hadid = {}
+			}
+			c_al_alamayn = {
+				color={ 104 223 138 }
+				color2={ 255 255 255 }
+				
+				b_zygra = {}
+				b_elalamein = {
+				}
+				b_sidibarrani = {
+				}
+				b_fuka = {
+				}
+				b_katabathmos = {
+				}
+				b_ghazal = {
+				}
+				b_shammas = {
+				}
+			}
+			c_quattara = {
+				color={ 106 225 140 }
+				color2={ 255 255 255 }
+				
+				egyptian_arabic = "Siwah"
+				bedouin_arabic = "Siwah"
+				maghreb_arabic = "Isiwan"
+				levantine_arabic = "Siwah"
+				andalusian_arabic = "Siwah"
+				coptic = "Sesamu"
+				
+				b_siwa = {
+					egyptian_arabic = "Siwah"
+					bedouin_arabic = "Siwah"
+					maghreb_arabic = "Isiwan"
+					levantine_arabic = "Siwah"
+					andalusian_arabic = "Siwah"
+					coptic = "Sesamu"
+				}
+				b_quattara = {
+					coptic = "Attara"
+				}
+				b_caraoasis = {
+				}
+				b_qaretagnes = {
+				}
+				b_abdannabi = {
+				}
+				b_dayr = {
+				}
+				b_alamelshwawish = {
+				}
+				b_ziwaelbahari = {
+				}
+			}
+		}
+	}
+	
+	k_jerusalem = {
+		color={ 180 180 180 }
+		color2={ 255 255 255 }
+		
+		capital = 774 # Jerusalem
+		
+		ashkenazi = "Yerusholaim"
+		sephardi = "Yerushalaim"
+		roman = "Philistia"
+		armenian = "Philistia"
+		greek = "Philistia"
+		alan = "Philistia"
+		georgian = "Philistia"
+		assyrian = "Philistia"
+		roman = "Judea"
+		
+		assimilate = no # Duchies cannot de jure drift IN or OUT of this title
+		
+		culture = levantine_arabic
+		
+		# Creation/Usurp Trigger
+		allow = {
+			religion_group = christian
+		}
+		
+		# Creation Effect
+		gain_effect = {
+			if = {
+				limit = { NOT = { has_global_flag = created_jerusalem } }
+				prestige = 5000
+				piety = 2000 
+				set_global_flag = created_jerusalem
+			}
+		}
+		
+		christian = 500 # Crusade target weight
+		muslim = 250 # Crusade target weight
+		zoroastrian_group = 200 # Crusade target weight
+		jewish_group = 3000 # Crusade target weight
+		
+		d_oultrejourdain = {
+			color={ 190 190 180 }
+			color2={ 255 255 255 }
+			
+			capital = 723 # Madaba
+		
+			c_negev = {
+				color={ 190 180 165 }
+				color2={ 255 255 255 }
+			
+				b_negev = {
+				}
+				b_yeruham = {
+				}
+				b_dimona = {
+				}
+				b_avdat = {
+				}
+				b_albaqar = {
+				}
+				b_kmehin = {
+				}
+				b_ezuz = {
+				}
+				b_haluza = {
+				}
+			}
+			c_monreal = {
+				color={ 190 170 155 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Wadi Musa"
+				maghreb_arabic = "Wadi Musa"
+				levantine_arabic = "Wadi Musa"
+				egyptian_arabic = "Wadi Musa"
+				andalusian_arabic = "Wadi Musa"
+			
+				b_monreal = {
+					bedouin_arabic = "Wadi Musa"
+					maghreb_arabic = "Wadi Musa"
+					levantine_arabic = "Wadi Musa"
+					egyptian_arabic = "Wadi Musa"
+					andalusian_arabic = "Wadi Musa"
+				}
+				b_hurmniz = {
+				}
+				b_sela = {
+				}
+				b_tafila = {
+				}
+				b_bildad = {
+				}
+				b_paran = {
+				}
+				b_idan = {
+				}
+			}
+			c_kerak = {
+				color={ 150 150 170 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Al-Karak"
+				maghreb_arabic = "Al-Karak"
+				levantine_arabic = "Al-Karak"
+				egyptian_arabic = "Al-Karak"
+				andalusian_arabic = "Al-Karak"
+			
+				b_kirhaseset = {
+				}
+				b_kerak = {
+					bedouin_arabic = "Al-Karak"
+					maghreb_arabic = "Al-Karak"
+					levantine_arabic = "Al-Karak"
+					egyptian_arabic = "Al-Karak"
+					andalusian_arabic = "Al-Karak"
+				}
+				b_tamar = {
+				}
+				b_zoar = {
+				}
+				b_zaimona = {
+				}
+				b_bozra = {
+				}
+				b_punon = {
+				}
+				b_krakdemoab = {
+				}
+			}
+			c_madaba = {
+				color={ 150 140 160 }
+				color2={ 255 255 255 }
+				
+				ashkenazi = "Meidvo"
+				sephardi = "Meidva"
+				
+				b_madaba = {
+				}
+				b_muwaqqar = {
+				}
+				b_qastal = {
+				}
+				b_bilal = {
+				}
+				b_umm_ar-rasas = {
+				}
+				b_sahab = {
+				}
+				b_wadi_al_sir = {
+				}
+				b_samhal = {
+				}
+			}
+		}
+		d_ascalon = {
+			color={ 160 160 200 }
+			color2={ 255 255 255 }
+			
+			capital = 780 # Ascalon
+			
+			ashkenazi = "Ashqelon"
+			sephardi = "Ashqelon"
+		
+			c_darum = {
+				color={ 167 165 190 }
+				color2={ 255 255 255 }
+			
+				b_darum = {
+				}
+				b_gaza = {
+				}
+				b_rafah = {
+				}
+				b_radwan = {
+				}
+				b_salqah = {
+				}
+				b_gerar = {
+				}
+				b_jarara = {
+				}
+				b_abasan = {
+				}
+			}
+			c_jaffa = {
+				color={ 167 190 150 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Arsuf"
+				maghreb_arabic = "Arsuf"
+				levantine_arabic = "Arsuf"
+				egyptian_arabic = "Arsuf"
+				andalusian_arabic = "Arsuf"
+				ashkenazi = "Yophoi"
+				sephardi = "Yapho"
+			
+				b_jaffa = {
+					bedouin_arabic = "Arsuf"
+					maghreb_arabic = "Arsuf"
+					levantine_arabic = "Arsuf"
+					egyptian_arabic = "Arsuf"
+					andalusian_arabic = "Arsuf"
+				}
+				b_arsuf = {
+				}
+				b_lydda = {
+				}
+				b_ibelin = {
+				}
+				b_ramleh = {
+				}
+				b_yazur = {
+				}
+				b_qula = {
+				}
+				b_beitdejan = {
+				}
+			}
+			c_ascalon = {
+				color={ 176 190 140 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Asqalan"
+				maghreb_arabic = "Asqalan"
+				levantine_arabic = "Asqalan"
+				egyptian_arabic = "Asqalan"
+				andalusian_arabic = "Asqalan"
+				ashkenazi = "Ashqelon"
+				sephardi = "Ashqelon"
+			
+				b_ascalon = {
+					bedouin_arabic = "Asqalan"
+					maghreb_arabic = "Asqalan"
+					levantine_arabic = "Asqalan"
+					egyptian_arabic = "Asqalan"
+					andalusian_arabic = "Asqalan"
+				}
+				b_harbijah = {
+				}
+				b_agelen = {
+				}
+				b_laforbie = {
+				}
+				b_blanchegarde = {
+				}
+				b_bothme = {
+				}
+				b_huidre = {
+				}
+				b_semsem = {
+				}
+			}
+			c_beersheb = {
+				color={ 139 170 160 }
+				color2={ 255 255 255 }
+				
+				ashkenazi = "Beir-Sheva"
+				sephardi = "Ber-Sheva"
+			
+				b_beersheb = {
+				}
+				b_estemon = {
+				}
+				b_massada = {
+				}
+				b_debir = {
+				}
+				b_gilat = {
+				}
+				b_rahat = {
+				}
+				b_ofakim = {
+				}
+				b_abuzqayqa = {
+				}
+			}
+		}
+		d_jerusalem = {
+			color={ 202 202 190 }
+			color2={ 255 255 255 }
+			
+			capital = 774 # Jerusalem
+			
+			ashkenazi = "Yerusholaim"
+			sephardi = "Yerushalaim"
+			
+			christian = 250 # Crusade target weight
+			muslim = 250 # Crusade target weight
+		
+			c_jerusalem = {
+				color={ 250 250 230 }
+				color2={ 255 255 255 }
+				
+				ashkenazi = "Yerusholaim"
+				sephardi = "Yerushalaim"
+				
+				christian = 250 # Crusade target weight
+				muslim = 250 # Crusade target weight
+
+				holy_site = catholic
+				holy_site = orthodox
+				holy_site = sunni
+				holy_site = shiite
+				holy_site = miaphysite
+				holy_site = monophysite
+				holy_site = nestorian
+				holy_site = pagan
+				holy_site = yazidi
+				holy_site = jewish
+				holy_site = samaritan
+				holy_site = karaite
+				holy_site = ibadi
+				holy_site = manichean
+				
+				b_mirabel = { # Base name changed to "Majdal Yaba"
+					german = "Mirabel"
+					lombard = "Mirabel"
+					old_frankish = "Mirabel"
+					suebi = "Mirabel"
+					english = "Mirabel"
+					saxon = "Mirabel"
+					old_saxon = "Mirabel"
+					frisian = "Mirabel"
+					dutch = "Mirabel"
+					frankish = "Mirabel"
+					norman = "Mirabel"
+					italian = "Mirabel"
+					occitan = "Mirabel"
+					basque = "Mirabel"
+					castillan = "Mirabel"
+					catalan = "Mirabel"
+					portuguese = "Mirabel"
+					visigothic = "Mirabel"
+					irish = "Mirabel"
+					scottish = "Mirabel"
+					pictish = "Mirabel"
+					welsh = "Mirabel"
+					breton = "Mirabel"
+					greek = "Antipatris"
+					armenian = "Antipatris"
+					georgian = "Antipatris"
+				}
+				b_jerusalem = {
+					pentarchy = yes
+				}
+				b_nablus = {
+				}
+				b_rammala = {
+				}
+				b_beitnuba = {
+				}
+				b_montgisard = {
+				} 
+				b_jericho = {
+				}
+				b_saintsamuel = {
+				}
+			}
+			c_acre = {
+				color={ 230 190 154 }
+				color2={ 255 255 255 }
+				
+				ashkenazi = "Akkoi"
+				sephardi = "Akko"
+		
+				b_acre = {
+				}
+				b_haifa = {
+				}
+				b_syrcaesarea = {
+				}
+				b_merle = {
+				}
+				b_adelon = {
+				}
+				b_manawat = {
+				}
+				b_recordana = {
+				}
+				b_athlith = {
+				}
+			}
+			c_hebron = {
+				color={ 200 210 160 }
+				color2={ 255 255 255 }
+				
+				ashkenazi = "Hevron"
+				sephardi = "Hevron"
+		
+				b_hebron = {
+				}
+				b_bethlehem = {
+				}
+				b_deimachar = {
+				}
+				b_syrbelmont = {
+				}
+				b_alsamoa = {
+				}
+				b_saintcharlton = {
+				}
+				b_latrun = {
+				}
+				b_bethgibelin = {
+				}
+			}
+		}
+		d_galilee = {
+			color={ 225 200 160 }
+			color2={ 255 255 255 }
+			
+			capital = 771 # Tyrus
+			
+			ashkenazi = "HaGalil"
+			sephardi = "HaGalil"
+		
+			c_tiberias = {
+				color={ 225 220 160 }
+				color2={ 255 255 255 }
+			
+				b_tiberias = {
+				}
+				b_nazareth = {
+				}
+				b_mnttabor = {
+				} 
+				b_bethsan = {
+				}
+				b_caymont = {
+				}
+				b_hattin = {
+				}
+				b_ashtera = {
+				}
+				b_lafeve = {
+				}
+			}
+			c_tyrus = {
+				color={ 245 245 200 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Sur"
+				maghreb_arabic = "Sur"
+				levantine_arabic = "Sur"
+				egyptian_arabic = "Sur"
+				andalusian_arabic = "Sur"
+				ashkenazi = "Tzoir"
+				sephardi = "Tzor"
+			
+				b_tyrus = {
+					bedouin_arabic = "Sur"
+					maghreb_arabic = "Sur"
+					levantine_arabic = "Sur"
+					egyptian_arabic = "Sur"
+					andalusian_arabic = "Sur"
+				}
+				b_sarafand = {
+				}
+				b_scandalon = {
+				}
+				b_megedel = {
+				}
+				b_syrmontfort = {
+				}
+				b_casalimbert = {
+				}
+				b_hunin = {
+				}
+				b_syrbelfort = {
+				}
+			}
+			c_beirut = {
+				color={ 255 245 190 }
+				color2={ 255 255 255 }
+			
+				b_beirut = {
+				}
+				b_sidon = {
+				}
+				b_journie = {
+				}
+				b_abualhasan = {
+				}
+				b_cavedetyron = {
+				}
+				b_mashgarah = {
+				} 
+				b_sarepta = {
+				}
+				b_beitkfeya = {
+				}
+			}
+			c_safed = {
+				color={ 230 250 190 }
+				color2={ 255 255 255 }
+			
+				b_safed = {
+				}
+				b_banyas = {
+				}
+				b_chastelet = {
+				}
+				b_toron = {
+				}
+				b_subeiba = {
+				}
+				#b_karmel = {
+				#}
+				b_qatsrin = {
+				}
+				b_belvoir = {
+				}
+			}
+		}
+	}
+	
+	k_syria = {
+		color={ 145 130 88 }
+		color2={ 255 255 255 }
+		
+		culture = levantine_arabic
+		
+		capital = 728 # Damascus
+		
+		orthodox = 200 # Crusade target weight
+		muslim = 200 # Crusade target weight
+		zoroastrian_group = 500 # Crusade target weight
+		
+		d_aleppo = {
+			color={ 85 232 20 }
+			color2={ 255 255 255 }
+			
+			capital = 733 # Aleppo
+			
+			bedouin_arabic = "Halab"
+			maghreb_arabic = "Halab"
+			levantine_arabic = "Halab"
+			egyptian_arabic = "Halab"
+			andalusian_arabic = "Halab"
+			ashkenazi = "Chalpe"
+			sephardi = "Chalpe"
+			greek = "Beroea"
+		
+			c_asas = {
+				color={ 87 234 22 }
+				color2={ 255 255 255 }
+			
+				b_asas = {
+				}
+				b_rakka = {
+				}
+				b_kallinikos = {
+				}
+				b_talabyad = {
+				}
+				b_tabqa = {
+				}
+				b_souriya = {
+				}
+				b_resafa = {
+				}
+				b_zaazouaa = {
+				}
+			}
+			c_aleppo = {
+				color={ 91 238 26 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Halab"
+				maghreb_arabic = "Halab"
+				levantine_arabic = "Halab"
+				egyptian_arabic = "Halab"
+				andalusian_arabic = "Halab"
+				ashkenazi = "Chalpe"
+				sephardi = "Chalpe"
+				greek = "Beroea"
+			
+				b_aleppo = {
+				}
+				b_azaz = {
+				}
+				b_mashala = {
+				} 
+				b_lerminet = {
+				}
+				b_sarmin = {
+				}
+				b_harim = {
+				}
+				b_qusayr = {
+				}
+				b_maaratannuman = {
+				}
+			}
+			c_homs = {
+				color={ 93 240 28 }
+				color2={ 255 255 255 }
+			
+				b_homs = {
+				}
+				b_zweitina = {
+				}
+				b_emesa = {
+				}
+				b_alkhazandar = {
+				}
+				b_qadesh = {
+				}
+				b_sadad = {
+				}
+				b_marmarita = {
+				}
+				b_qatna = {
+				}
+			}
+			c_hama = {
+				color={ 95 242 30 }
+				color2={ 255 255 255 }
+			
+				b_hama = {
+				}
+				b_hamath = {
+				}
+				b_mhardeh = {
+				}
+				b_qarqar = {
+				}
+				b_bara = {
+				} 
+				b_salamiyah = {
+				}
+				b_serjilla = {
+				}
+				b_kharsan = {
+				}
+			}
+		}
+		d_antioch = {
+			color={ 142 63 129 }
+			color2={ 255 255 255 }
+			
+			capital = 764 # Antioch
+		
+			c_antiocheia = {
+				color={ 152 69 135 }
+				color2={ 255 255 255 }
+
+				holy_site = orthodox
+				holy_site = miaphysite
+				holy_site = monophysite
+				
+				b_antiocheia = {
+					pentarchy = yes
+				}
+				b_latakiah = {
+				}
+				b_stsymeon = {
+				}
+				b_darbsak = {
+				}
+				b_hazart = {
+				}
+				b_saone = {
+				}
+				b_harenc = {
+				}
+				b_baghras = {
+				}
+			}
+			c_archa = {
+				color={ 109 194 47 }
+				color2={ 255 255 255 }
+			
+				b_archa = {
+				}
+				b_shayzar = {
+				}
+				b_famia = {
+				}
+				b_chastelblanc = {
+				}
+				b_kafroun = {
+				}
+				b_treiz = {
+				}
+				b_masyaf = {
+				}
+			}
+			c_alexandretta = {
+				color={ 112 197 50 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Iskandarun"
+				maghreb_arabic = "Iskandarun"
+				levantine_arabic = "Iskandarun"
+				egyptian_arabic = "Iskandarun"
+				andalusian_arabic = "Iskandarun"
+				turkish = "Iskandarun"
+				armenian = "Hrosos"
+			
+				b_alexandretta = {
+					bedouin_arabic = "Iskandarun"
+					maghreb_arabic = "Iskandarun"
+					levantine_arabic = "Iskandarun"
+					egyptian_arabic = "Iskandarun"
+					andalusian_arabic = "Iskandarun"
+					turkish = "Iskandarun"
+				}
+				b_rhosus = {
+					armenian = "Hrosos"
+				}
+				b_portbonnel = {
+				}
+				b_myriandros = {
+				}
+				b_portella = {
+				}
+				b_derbasak = {
+				}
+				b_sarvantikar = {
+				}
+				b_larochederissole = {
+				}
+			}
+		}
+		d_tripoli = {
+			color={ 71 150 32 }
+			color2={ 255 255 255 }
+			
+			capital = 767 # Tripoli
+		
+			c_tortosa = {
+				color={ 73 152 34 }
+				color2={ 255 255 255 }
+			
+				b_tortosa = {
+				}
+				b_maraclea = {
+				}
+				b_balemia = {
+				}
+				b_jabala = {
+				}
+				b_valania = {
+				}
+				b_ruad = {
+				}
+				b_alkhawabi = {
+				}
+				b_margat = {
+				}
+			}
+			c_tripoli = {
+				color={ 75 154 36 }
+				color2={ 255 255 255 }
+			
+				b_syrtripoli = {
+				}
+				b_gibelet = {
+				}
+				b_boutron = {
+				}
+				b_arqah = {
+				}
+				b_besmedin = {
+				}
+				b_alqulayat = {
+				}
+				b_nephin = {
+				}
+				b_alqadmus = {
+				}
+			}
+			c_baalbek = {
+				color={ 77 156 38 }
+				color2={ 255 255 255 }
+			
+				b_baalbek = {
+				}
+				b_akkar = {
+				}
+				b_halbah = {
+				}
+				b_zahle = {
+				}
+				b_laboue = {
+				}
+				b_buissera = {
+				}
+				b_riyaq = {
+				}
+				b_chlifa = {
+				}
+				b_krakdeschevaliers = {
+				}
+			}
+		}
+		d_damascus = {
+			color={ 122 255 3 }
+			color2={ 255 255 255 }
+			
+			bedouin_arabic = "Damashq"
+			maghreb_arabic = "Damashq"
+			levantine_arabic = "Damashq"
+			egyptian_arabic = "Damashq"
+			andalusian_arabic = "Damashq"
+			ashkenazi = "Damesheq"
+			sephardi = "Damesheq"				
+			
+			capital = 728 # Damascus
+		
+			c_damascus = {
+				color={ 125 255 6 }
+				color2={ 255 255 255 }
+				
+				bedouin_arabic = "Damashq"
+				maghreb_arabic = "Damashq"
+				levantine_arabic = "Damashq"
+				egyptian_arabic = "Damashq"
+				andalusian_arabic = "Damashq"
+				ashkenazi = "Damesheq"
+				sephardi = "Damesheq"			
+
+				holy_site = shiite
+				holy_site = jewish
+				holy_site = samaritan
+				holy_site = karaite
+				holy_site = qarmatian
+				
+				b_qsarbardawil = {
+				}
+				b_damascus = {
+				}
+				b_daraa = {
+				}
+				b_shahba = {
+				}
+				b_suada = {
+				}
+				b_alsanamayn = {
+				}
+				b_izra = {
+				}
+				b_duma = {
+				}
+			}
+			c_irbid = {
+				color={ 128 255 9 }
+				color2={ 255 255 255 }
+			
+				b_aljun = {
+				}
+				b_irbid = {
+				}
+				b_pella = {
+				}
+				b_yarmouk = {
+				}
+				b_habisjaldak = {
+				}
+				b_aydoun = {
+				}
+				b_ummqais = {
+				}
+				b_gadera = {
+				}
+			}
+			c_al_mafraq = {
+				color={ 134 255 15 }
+				color2={ 255 255 255 }
+			
+				b_mafraq = {
+				}
+				b_thughra = {
+				}
+				b_jarash = {
+				}
+				b_nasib = {
+				}
+				b_buwayda = {
+				}
+				b_ramtah = {
+				}
+				b_taebah = {
+				}
+				b_elemtaih = {
+				}
+			}
+			c_az_zarqa = {
+				color={ 103 214 143 }
+				color2={ 255 255 255 }
+				
+				b_zarqa = {
+				}
+				b_qasramra = {
+				}
+				b_russeifa = {
+				}
+				b_qasralhallabat = {
+				}
+				b_shabib = {
+				}
+				b_hashemiyya = {
+				}
+				b_khurqah = {
+				}
+				b_amratamad = {
+				}
+			}
+			c_amman = {
+				color={ 131 255 12 }
+				color2={ 255 255 255 }
+			
+				b_amman = {
+				}
+				b_dhiban = {
+				}
+				b_salt = {
+				}
+				b_mahis = {
+				}
+				b_fuheis = {
+				}
+				b_deir_alla = {
+				}
+				b_jerash = {
+				}
+				b_al_balqa = {
+				}
+			}
+		}
+		d_palmyra = {
+			color={ 35 232 20 }
+			color2={ 255 255 255 }
+			
+			capital = 730 # Palmyra
+			
+			c_palmyra = {
+				color={ 59 236 20 }
+				color2={ 255 255 255 }
+			
+				b_arak = {
+				}
+				b_palmyra = {
+				}
+				b_arraml = {
+				}
+				b_alqasr = {
+				}
+				b_jihar = {
+				}
+				b_tiace = {
+				} 
+				b_alhuwaysis = {
+				}
+				b_khirbat = {
+				}
+			}
+			c_syria = {
+				color={ 37 234 22 }
+				color2={ 255 255 255 }
+			
+				b_amrah = {
+				}
+				b_otaybah = {
+				}
+				b_adra = {
+				}
+				b_jarba = {
+				}
+				b_qasmiye = {
+				}
+				b_hayjanah = {
+				}
+				b_buraq = {
+				}
+				b_baly = {
+				}
+			}
+			c_druz = {
+				color={ 39 236 24 }
+				color2={ 255 255 255 }
+			
+				b_salkhard = {
+				}
+				b_dibin = {
+				}
+				b_awas = {
+				}
+				b_busra = {
+				}
+				b_ghariyah = {
+				}
+				b_shannireh = {
+				}
+				b_samj = {
+				}
+				b_thoula = {
+				}
+			}
+			c_tadmor = {
+				color={ 43 240 28 }
+				color2={ 255 255 255 }
+			
+				b_husaiba = {
+				}
+				b_bukamal = {
+				}
+				b_alqaim = {
+				}
+				b_salhiyah = {
+				}
+				b_assusah = {
+				}
+				b_subaykhan = {
+				}
+				b_asharah = {
+				}
+				b_alqunjah = {
+				}
+			}
+		}
+	}
+}
+
+e_maghreb = {
+	color={ 73 208 50 }
+	color2={ 255 255 255 }
+	
+	capital = 843 # Marrakech
+	
+	culture = maghreb_arabic
+	
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture = maghreb_arabic
+			}
+		}
+	}
+	
+	short_name = yes
+	
+	k_mauretania = {
+		color={ 58 188 41 }
+		color2={ 255 255 255 }
+		
+		capital = 843 # Marrakech
+		
+		culture = maghreb_arabic
+		
+		muslim = 100 # Crusade target weight
+		west_african_pagan_reformed = 100
+		aztec_reformed = 500
+	
+		d_marrakech = {
+			color={ 43 150 32 }
+			color2={ 255 255 255 }
+			
+			capital = 843 # Marrakech
+		
+			c_marrakech = {
+				color={ 45 152 34 }
+				color2={ 255 255 255 }
+
+				holy_site = aztec
+				holy_site = aztec_reformed
+				
+				b_marrakech = {
+				}
+				b_sidirahhal = {
+				}
+				b_elanakir = {
+				}
+				b_demnat = {
+				}
+				b_ouarzazate = {
+				}
+				b_asni = {
+				}
+				b_thineghir = {
+				}
+			}
+			c_anti-atlas = { # Safi
+				color={ 51 158 40 }
+				color2={ 255 255 255 }
+				
+				b_safi = {}
+				b_agadir = {}
+				b_argana = {}
+				b_illrh = {}
+				b_essaouira = {}
+				b_akermoud = {}
+				b_haddraa = {}
+				b_aitelaouni = {}
+				b_qumelaioun = {}
+				b_aguedal = {}
+			}
+			c_massat = { # Anfa
+				color={ 53 160 42 }
+				color2={ 255 255 255 }
+				
+				b_anfa = {}
+				b_mazaghan = {}
+				b_fadala = {}
+				b_azammut = {}
+				b_amerchen = {} # Fictional, for prosperity
+				b_el_bakra = {} # Fictional, for prosperity
+				b_zidania = {} # Fictional, for prosperity
+			}
+			c_canarias = {
+				color={ 60 190 43 }
+				color2={ 255 255 255 }
+		
+				b_tenerife = {
+				}
+				b_lagomera = {
+				}
+				b_lanzarote = {
+				}
+				b_fuerteventura = {
+				}
+				b_lagraciosa = {
+				}
+				b_alegranza = {
+				}
+				b_lapalma = {
+				}
+			}
+			c_tadla = {
+				color={ 60 190 43 }
+				color2={ 255 255 255 }
+		
+				b_tadla = {}
+				b_afza = {}
+				b_dai = {}
+				b_wazeqqur = {}
+				b_ait_iyat = {}
+				b_wawmana = {}
+				b_ait_itab = {}
+			}
+			c_tinmallal = {
+				color={ 60 190 43 }
+				color2={ 255 255 255 }
+		
+				b_tinmallal = {}
+				b_aghmat = {}
+				b_naffis = {}
+				b_et_tnine_gharbia = {} # Fictional, for prosperity
+				b_imidar_takhtani = {} # Fictional, for prosperity
+				b_dar_er_rhoul = {} # Fictional, for prosperity
+				b_tamrghoute = {} # Fictional, for prosperity
+			}
+		}
+		d_tangiers = {
+			color={ 125 224 105 }
+			color2={ 255 255 255 }
+			
+			capital = 841 # Tangiers
+			
+			c_tangiers = {
+				color={ 51 255 9 }
+				color2={ 255 255 255 }
+			
+				b_tangiers = {
+				}
+				b_laraiche = {
+				}
+				b_mulaybuselham = {
+				}
+				b_alcazarquivir = {
+				}
+				b_asilah = {
+				}
+				b_ainbenamar = {
+				}
+				b_barrha = {
+				}
+				b_charkia = {
+				}
+			}
+			c_cebta = { # Ceuta
+				color={ 54 255 12 }
+				color2={ 255 255 255 }
+				
+				maghreb_arabic = "Sebta"
+				
+				b_cueta = {
+					maghreb_arabic = "Sebta"
+				}
+				b_tetouan = {
+				}
+				b_Xauen = {
+				}
+				b_aulef = {
+				}
+				b_babtaza = {
+				}
+				b_targuist = {
+				}
+				b_mdiq = {
+				}
+				b_martil = {
+				}
+			}
+			c_el_rif = {
+				color={ 28 240 63 }
+				color2={ 255 255 255 }
+			
+				b_melilla = {}
+				b_alhoceima = {}
+				b_midar = {}
+				b_ketama = {} #Cebta/Fes
+				b_nador = {}
+				b_driouch = {}
+				b_id_amy = {} # Fictional, for prosperity
+				b_agadirene = {} # Fictional, for prosperity
+			}
+		}
+		d_fes = {
+			color={ 20 232 55 }
+			color2={ 255 255 255 }
+			
+			capital = 840 # Fes
+		
+			c_fes = {
+				color={ 24 236 59 }
+				color2={ 255 255 255 }
+			
+				b_fes = {}
+				b_zerhoun = {}
+				b_elhajeb = {}
+				b_enjil = {}
+				b_bouanane = {}
+				b_izerhan = {}
+				b_subu = {}
+			}
+			c_meknes = {
+				color={ 32 244 67 }
+				color2={ 255 255 255 }
+				
+				b_meknes = {}
+				b_sefrou = {}
+				b_tagragra = {}
+				b_terhirha = {} # Fictional, for prosperity
+				b_soughi = {} # Fictional, for prosperity
+				b_irhzi = {} # Fictional, for prosperity
+				b_amouguer = {} # Fictional, for prosperity
+			}
+			c_taza = {
+				color={ 32 244 67 }
+				color2={ 255 255 255 }
+				
+				b_taza = {}
+				b_safsaf = {}
+				b_geurcif = {}
+				b_saka = {}
+				b_tighdouine = {} # Fictional, for prosperity
+				b_mania = {} # Fictional, for prosperity
+				b_tamdrost = {} # Fictional, for prosperity
+			}
+			c_muluja = {
+				color={ 32 244 67 }
+				color2={ 255 255 255 }
+				
+				b_missour = {}
+				b_benitajjit = {}
+				b_ainechchair = {}
+				b_eladergha = {} # Fictional, for prosperity
+				b_souangountour = {} # Fictional, for prosperity
+				b_lemseied = {} # Fictional, for prosperity
+				b_elkrama = {} # Fictional, for prosperity
+			}
+			c_infa = {
+				color={ 48 255 6 }
+				color2={ 255 255 255 }
+			
+				b_infa = {
+				}
+				b_rabat = {
+				}
+				b_sale = {
+				}
+				b_tiflet = {
+				}
+				b_berrechid = {
+				}
+				b_azemmour = {
+				}
+				b_khouribga = {
+				}
+				b_oulmes = {
+				}
+			}
+		}
+		d_alger = {
+			color={ 32 150 43 }
+			color2={ 255 255 255 }
+			
+			capital = 831 # Al Djazir
+		
+			c_al_djazair = {
+				color={ 53 200 87 }
+				color2={ 255 255 255 }
+			
+				b_algiers = {
+				}
+				b_tipasa = {
+				}
+				b_chiffa = {
+				}
+				b_sidiakacha = {
+				}
+				b_rhedadoua = {
+				}
+				b_elachour = {
+				}
+				b_elRdair = {
+				}
+				b_tirourda = {
+				}
+				b_tiziouzou = { #Alger / Bejaija
+				}
+				b_mirabeau = { #Alger
+				}
+			}
+			c_orania = {
+				color={ 45 192 79 }
+				color2={ 255 255 255 }
+			
+				b_oran = {
+				}
+				b_mostaganem = {
+				}
+				b_aintemouchent = {
+				}
+				b_maghnia = {
+				}
+				b_benisaf = {
+				}
+				b_ainelberd = {
+				}
+				b_merselhadjad = {
+				}
+				b_gdyel = {
+				}
+			}
+			c_beni_yanni = {
+				color={ 35 153 46 }
+				color2={ 255 255 255 }
+			
+				b_bourmedes = {
+				}
+				b_tafoughalt = {
+				}
+				b_tigzirt = {
+				}
+				b_bujima = {
+				}
+				b_azeffoun = {
+				}
+				b_azazga = {
+				}
+				b_taoudouch = {
+				}
+				b_thiza = {
+				}
+			}
+		}
+		d_tlemcen = {
+			color={ 65 122 40 }
+			color2={ 255 255 255 }
+			
+			capital = 834 # Tlemcen
+			
+			c_tlemcen = {
+				color={ 43 190 77 }
+				color2={ 255 255 255 }
+			
+				b_tlemcen = {
+				}
+				b_sidibelabbes = {
+				}
+				b_muaskar = {
+				}
+				b_bedrabine = {
+				}
+				b_tessala = {
+				}
+				b_letelagh = {
+				}
+				b_dhaya = {
+				}
+				b_elhaicaiba = {
+				}
+			}
+			c_snassen = { # Wajda
+				color={ 36 248 71 }
+				color2={ 255 255 255 }
+			
+				b_oujda = {
+				}
+				b_jerada = {
+				}
+				b_saldia = {
+				}
+				b_ainbenimathar = {
+				}
+				b_debdou = {
+				}
+				b_tendrara = {
+				}
+				b_berkane = {
+				}
+				b_ahfir = {
+				}
+			}
+			c_figuig = { # Tendara
+				color={ 32 244 67 }
+				color2={ 255 255 255 }
+			
+				b_figuig = {}
+				b_bouarfa = {}
+				b_ich = {}
+				b_ganastel = {} # Fictional, for prosperity
+				b_benhammouch = {} # Fictional, for prosperity
+				b_drablia = {} # Fictional, for prosperity
+				b_randon = {} # Fictional, for prosperity
+			}
+		}
+		d_sijilmasa = {
+			color={ 100 168 77 }
+			color2={ 255 255 255 }
+			
+			capital = 918 # Sijilmasa
+			
+			c_sijilmasa = {
+				color={ 72 214 60 }
+				color2={ 255 255 255 }
+				
+				b_sijilmasa = {}
+				b_merzouga = {}
+				b_tanamouste= {}
+				b_ertoud = {}
+				b_merzane = {}
+				b_hannabou = {}
+				b_tadaout = {}
+				b_tisserdmine = {}
+			}
+			c_tudgha = {
+				color={ 130 180 61 }
+				color2={ 255 255 255 }
+				
+				b_tudgha = {}
+				b_alnif = {}
+				b_oled_amira = {} # Fictional, for prosperity
+				b_tarzout = {} # Fictional, for prosperity
+				b_sidi_bidi = {} # Fictional, for prosperity
+				b_zbair = {} # Fictional, for prosperity
+				b_ouaourhrout = {} # Fictional, for prosperity
+			}
+			c_ziz = {
+				color={ 130 180 61 }
+				color2={ 255 255 255 }
+				
+				b_ziz = {}
+				b_bechar = {}
+				b_boudnib = {}
+				b_douar_chaouia = {} # Fictional, for prosperity
+				b_msanne = {} # Fictional, for prosperity
+				b_aghoud = {} # Fictional, for prosperity
+				b_tiskouit = {} # Fictional, for prosperity
+			}
+			c_taghaza = {
+				color={ 130 180 61 }
+				color2={ 255 255 255 }
+				
+				b_taghaza = {}
+				b_kerzaz = {}
+				b_metarta = {}
+				b_reggane = {}
+				b_adrar = {}
+				b_aougrout = {}
+				b_charouine = {}
+				b_alouarta = {}
+			}
+		}
+		d_sous = {
+			color={ 56 140 0 }
+			color2={ 255 255 255 }
+			
+			capital = 847 # Sous/Tharasset
+			
+			c_tharasset = { # Sous
+				color={ 47 154 16 }
+				color2={ 255 255 255 }
+				
+				b_tiznit = {}
+				b_igilliz = {}
+				b_rgab = {}
+				b_guelmim = {}
+				b_mihrleft = {}
+				b_belkassem = {}
+				b_ouaouteit = {}
+				b_taroudaut = {}
+				b_tata = {}
+				b_biourga = {}
+			}
+			c_ifni = {
+				color={ 49 156 38 }
+				color2={ 255 255 255 }
+				
+				b_ifni = {}
+				b_tharasset = {}
+				b_tartaya = {}
+				b_tantan = {}
+				b_akhfennir = {}
+				b_chbika = {}
+				b_tidergit = {}
+				b_amot = {}
+				b_tiglit = {}
+			}
+			c_warzazat = {
+				color={ 41 125 16 }
+				color2={ 255 255 255 }
+				
+				b_warzazat = {}
+				b_tasagdah = {}
+				b_shwan = {}
+				b_qalat_sless = {} # Fictional, for prosperity
+				b_el_jehifa = {} # Fictional, for prosperity
+				b_chtaouna = {} # Fictional, for prosperity
+				b_timhata = {} # Fictional, for prosperity
+			}
+			c_draa = {
+				color={ 58 127 35 }
+				color2={ 255 255 255 }
+				
+				holy_site = west_african_pagan
+				holy_site = west_african_pagan_reformed
+				
+				b_tazagourt = {}
+				b_tizgui = {}
+				b_kasbaeljoua = {}
+				b_alogoum = {}
+				b_jenane_el_menzeh = {} # Fictional, for prosperity
+				b_beni_djenade = {} # Fictional, for prosperity
+				b_tamchennennt = {} # Fictional, for prosperity
+			}
+		}
+		d_adrar = {
+			color={ 90 190 5 }
+			color2={ 255 255 255 }
+			
+			capital = 920 # Ouadane
+			
+			c_ouadane = {
+				color={ 23 109 202 }
+				color2={ 255 255 255 }
+				
+				b_ouadane = {}
+				b_idjil = {}
+				b_wadan = {}
+				b_azuggi = {}
+				b_ksaralkiali = {}
+				b_wadane = {} #Fictional, for prosperity
+				b_kaliki = {} #Fictional, for prosperity
+				b_gag = {} #Fictional, for prosperity
+			}
+			c_idjil = {
+				color={ 8 76 207 }
+				color2={ 255 255 255 }
+				
+				b_bir_um_grein = {}
+				b_zouerat = {}
+				b_tazadit = {}
+				b_rouessa = {}
+				b_fderick = {}
+				b_krossa = {} #Fictional, for prosperity
+				b_mosa = {} #Fictional, for prosperity
+			}
+		}
+		d_tahert = {
+			color={ 78 237 115 }
+			color2={ 255 255 255 }
+			
+			capital = 830 # Tahert
+			
+			c_lemdiyya = { # Tahert
+				color={ 51 198 85 }
+				color2={ 255 255 255 }
+				
+				b_tiaret = {
+				}
+				b_medea = {
+				}
+				b_relizane = {
+				}
+				b_aindefla = {
+				}
+				b_elrhenb = {
+				}
+				b_aintorki = {
+				}
+				b_blida = {
+				}
+				b_elhachem = {
+				}
+				b_sidimohammed = {
+				}
+			}
+			c_atlas_mnt = { # Askedal
+				color={ 49 196 83 }
+				color2={ 255 255 255 }
+				
+				holy_site = ibadi
+				
+				b_askedal = {
+				}
+				b_djelfa = {
+				}
+				b_bordj = {
+				}
+				b_elyourh = {
+				}
+				b_selmana = {
+				}
+				b_ainrich = {
+				}
+				b_ainzmila = {
+				}
+				b_hassibenmadjeb = {
+				}
+			}
+			c_hanyan = { # Yalala
+				color={ 47 194 81 }
+				color2={ 255 255 255 }
+				
+				b_hanyan = {
+				}
+				b_naama = {
+				}
+				b_saida = {
+				}
+				b_alkasdir = {
+				}
+				b_alancha = {
+				}
+				b_magoura = {
+				}
+				b_raselma = {
+				}
+				b_bougtob = {
+				}
+			}
+			c_ashir = {
+				color={ 72 214 60 }
+				color2={ 255 255 255 }
+				
+				b_asir_yasir = {}
+				b_asir_banya = {}
+				b_sidiheg = {}
+				b_roumana = {}
+				b_sidinhar = {}
+				b_mouddat = {} # Fictional, for prosperity
+				b_iboutarene = {} # Fictional, for prosperity
+			}
+		}
+	}
+	
+	k_africa = {
+		color={ 21 255 3 }
+		color2={ 255 255 255 }
+		
+		capital = 817 # Tunis
+		
+		culture = maghreb_arabic
+		
+		orthodox = 10 # Crusade target weight
+		muslim = 200 # Crusade target weight
+		west_african_pagan_reformed = 50
+		zoroastrian_group = 50 # Crusade target weight
+
+		bedouin_arabic = Ifriqiya
+		maghreb_arabic = Ifriqiya
+		egyptian_arabic = Ifriqiya
+		levantine_arabic = Ifriqiya
+		andalusian_arabic = Ifriqiya
+		
+		d_tunis = {
+			color={ 45 255 3 }
+			color2={ 255 255 255 }
+			
+			capital = 817 # Tunis
+		
+			c_tunis = {
+				color={ 23 235 98 }
+				color2={ 255 255 255 }
+			
+				b_tunis = {
+				}
+				b_ariana = {
+				}
+				b_sousse = {
+				}
+				b_cartaghe = {
+				}
+				b_zaghouan = {
+				}
+				b_benarous = {
+				}
+				b_kelibia = {
+				}
+				b_hammamet = {
+				}
+			}
+			c_medjerda = {
+				color={ 26 238 101 }
+				color2={ 255 255 255 }
+				
+				b_medjerda = {
+				}
+				b_lekef = {
+				}
+				b_siliana = {
+				}
+				b_qaafur = {
+				}
+				b_sidimubarak = {
+				}
+				b_dougga = {
+				}
+				b_elkrib = {
+				}
+			}
+			c_bizerte = {
+				color={ 29 241 104 }
+				color2={ 255 255 255 }
+			
+				b_bizerte = {
+				}
+				b_tunbeja = {
+				}
+				b_jendouba = {
+				}
+				b_ghezala = {
+				}
+				b_manziljamal = {
+				}
+				b_almatin = {
+				}
+				b_tamra = {
+				}
+				b_netza = {
+				}
+			}
+			c_kairwan = {
+				color={ 32 244 107 }
+				color2={ 255 255 255 }
+			
+				b_kairouan = {
+				}
+				b_jalula = {
+				}
+				b_raqqada = {
+				}
+				b_sidibouzid = {
+				}
+				b_haffouz = {
+				}
+				b_chebika = {
+				}
+				b_meknassy = {
+				}
+			}
+			c_mahdia = {
+				color={ 35 247 110 }
+				color2={ 255 255 255 }
+			
+				b_mahdia = {
+				}
+				b_monastir = {
+				}
+				b_sfax = {
+				}
+				b_msaken = {
+				}
+				b_agareb = {
+				}
+				b_neffatia = {
+				}
+				b_sidimansour = {
+				}
+				b_lalaouza = {
+				}
+				b_lacroix = {
+				}
+			}
+		}
+		d_tripolitania = {
+			color={ 63 175 117 }
+			color2={ 255 255 255 }
+			
+			capital = 811 # Tripolitania
+		
+			c_tripolitana = {
+				color={ 45 192 107 }
+				color2={ 255 255 255 }
+			
+				b_libtripoli = {
+				}
+				b_sabratah = {
+				}
+				b_baniwaled = {
+				}
+				b_gherlan = {
+				}
+				b_funduq = {
+				}
+				b_aljamil = {
+				}
+				b_mazuzah = {
+				}
+			}
+			c_djerba = {
+				color={ 49 196 111 }
+				color2={ 255 255 255 }
+			
+				b_houmtsouk = {
+				}
+				b_midoun = {
+				}
+				b_ajim = {
+				}
+				b_aghir = {
+				}
+				b_abarda = {
+				}
+				b_elmey = {
+				}
+				b_cedriane = {
+				}
+				b_taguermess = {
+				}
+				b_tataouine = {
+				}
+				b_aljanain = {
+				}
+			}
+			c_leptis_magna = {
+				color={ 53 200 115 }
+				color2={ 255 255 255 }
+			
+				b_leptismagna = {
+				}
+				b_misratah = {
+				}
+				b_alhasun = {
+				}
+				b_abunujaym = {
+				}
+				b_qirdah = {
+				}
+				b_alghiran = {
+				}
+				b_naimah = {
+				}
+				b_gioda = {
+				}
+			}
+			c_nafusa = {
+				color={ 69 222 82 }
+				color2={ 255 255 255 }
+				
+				b_nafusa = {}
+				b_dar_jdida = {} # Fictional, for prosperity
+				b_erruda = {} # Fictional, for prosperity
+				b_dar_dred = {} # Fictional, for prosperity
+				b_sejenane = {} # Fictional, for prosperity
+				b_dechret_bahirine = {} # Fictional, for prosperity
+				b_kroussia = {} # Fictional, for prosperity
+			}
+			c_nalut = {
+				color={ 45 165 97 }
+				color2={ 255 255 255 }
+				
+				b_nalut = {}
+				b_fursata = {}
+				b_douar_bessouf = {} # Fictional, for prosperity
+				b_tamaghzah = {} # Fictional, for prosperity
+				b_dar_el_mzali = {} # Fictional, for prosperity
+				b_el_amarmria = {} # Fictional, for prosperity
+				b_el_mstiri = {} # Fictional, for prosperity
+			}
+		}
+		d_syrte = {
+			color={ 146 222 115 }
+			color2={ 255 255 255 }
+			
+			capital = 809 # Syrte
+			
+			c_syrte = {
+				color={ 120 202 135 }
+				color2={ 255 255 255 }
+			
+				b_syrte = {}
+				b_abuhadi = {}
+				b_assidr = {}
+				b_lanuf = {}
+				b_nawfalliyah = {}
+				b_sinauen = {} # Fictional, for prosperity
+				b_lathrun = {} # Fictional, for prosperity
+			}
+			c_tadjrift = {
+				color={ 57 204 119 }
+				color2={ 255 255 255 }
+				
+				b_tadjrift = {}
+				b_waddan = {}
+				b_assultan = {}
+				b_zaafran = {} # Fictional, for prosperity
+				b_gicherra = {} # Fictional, for prosperity
+				b_ouifat = {} # Fictional, for prosperity
+				b_qaryat_it_zaydan = {} # Fictional, for prosperity
+			}
+			c_ajadabiya = {
+				color={ 131 233 97 }
+				color2={ 255 255 255 }
+				
+				b_ajadabiya = {}
+				b_al_aghaila = {}
+				b_qaryatbishr = {}
+				b_gargaresc = {} # Fictional, for prosperity
+				b_tagma = {} # Fictional, for prosperity
+				b_el_fogha = {} # Fictional, for prosperity
+				b_karsah = {} # Fictional, for prosperity
+			}
+		}
+		d_jerid = {
+			color={ 38 179 27 }
+			color2={ 255 255 255 }
+			
+			capital = 814 # Gabes
+			
+			c_gabes = {
+				color={ 38 250 113 }
+				color2={ 255 255 255 }
+			
+				b_gabes = {
+				}
+				b_kebili = {
+				}
+				b_medenine = {
+				}
+				b_haddej = {
+				}
+				b_steftimi = {
+				}
+				b_alqalah = {
+				}
+				b_al_hamma = {
+				}
+			}
+			c_suf = {
+				color={ 38 220 50 }
+				color2={ 255 255 255 }
+				
+				b_suf = {}
+				b_dar_abd_el_aziz = {} # Fictional, for prosperity
+				b_beni_kaltoum = {} # Fictional, for prosperity
+				b_fatnassa = {} # Fictional, for prosperity
+				b_beni_dinhet = {} # Fictional, for prosperity
+				b_bidane = {} # Fictional, for prosperity
+				b_el_aouina = {} # Fictional, for prosperity
+			}
+			c_gafsa = {
+				color={ 38 150 97 }
+				color2={ 255 255 255 }
+				
+				b_gafsa = {}
+				b_nafta = {}
+				b_madas = {}
+				b_hamma = {}
+				b_taqyus = {}
+				b_tozeur = {}
+				b_gourine = {} # Fictional, for prosperity
+			}
+		}
+		d_cyrenaica = {
+			color={ 32 150 63 }
+			color2={ 255 255 255 }
+			
+			capital = 806 # Cyrenaica
+
+			egyptian_arabic = "Barqa"
+			bedouin_arabic = "Barqa"
+			maghreb_arabic = "Barqa"
+			levantine_arabic = "Barqa"
+			andalusian_arabic = "Barqa"			
+		
+			c_cyrenaica = {
+				color={ 34 152 65 }
+				color2={ 255 255 255 }
+			
+				b_cyrene = {
+				}
+				b_marsasusah = {
+				}
+				b_derna = {
+				}
+				b_altamimi = {
+				}
+				b_alqubbah = {
+				}
+				b_athrun = {
+				}
+				b_mukhayta = {
+				}
+				b_khadra = {
+				}
+			}
+			c_senoussi = {
+				color={ 36 154 67 }
+				color2={ 255 255 255 }
+			
+				b_kufra = {
+				}
+				b_jalu = {
+				}
+				b_jakharrah = {
+				}
+				b_gabr = {
+				}
+				b_attallab = {
+				}
+				b_attaj = {
+				}
+				b_buzayman = {
+				}
+				b_tazirbu = {
+				}
+			}
+			c_benghazi = {
+				color={ 38 156 69 }
+				color2={ 255 255 255 }
+
+				egyptian_arabic = "Barqa"
+				bedouin_arabic = "Barqa"
+				maghreb_arabic = "Barqa"
+				levantine_arabic = "Barqa"
+				andalusian_arabic = "Barqa"	
+			
+				b_benghazi = {
+				}
+				b_barca = {
+				}
+				b_oriana = {
+				}
+				b_tulmaytath = {
+				}
+				b_ajdabiya = {
+				}
+				b_daryanah = {
+				}
+				b_tansulukh = {
+				}
+				b_jardinah = {
+				}
+			}
+			c_tobruk = {
+				color={ 40 158 71 }
+				color2={ 255 255 255 }
+			
+				b_tobruk = {
+				}
+				b_bardia = {
+				}
+				b_sollum = {
+				}
+				b_alqardabah = {
+				}
+				b_acroma = {
+				}
+				b_kambut = {
+				}
+				b_zanzur = {
+				}
+				b_rukbah = {
+				}
+			}
+		}
+		d_kabylia = {
+			color={ 164 247 131 }
+			color2={ 255 255 255 }
+			
+			capital = 822 # Bejaija
+		
+			c_tell_atlas = { # Setif
+				color={ 37 155 48 }
+				color2={ 255 255 255 }
+			
+				b_setif = {
+				}
+				b_ikjan = {
+				}
+				b_zaoula = {
+				}
+				b_nacina = {
+				}
+				b_draaelmizan = {
+				}
+				b_tagoughalt = {
+				}
+				b_mechreck = {
+				}
+				b_tadjenanet = {
+				}
+			}
+			c_constantine = {
+				color={ 45 251 102 }
+				color2={ 255 255 255 }
+			
+				b_constantine = {
+				}
+				b_tijis = {
+				}
+				b_guelma = {
+				}
+				b_elkhroub = {
+				}
+				b_oumelbouaghi = {
+				}
+				b_mechtakebira = {
+				}
+				b_guerrah = {
+				}
+			}
+			c_bejaija = {
+				color={ 49 255 106 }
+				color2={ 255 255 255 }
+			
+				b_bejaija = {
+				}
+				b_mila = {
+				}
+				b_elbekara = {
+				}
+				b_jijel = {
+				}
+				b_boudaoud = {
+				}
+				b_gantas = {
+				}
+				b_eldjabia = {
+				}
+				b_akaoudj = {
+				}
+			}
+			c_annaba = {
+				color={ 51 255 108 }
+				color2={ 255 255 255 }
+			
+				b_annabah = {
+				}
+				b_eltarf = {
+				}
+				b_soukahras = {
+				}
+				b_skikda = {
+				}
+				b_elbouni = {
+				}
+				b_boudjama = {
+				}
+				b_drean = {
+				}
+				b_meroudj = {
+				}
+			}
+			c_biskra = {
+				color={ 47 253 104 }
+				color2={ 255 255 255 }
+			
+				b_biskra = {
+				}
+				b_magra = {
+				}
+				b_batna = {
+				}
+				b_sidiokba = {
+				}
+				b_nebka = {
+				}
+				b_bigou = {
+				}
+				b_branis = {
+				}
+				b_mekhadma = {
+				}
+			}
+			c_tebessa = {
+				color={ 51 255 108 }
+				color2={ 255 255 255 }
+			
+				b_tebessa = {}
+				b_baghaya = {}
+				b_tala = {}
+				b_maydara = {}
+				b_maskiyana = {}
+				b_kasserine = {}
+				b_khenchela = {}
+			}
+		}
+		d_mzab = {
+			color={ 74 242 62 }
+			color2={ 255 255 255 }
+			
+			capital = 822 # Laghouat/Ouled Nail
+			
+			c_mzab = { # Ghardaia
+				color={ 39 157 50 }
+				color2={ 255 255 255 }
+			
+				b_ghardaia = {}
+				b_noumerat = {}
+				b_sebseb = {}
+				b_zelfana = {}
+				b_bermane = {}
+				b_mzab = {}
+				b_ouargla = {}
+			}
+			c_ouled_nail = { # Laghouat
+				color={ 41 159 52 }
+				color2={ 255 255 255 }
+				
+				b_al_aghwat = {
+				}
+				b_tilghemt = {
+				}
+				b_tubirett = {
+				}
+				b_msila = {
+				}
+				b_ainzia = {
+				}
+				b_beneldir = {
+				}
+				b_bordjelcaid = {
+				}
+			}
+			c_arigh = {
+				color={ 51 255 108 }
+				color2={ 255 255 255 }
+				
+				b_arigh = {}
+				b_ajlu = {}
+				b_bouchaoui = {} # Fictional, for prosperity
+				b_mgadid = {} # Fictional, for prosperity
+				b_zemours = {} # Fictional, for prosperity
+				b_timoktene = {} # Fictional, for prosperity
+				b_rabta = {} # Fictional, for prosperity
+			}
+			c_tuggurt = {
+				color={ 51 255 108 }
+				color2={ 255 255 255 }
+				
+				b_tuggurt = {}
+				b_elalia = {}
+				b_elbour = {}
+				b_timeliline = {} # Fictional, for prosperity
+				b_smadja = {} # Fictional, for prosperity
+				b_tennsaout = {} # Fictional, for prosperity
+				b_meftah = {} # Fictional, for prosperity
+			}
+		}
+	}
+}
+
+e_abyssinia = {
+	color={ 181 133 68 }
+	color2={ 255 255 255 }
+	
+	capital = 883 # Gondar
+	
+	culture = ethiopian
+	
+	k_abyssinia = {
+		color={ 120 62 20 }
+		color2={ 255 255 255 }
+		
+		capital = 883 # Gondar
+		
+		culture = ethiopian
+		
+		jewish_group = 100
+		
+		d_harer = { # Berbera
+			color={ 127 151 52 }
+			color2={ 255 255 255 }
+			
+			capital = 872 # Berbera
+		
+			c_busaso = {
+				color={ 127 151 52 }
+				color2={ 255 255 255 }
+			
+				b_mosylon = {
+				}
+				b_bandaraassim = {
+				}
+				b_lasanod = {
+				}
+				b_garoowe = {
+				}
+				b_qardho = {
+				}
+				b_erigavo = {
+				}
+				b_hadaftimo = {
+				}
+				b_buraan = {
+				}
+			}
+			c_berbera = {
+				color={ 127 151 52 }
+				color2={ 255 255 255 }
+			
+				b_berbera = {
+				}
+				b_maydh = {
+				}
+				b_gabiley = {
+				}
+				b_burco = {
+				}
+				b_mandera = {
+				}
+				b_daarbuduq = {
+				}
+				b_shiikh = {
+				}
+			}
+			c_zeila = {
+				color={ 127 151 52 }
+				color2={ 255 255 255 }
+			
+				b_zeila = {
+				}
+				b_hargeysa = {
+				}
+				b_borama = {
+				}
+				b_amud = {
+				}
+				b_jijiga = {
+				}
+				b_dilla = {
+				}
+				b_lughaya = {
+				}
+			}
+		}
+		
+		d_axum = {
+			color={ 186 135 70 }
+			color2={ 255 255 255 }
+			
+			capital = 875 # Aksum
+		
+			c_aksum = {
+				color={ 186 135 70 }
+				color2={ 255 255 255 }
+
+				holy_site = miaphysite
+				holy_site = monophysite
+				
+				b_adwa = {
+				}
+				b_aksum = {
+				}
+				b_mekele = {
+				}
+				b_rama2 = {
+				}
+				b_adigrat = {
+				}
+				b_hawzen = {
+				}
+				b_yeha = {
+				}
+			}
+			c_massawa = {
+				color={ 186 135 70 }
+				color2={ 255 255 255 }
+			
+				b_massawa = {
+				}
+				b_cheren = {
+				}
+				b_dahano = {
+				}
+				b_matara = {
+				}
+				b_qohaito = {
+				}
+				b_adulis = {
+				}
+				b_sembel = {
+				}
+			}
+			c_akordat = {
+				color={ 186 135 70 }
+				color2={ 255 255 255 }
+			
+				b_akordat = {
+				}
+				b_teseney = {
+				}
+				b_antalla = {
+				}
+				b_barentu = {
+				}
+				b_dghe = {
+				}
+				b_mogolo = {
+				}
+				b_shambuko = {
+				}
+			}
+
+		}
+		d_semien = {
+			color={ 146 105 50 }
+			color2={ 255 255 255 }
+			
+			ashkenazi = "Beta Israel"
+			sephardi = "Beta Israel"
+			
+			capital = 1380 # Semien
+
+			c_tigrinya = {
+				color={ 146 105 50 }
+				color2={ 255 255 255 }
+			
+				b_tigrinya = {
+				}
+				b_adi_ramets = {
+				}
+				b_amba_maderiya = {
+				}
+				b_bilamba = {
+				}
+				b_golonco = {
+				}
+				b_zagamat = {
+				}
+				b_adenna = {
+				}
+			}
+			c_semien = {
+				color={ 146 105 50 }
+				color2={ 255 255 255 }
+			
+				b_dabat = {
+				}
+				b_debark = {
+				}
+				b_ciarveta = {
+				}
+				b_oivela_mariam = {
+				}
+				b_belesa = {
+				}
+				b_amja_lebes = {
+				}
+				b_ambaras = {
+				}
+			}
+		}
+		d_afar = {
+			color={ 159 189 65 }
+			color2={ 255 255 255 }
+			
+			capital = 873 # Harer
+
+			c_assab = {
+				color={ 159 189 65 }
+				color2={ 255 255 255 }
+			
+				b_assab = {
+				}
+				b_debaysima = {
+				}
+				b_rehayto = {
+				}
+				b_manda = {
+				}
+				b_agurto = {
+				}
+				b_mergebla = {
+				}
+				b_gehare = {
+				}
+			}
+			c_asayita = {
+				color={ 159 189 65 }
+				color2={ 255 255 255 }
+			
+				b_asayita = {
+				}
+				b_afambo = {
+				}
+				b_serdo = {
+				}
+				b_dedai = {
+				}
+				b_lofefle = {
+				}
+				b_tendaho = {
+				}
+				b_jewaha = {
+				}
+			}
+			c_harer = {
+				color={ 159 189 65 }
+				color2={ 255 255 255 }
+			
+				b_dakkar = {
+				}
+				b_harar = {
+				}
+				b_alemaya = {
+				}
+				b_diridawa = {
+				}
+				b_kurfachele = {
+				}
+				b_kombolcha = {
+				}
+				b_babile = {
+				}
+			}
+			c_tadjoura = {
+				color={ 159 189 65 }
+				color2={ 255 255 255 }
+			
+				b_tadjoura = {
+				}
+				b_berenice = {
+				}
+				b_obock = {
+				}
+				b_galafi = {
+				} 
+				b_dikhil = {
+				}
+				b_djibouti = {
+				}
+				b_holhol = {
+				}
+				b_randa = {
+				}
+			}
+		}
+		d_gondar= {
+			color={ 215 119 45 }
+			color2={ 255 255 255 }
+			
+			capital = 883 # Gondar
+		
+			c_gondar = {
+				color={ 215 119 45 }
+				color2={ 255 255 255 }
+			
+				b_fasilghebbi = {
+				}
+				b_gondar = {
+				}
+				b_roha = {
+				}
+				b_ambassel = {
+				}
+				b_bahirdar = {
+				}
+				b_magdala = {
+				}
+				b_tanaqirqos = {
+				}
+				b_dembiya = {
+				}
+			}
+			c_begemder = {
+				color={ 215 119 45 }
+				color2={ 255 255 255 }
+			
+				b_gereger = {
+				}
+				b_filakit = {
+				}
+				b_chekerefta = {
+				}
+				b_danya = {
+				}
+				b_bete_yohanis = {
+				}
+				b_awariya = {
+				}
+				b_maryamu = {
+				}
+			}
+		}
+		d_wag = {
+			color={ 186 100 55 }
+			color2={ 255 255 255 }
+			
+			capital =  1417 # Wag
+		
+			c_wag = {
+				color={ 186 100 55 }
+				color2={ 255 255 255 }
+			
+				b_sekota = {
+				}
+				b_zumbo = {
+				}
+				b_sacca = {
+				}
+				b_tsaicha = {
+				}
+				b_lashwa = {
+				}
+				b_indeher_giba = {
+				}
+				b_liktaba = {
+				}
+			}
+			c_lakomelza = {
+				color={ 186 100 55 }
+				color2={ 255 255 255 }
+			
+				b_dessye = {
+				}
+				b_kembolcha = {
+				}
+				b_ziya = {
+				}
+				b_habru = {
+				}
+				b_tigaja = {
+				}
+				b_cherkwa = {
+				}
+				b_metene = {
+				}
+			}
+		}
+		d_gojjam = {
+			color={ 137 90 76 }
+			color2={ 255 255 255 }
+			
+			capital =  1280 # Gojjam
+		
+			c_gojjam = {
+				color={ 137 90 76 }
+				color2={ 255 255 255 }
+			
+				b_gojjam = {
+				}
+				b_mankorar = {
+				}
+				b_eliyas = {
+				}
+				b_yejube = {
+				}
+				b_godana_mikael = {
+				}
+				b_yegeleka = {
+				}
+				b_baremma = {
+				}
+			}
+			c_matamma = {
+				color={ 137 90 76 }
+				color2={ 255 255 255 }
+			
+				b_ginbo = {
+				}
+				b_bonga = {
+				}
+				b_gishabay = {
+				}
+				b_wacha = {
+				}
+				b_chiri = {
+				}
+				b_kaffa = {
+				}
+				b_yadeta = {
+				}
+				b_garo = {
+				}
+			}
+		}
+		d_damot = {
+			color={ 198 93 30 }
+			color2={ 255 255 255 }
+			
+			capital = 1428 # Damot
+		
+			c_damot = {
+				color={ 198 93 30 }
+				color2={ 255 255 255 }
+			
+				b_malbarde = {
+				}
+				b_muger = {
+				}
+				b_yirga_chefe = {
+				}
+				b_fasha = {
+				}
+				b_awasa = {
+				}
+				b_zima = {
+				}
+				b_teltele = {
+				}
+			}
+			c_asosa = {
+				color={ 198 93 30 }
+				color2={ 255 255 255 }
+			
+				b_asosa = {
+				}
+				b_bambasi = {
+				}
+				b_genetemariam = {
+				}
+				b_debrezeyit = {
+				}
+				b_mankush = {
+				}
+				b_dibate = {
+				}
+				b_ketema = {
+				}
+				b_kormuk = {
+				}
+			}
+		}
+		d_shewa = {
+			color={  147 90 48 }
+			color2={ 255 255 255 }
+			
+			capital = 882 # Ankober
+		
+			c_ankober = {
+				color={  147 90 48 }
+				color2={ 255 255 255 }
+			
+				b_ankober = {
+				}
+				b_doqaqit = {
+				}
+				b_qundi = {
+				}
+				b_saqqa = {
+				}
+				b_aliyuamba = {
+				}
+				b_berehet = {
+				}
+				b_keyagebriel = {
+				}
+				b_tegulet = {
+				}
+			}
+			c_antalo = {
+				color={  147 90 48 }
+				color2={ 255 255 255 }
+			
+				b_entoto = {
+				}
+				b_hayq = {
+				}
+				b_shewa = {
+				}
+				b_antsokia = {
+				}
+				b_debreberhan = {
+				}
+				b_bale = {
+				}
+				b_debrelibanos = {
+				}
+				b_oromos = {
+				}
+			}
+		}
+	}
+	
+	k_nubia = {
+		color={ 180 85 39 }
+		capital = 793 # Makuria
+		
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					religion_group = christian
+				}
+			}
+		}
+		
+		d_nobatia = {
+			color = { 162 133 85 }
+
+			capital = 1282 # Dotawo
+
+			c_dotawo = {
+				color = { 160 130 85 }
+				color2={ 255 255 255 }
+			
+				b_dotawo = {
+				}
+				b_jebeladda = {
+				}
+				b_faras = {
+				}
+				b_qasribrim = {
+				}
+				b_ballana = {
+				}
+				b_buhen = {
+				}
+				b_premnis = {
+				}
+			}
+			c_nobatia = {
+				color = { 150 140 65 }
+				color2={ 255 255 255 }
+			
+				b_semna = {
+				}
+				b_wawa = {
+				}
+				b_delgo = {
+				}
+				b_soleb = {
+				}
+				b_abri = {
+				}
+				b_akasha = {
+				}
+				b_kulubnarti = {
+				}
+			}
+			c_nubia = {
+				color = { 145 130 60 }
+				color2={ 255 255 255 }
+			
+				b_anag = {
+				}
+				b_eirayab = {
+				}
+				b_salala = {
+				}
+				b_nafab = {
+				}
+				b_komotit = {
+				}
+				b_tahtani = {
+				}
+				b_fanoidig = {
+				}
+				b_nubia = {
+				}
+			}
+			c_aydhab = {
+				color = { 125 120 65 }
+				color2={ 255 255 255 }
+			
+				b_aydhab = {
+				}
+				b_halayeb = {
+				}
+				b_troglodytica = {
+				}
+				b_marsaalam = {
+				}
+				b_elba = {
+				}
+				b_shalateen = {
+				}
+				b_zabargad = {
+				}
+			}
+		}
+		d_nubia = { # Makuria
+			color = { 141 162 79 }
+			capital = 793 # Makuria
+			
+			c_makuria = {
+				color = { 140 155 75 }
+				color2={ 255 255 255 }
+			
+				b_dongola = {
+				}
+				b_kawa = {
+				}
+				b_affat = {
+				}
+				b_qubban = {
+				}
+				b_gabriya = {
+				}
+				b_kerma = {
+				}
+				b_kerat = {
+				}
+			}
+			c_napata = {
+				color = { 155 140 67 }
+				color2={ 255 255 255 }
+
+				b_napata = {
+				}
+				b_marawi = {
+				}
+				b_ghazali = {
+				}
+				b_kanisah = {
+				}
+				b_korti = {
+				}
+				b_keheilli = {
+				}
+				b_karima = {
+				}
+			}
+			c_atbara = {
+				color = { 145 120 50 }
+				color2={ 255 255 255 }
+			
+				b_atbara = {
+				}
+				b_meruwah = {
+				}
+				b_begarawiyah = {
+				}
+				b_hajaralasla = {
+				}
+				b_ummmardi = {
+				}
+				b_abudis = {
+				}
+				b_shendi = {
+				}
+			}
+
+		}
+		d_sennar = { # Alodia
+			color={ 128 60 20 }
+			color2={ 255 255 255 }
+			
+			capital = 1334 # Alodia
+			
+			c_alodia = {
+				color={ 135 65 20 }
+				color2={ 255 255 255 }
+			
+				b_alwa = {
+				}
+				b_soba = {
+				}
+				b_omdurman = {
+				}
+				b_barah = {
+				}
+				b_omjerky = {
+				}
+				b_malaka = {
+				}
+				b_wawissi = {
+				}
+			}
+			c_sennar = {
+				color={ 115 60 20 }
+				color2={ 255 255 255 }
+			
+				b_sennar = {
+				}
+				b_tabat = {
+				}
+				b_sinjah = {
+				}
+				b_bakkah = {
+				}
+				b_kukur = {
+				}
+				b_galgani = {
+				}
+				b_wadrawah = {
+				}
+				b_kinanah = {
+				}
+			}
+			c_kosti = {
+				color={ 160 70 40 }
+				color2={ 255 255 255 }
+			
+				b_kosti = {
+				}
+				b_abbeit = {
+				}
+				b_tandalti = {
+				}
+				b_umm_ruwaba = {
+				}
+				b_dalang = {
+				}
+				b_kaduqli = {
+				}
+				b_lagawa = {
+				}
+			}
+			c_darfur = {
+				color={ 75 190 165 }
+				color2={ 255 255 255 }
+				
+				b_el_fasher = {}
+				b_ain_farah = {}
+				b_uri = {}
+				b_um_marrih = {} # Fictional - For Prosperity
+				b_kalkal = {} # Fictional - For Prosperity
+				b_ad_dukaydik = {} # Fictional - For Prosperity
+				b_masalat = {} # Fictional - For Prosperity
+			}
+			c_bayuda = {
+				color={ 64 216 152 }
+				color2={ 255 255 255 }
+				
+				b_bayuda = {}
+				b_almeragh = {}
+				b_atongour = {} # Fictional - For Prosperity
+				b_jeroko = {} # Fictional - For Prosperity
+				b_es_soriba = {} # Fictional - For Prosperity
+				b_elkhandaq = {} # Fictional - For Prosperity
+				b_faras_east = {} # Fictional - For Prosperity
+			}
+		}
+		d_hayya = { # Blemmyia
+			color={ 186 91 41 }
+			color2={ 255 255 255 }
+			
+			capital = 878 # Hayya
+
+			culture = nubian
+		
+			c_suakin = {
+				color={ 176 85 35 }
+				color2={ 255 255 255 }
+			
+				b_sawakin = {
+				}
+				b_tisiamti = {
+				}
+				b_salum = {
+				}
+				b_taiwi = {
+				}
+				b_derkin = {
+				}
+				b_dubarua = {
+				}
+				b_komelshokafa = {
+				}
+			}
+			c_trinkitat = {
+				color={ 141 55 35 }
+				color2={ 255 255 255 }
+			
+				b_trinkitat = {
+				}
+				b_derri = {
+				}
+				b_tokar = {
+				}
+				b_farata = {
+				}
+				b_teb = {
+				}
+				b_kwababa = {
+				}
+				b_mukden = {
+				}
+			}
+			c_hayya = {
+				color={ 186 91 41 }
+				color2={ 255 255 255 }
+			
+				b_hayya = {
+				}
+				b_musmer = {
+				}
+				b_sinkat = {
+				}
+				b_kataigarsa = {
+				}
+				b_aliab = {
+				}
+				b_gebeit = {
+				}
+				b_taris = {
+				}
+			}
+			c_kassala = {
+				color={ 200 101 34 }
+				color2={ 255 255 255 }
+			
+				b_kassala = {
+				}
+				b_doka = {
+				}
+				b_dinder = {
+				}
+				b_aroma = {
+				}
+				b_kagnarti = {
+				}
+				b_tebteb = {
+				}
+				b_gherset = {
+				}
+			}
+			c_gezira = {
+				color={ 215 122 38 }
+				color2={ 255 255 255 }
+				
+				b_wolqayt = {}
+				b_showak = {}
+				b_tangasi = {} # Fictional - For Prosperity
+				b_dahar_jihena = {} # Fictional - For Prosperity
+				b_koijam = {} # Fictional - For Prosperity
+				b_shawwaf = {} # Fictional - For Prosperity
+				b_karkab = {} # Fictional - For Prosperity
+			}
+		}
+	}
+	
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = east_african
+			}
+		}
+		has_landed_title=k_egypt
+		has_landed_title=k_nubia
+		has_landed_title=k_abyssinia
+	}
+}
+
+e_britannia = {
+	color={ 172 22 22 }
+	color2={ 255 255 255 }
+	capital = 32 # Middlesex
+	
+	welsh = Prydain
+	irish = Alba
+	scottish = Alba
+	pictish = Alba
+	breton = Prydain
+	
+	# Creation/usurpation trigger
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture = english
+				culture = saxon
+				culture = norman
+				culture_group = celtic
+				culture_group = north_germanic
+			}
+		}
+	}
+
+	k_england = {
+		color={ 202 26 26 }
+		color2={ 255 255 255 }
+		capital = 32 # Middlesex
+		dignity = 10 # Counted as having this many more counties than it does
+		
+		catholic = 300 # Crusade target weight
+		norse_pagan_reformed = 200 # Crusade target weight
+		aztec_reformed = 500
+		
+		culture = saxon
+
+		welsh = Lloegyr
+		pictish = Lloegyr
+		breton = Lloegyr
+		irish = Sasana
+		roman = Britannia
+		
+		d_northumberland = {
+			color={ 255 0 0 }
+			color2={ 255 255 255 }
+			
+			capital = 52 # Northumberland
+
+			saxon = Northumbria
+			
+			c_northumberland = {
+				color={ 255 10 0 }
+				color2={ 255 255 255 }
+				
+				saxon = Northumbria
+			
+				b_morpeth = {
+				}
+				b_bamburgh = {
+					norwegian = "Bamborg"
+					danish = "Bamborg"
+					swedish = "Bamborg"
+					norse = "Bamborg"
+				}
+				b_hexham = {
+				}
+				b_newcastle = {
+					saxon="Corbridge"
+				}
+				b_alnwick = {
+				}
+				b_st_aidans = {
+				}
+				b_mitford = {
+				}
+			}
+			c_lindisfarne = {
+				color={ 255 20 4 }
+				color2={ 255 255 255 }
+							
+				b_lindisfarne = {
+				}
+				b_yeavering = {
+				}
+				b_norham = {
+				}
+				b_tweedmouth = {
+				}
+				b_lowick = {
+				}
+				b_etal = {
+				}
+				b_cornhill = {
+				}
+			}
+			c_durham = {
+				color={ 255 15 0 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Dunholm"
+				danish = "Dunholm"
+				swedish = "Dunholm"
+				norse = "Dunholm"
+	
+				b_gateshead = {
+				}
+				b_durham = {
+					norwegian = "Dunholm"
+					danish = "Dunholm"
+					swedish = "Dunholm"
+					norse = "Dunholm"
+				}
+				b_chester-le-street = {
+				}
+				b_jarrow = {
+				}
+				b_hartlepool = {
+				}
+				b_auckland = {
+				}
+				b_raby = {
+				}
+				b_st_cuthbert = {
+				}
+			}
+		}
+		d_cumbria = {
+			color = { 44 175 255 }
+			color2={ 255 255 255 }
+			
+			capital = 53 # Cumberland
+			
+			welsh = "Gogledd Rheged" #North Rheged
+			
+			c_cumberland = {
+				color={ 30 185 243 }
+				color2={ 255 255 255 }
+	
+				b_carlisle = {
+				}
+				b_burgh = {
+				}
+				b_gilsland = {
+				}
+				b_penrith = {
+				}
+				b_egremont = {
+				}
+				b_papcastlet = {
+				}
+				b_cockermouth = {
+				}
+				b_dacre = {
+				}
+			}
+			c_westmorland = {
+				color={ 255 55 10 }
+				color2={ 255 255 255 }
+			
+				b_appleby = {
+				}
+				b_kendal = {
+				}
+				b_lowther = {
+				}
+				b_cartmel = {
+				}
+				b_kirkby = {
+				}
+				b_brough = {
+				}
+				b_shap = {
+				}
+				b_brougham = {
+				}
+			}
+		}
+		d_lancaster = {
+			color={ 255 48 0 }
+			color2={ 255 255 255 }
+			
+			capital = 58 # Lancaster
+			
+			welsh = "De Rheged" #South Rheged
+			
+			c_lancaster = {
+				color={ 255 50 5 }
+				color2={ 255 255 255 }
+
+				saxon = "Amounderness"
+
+				b_salford = {
+				}
+				b_lancaster = {
+				}
+				b_preston = {
+				}
+				b_sawley = {
+				}
+				b_gisburn = {
+				}
+				b_furness = {
+				}
+				b_clitheroe = {
+				}
+			}
+			c_chester = {
+				color={ 255 60 15 }
+				color2={ 255 255 255 }
+			
+				b_chester = {
+				}
+				b_halton = {
+				}
+				b_malpas = {
+				}
+				b_northwich = {
+				}
+				b_macclesfield = {
+				}
+				b_beeston = {
+				}
+				b_sandbach = {
+				}
+				b_nantwich = {
+				}
+			}
+			c_derby = {
+				color={ 255 65 20 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Djuraby"
+				danish = "Djuraby"
+				swedish = "Djuraby"
+				norse = "Djuraby"
+			
+				b_derby = {
+					norwegian = "Djuraby"
+					danish = "Djuraby"
+					swedish = "Djuraby"
+					norse = "Djuraby"
+				}
+				b_bakewell = {
+				}
+				b_repton = {
+				}
+				b_bolsover = {
+				}
+				b_castleton = {
+				}
+				b_chesterfield = {
+				}
+				b_burton = {
+				}
+				b_wirksworth = {
+				}
+			}
+		}
+		d_york = {
+			color={ 255 90 15 }
+			color2={ 255 255 255 }
+			
+			capital = 57 # York
+			
+			dignity = 2
+			
+			norwegian = "Jorvik"
+			danish = "Jorvik"
+			swedish = "Jorvik"
+			norse = "Jorvik"
+			saxon = "Deira"
+			welsh = Ebrauc
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 12
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			c_york = {
+				color={ 255 80 5 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Jorvik"
+				danish = "Jorvik"
+				swedish = "Jorvik"
+				norse = "Jorvik"
+				welsh = Ebrauc
+				roman = Eboracum
+	
+				b_york = {
+					norwegian = "Jorvik"
+					danish = "Jorvik"
+					swedish = "Jorvik"
+					norse = "Jorvik"
+					welsh = "Caer Ebrauc"
+					roman = Eboracum
+				}
+				b_richmond = {
+					saxon = "Catterick"
+				}
+				b_st_peters = {
+				}
+				b_scarborough = {
+					norwegian = "Skardaborg"
+					danish = "Skardaborg"
+					swedish = "Skardaborg"
+					norse = "Skardaborg"
+				}
+				b_middlesbrough = {
+				}
+				b_whitby = {
+				}
+				b_thirsk = {
+				}
+			}
+			c_hull = {
+				color={ 250 93 16 }
+				color2={ 255 255 255 }
+				
+				welsh = Deywr
+	
+				b_hull = {
+				}
+				b_stamford_bridge = {
+				}
+				b_beverley = {
+				}
+				b_wyke = {
+				}
+				b_guildhall = {
+				}
+				b_bridlington = {
+				}
+				b_hornsea = {
+				}
+			}
+			c_leeds = {
+				color={ 245 103 20 }
+				color2={ 255 255 255 }
+
+				welsh = Elmet
+	
+				b_leeds = {
+				}
+				b_doncaster = {
+				}
+				b_sherburn = {
+				}
+				b_selby = {
+				}
+				b_sheffield = {
+				}
+				b_pontefract = {
+				}
+				b_conisbrough = {
+					norwegian = "Kungsborg"
+					danish = "Kungsborg"
+					swedish = "Kungsborg"
+					norse = "Kungsborg"
+				}
+			}
+			c_yoredale = {
+				color={ 248 86 33 }
+				color2={ 255 255 255 }
+
+				welsh = Dunoting
+	
+				b_yoredale = {
+				}
+				b_settle = {
+				}
+				b_ilkley = {
+				}
+				b_bolton = {
+				}
+				b_skipton = {
+				}
+				b_bainbridge = {
+				}
+				b_middleham = {
+				}
+			}
+		}
+		d_norfolk = {
+			color={ 200 90 0 }
+			color2={ 255 255 255 }
+			
+			capital = 70 # Norfolk
+			
+			norman = "Norfolk"
+			english = "Norfolk"
+			
+			c_norfolk = {
+				color={ 255 95 5 }
+				color2={ 255 255 255 }
+			
+				b_norwich = {
+				}
+				b_thetford = {
+				}
+				b_buckenham = {
+				}
+				b_lynn = {
+				}
+				b_elmham = {
+				}
+				b_castle_rising = {
+				}
+				b_chatteris = {
+				}
+			}
+			c_suffolk = {
+				color={ 255 100 10 }
+				color2={ 255 255 255 }
+			
+				b_ipswich = {
+				}
+				b_ely = {
+				}
+				b_bury = {
+				}
+				b_lowestoft = {
+					danish = "Lothvistoft"
+					swedish = "Lothvistoft"
+					norwegian = "Lothvistoft"
+					norse = "Lothvistoft"
+				}
+				b_dunwich = {
+				}
+				b_stow = {
+				}
+				b_bungay = {
+				}
+				b_framlingham = {
+				}
+			}
+		}
+		d_bedford = { # Essex
+			color={ 241 15 15 }
+			color2={ 255 255 255 }
+			capital = 72 # Essex
+			
+			norman = "Bedford"
+			english = "Bedford"
+			welsh = "Calchwynedd"
+			
+			c_bedford = {
+				color={ 241 30 30 }
+				color2={ 255 255 255 }
+				
+				b_bedford = {
+				}
+				b_hertford = {
+				}
+				b_st_albans = {
+				}
+				b_berkhamsted = {
+				}
+				b_luton = {
+				}
+				b_dunstable = {
+				}
+				b_watford = {
+				}
+				b_ashridge = {
+				}
+			}
+			c_middlesex = {
+				color={ 241 90 35 }
+				color2={ 255 255 255 }
+			
+				holy_site = aztec
+				holy_site = aztec_reformed
+
+				b_westminster = {
+					used_for_dynasty_names = no
+					norse=Vestmystur
+				}
+				b_london = {
+					used_for_dynasty_names = no
+					norse=Lundúnir
+				}
+				b_st_pauls = {
+				}
+				b_tottenham = {
+				}
+				b_fulham = {
+				}
+				b_staines = {
+				}
+				b_harrow = {
+				}
+				b_chelsea = {
+				}
+			}
+			c_essex = {
+				color={ 241 25 25 }
+				color2={ 255 255 255 }
+				
+				b_maldon = {
+				}
+				b_havering = {
+				}
+				b_dunmow = {
+				}
+				b_colchester = {
+				}
+				b_waltham = {
+				}
+				b_barking = {
+				}
+				b_pleshey = {
+				}
+				b_hedingham = {
+				}
+			}
+			c_northampton = {
+				color={ 255 110 5 }
+				color2={ 255 255 255 }
+				
+				b_peterborough = {
+				}
+				b_huntingdon = {
+				}
+				b_ramsey = {
+				}
+				b_northampton = {
+				}
+				b_kettering = {
+				}
+				b_cambridge = {
+				}
+				b_crowland = {
+				}
+				b_rockingham = {
+				}
+			}
+		}
+		d_hereford = { # Mercia
+			color={ 241 47 15 }
+			color2={ 255 255 255 }
+			
+			capital = 67 # Warwick
+			
+			dignity = 5
+			
+			norman = "Warwick"
+			english = "Warwick"
+			welsh = "Pengwern"
+			
+			c_leicester = {
+				color={ 255 85 10 }
+				color2={ 255 255 255 }
+			
+				b_leicester = {
+				}
+				b_nottingham = {
+				}
+				b_southwell = {
+				}
+				b_newark = {
+				}
+				b_hucknall = {
+				}
+				b_tickhill = {
+				}
+				b_worksop = {
+				}
+				b_newstead = {
+					saxon = "Saint Martin"
+				}
+			}
+			c_lincoln = {
+				color={ 255 90 20 }
+				color2={ 255 255 255 }
+				
+				saxon = "Lindsey"
+
+				b_gainsborough = {
+				}
+				b_lincoln = {
+				}
+				b_boston = {
+				}
+				b_spalding = {
+				}
+				b_stamford = {
+				}
+				b_grantham = {
+				}
+				b_louth = {
+				}
+				b_bardney = {
+				}
+			}
+			c_warwick = {
+				color={ 241 60 30 }
+				color2={ 255 255 255 }
+			
+				b_coventry = {
+				}
+				b_warwick = {
+				}
+				b_lichfield = {
+				}
+				b_stafford = {
+				}
+				b_tamworth = {
+				}
+				b_kenilworth = {
+				}
+				b_tutbury = {
+				}
+				b_dudley = {
+				}
+			}
+			c_worcester = {
+				color={ 250 25 25 }
+				color2={ 255 255 255 }
+				
+				b_worcester = {
+				}
+				b_evesham = {
+				}
+				b_droitwich = {
+				}
+				b_kidderminster = {
+				}
+				b_pershore = {
+				}
+				b_malvern = {
+				}
+				b_bromsgrove = {
+				}
+				b_laughern = {
+				}
+			}
+		}
+		d_gloucester = { # Hwicce
+			color={ 241 79 15 }
+			color2={ 255 255 255 }
+			
+			capital = 21 # Gloucester
+			
+			norman = Gloucester
+			english = Gloucester
+			roman = Glevum
+			welsh = "Guenet"
+			
+			c_gloucester = {
+				color={ 241 85 25 }
+				color2={ 255 255 255 }
+
+				roman = Glevum
+			
+				b_gloucester = {
+				}
+				b_sudeley = {
+				}
+				b_tewkesbury = {
+				}
+				b_cheltenham = {
+				}
+				b_cirencester = {
+				}
+				b_winchcombe = {
+				}
+				b_hailes = {
+				}
+			}
+			c_wiltshire = {
+				color={ 241 95 45 }
+				color2={ 255 255 255 }
+			
+				b_wilton = {
+				}
+				b_sarum = {
+				}
+				b_clarendon = {
+				}
+				b_malmesbury = {
+				}
+				b_salisbury = {
+				}
+				b_devizes = {
+				}
+				b_ramsbury = {
+				}
+				b_marlborough = {
+				}
+			}
+			c_oxford = {
+				color={ 255 115 15 }
+				color2={ 255 255 255 }
+				
+				b_oxford = {
+				}
+				b_wallingford = {
+				}
+				b_abingdon = {
+				}
+				b_buckingham = {
+				}
+				b_banbury = {
+				}
+				b_reading = {
+				}
+				b_aylesbury = {
+				}
+				b_eynsham = {
+				}
+			}
+		}
+		d_canterbury = { # Sussex
+			color={ 241 100 15 }
+			color2={ 255 255 255 }
+			
+			capital = 73 # Kent
+			
+			c_surrey = {
+				color={ 241 105 55 }
+				color2={ 255 255 255 }
+				
+				b_farnham = {
+				}
+				b_guildford = {
+				}
+				b_lambeth = {
+				}
+				b_southwark = {
+				}
+				b_woking = {
+				}
+				b_chertsey = {
+				}
+				b_croydon = {
+				}
+				b_waverley = {
+				}
+			}
+			c_kent = {
+				color={ 241 115 65 }
+				color2={ 255 255 255 }
+				
+				holy_site = catholic
+				
+				b_rochester = {
+				}
+				b_dover = {
+				}
+				b_canterbury = {
+				}
+				b_faversham = {
+				}
+				b_sandwich = {
+				}
+				b_lympne = {
+				}
+				b_romney = {
+				}
+				b_tonbridge = {
+				}
+			}
+			c_sussex = {
+				color={ 241 110 60 }
+				color2={ 255 255 255 }
+				
+				b_hastings = {
+				}
+				b_pevensey = {
+				}
+				b_chichester = {
+				}
+				b_lewes = {
+				}
+				b_arundel = {
+					saxon = "Selsey"
+				}
+				b_rye = {
+				}
+				b_bramber = {
+				}
+				b_bodiam = {
+				}
+			}
+		}
+		d_somerset = {
+			color={ 241 15 63 }
+			color2={ 255 255 255 }
+			
+			capital = 28 # Somerset
+			
+			norman="Somerset"
+			english="Somerset"
+			welsh = "Lloegyr"
+			
+			c_somerset = {
+				color={ 241 30 75 }
+				color2={ 255 255 255 }
+				
+				b_taunton = {
+				}
+				b_glastonbury = {
+				}
+				b_ilchester = {
+				}
+				b_muchelney = {
+				}
+				b_castle_cary = {
+				}
+				b_bridgwater = {
+				}
+				b_yeovil = {
+				}
+			}
+			c_bath = {
+				color={ 241 15 55 }
+				color2={ 255 255 255 }
+
+				roman = "Aquae Sulis"
+				
+				b_bath = {
+					roman = "Aquae Sulis"
+				}
+				b_burnham = {
+				}
+				b_bristol = {
+				}
+				b_wells = {
+				}
+				b_cleeve = {
+				}
+				b_castle_batch = {
+				}
+				b_cadbury = {
+					saxon = Camalet
+				}
+			}
+		}
+		d_hampshire = {
+			color={ 241 45 53 }
+			color2={ 255 255 255 }
+			
+			capital = 26 # Winchester
+			
+			norman="Hampshire"
+			english="Hampshire"
+			
+			c_winchester = {
+				color={ 241 20 65 }
+				color2={ 255 255 255 }
+				
+				saxon="Wessex"
+				
+				b_southampton = {
+				}
+				b_portchester = {
+				}
+				b_winchester = {
+				}
+				b_romsey = {
+				}
+				b_andover = {
+				}
+				b_st_swithun = {
+				}
+				b_wherwell = {
+				}
+			}
+			c_wight = {
+				color={ 241 10 50 }
+				color2={ 255 255 255 }
+				
+				saxon="Wihtwara"
+				
+				b_carisbrooke = {
+				}
+				b_bonchurch = {
+				}
+				b_newport_wight = {
+				}
+				b_yarmouth = {
+				}
+				b_sandown = {
+				}
+				b_cowes = {
+				}
+				b_st_helens = {
+				}
+			}
+			c_dorset = {
+				color={ 241 25 70 }
+				color2={ 255 255 255 }
+				
+				b_wareham = {
+				}
+				b_corfe = {
+				}
+				b_shaftesbury = {
+				}
+				b_dorchester = {
+				}
+				b_sherborne = {
+				}
+				b_lyme = {
+				}
+				b_weymouth = {
+				}
+				b_wimborne = {
+				}
+			}
+		}
+		d_durham_palatine = {
+			color={ 251 33 12 }
+			color2={ 220 220 0 }
+			
+			capital = 56 # Durham
+			
+			title = "PRINCE_BISHOP"
+			foa = "PRINCE_BISHOP_FOA"
+			short_name = yes
+			location_ruler_title = yes
+			
+			allow = {
+				is_theocracy = yes
+			}
+			
+			religion = catholic
+			
+			# Cannot be held as a secondary title
+			primary = yes
+
+			assimilate = no
+			
+			dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+
+			dignity = 20	
+		}
+	}
+	
+	k_wales = {
+		color={ 135 25 3 }
+		color2={ 255 255 255 }
+		
+		capital = 64 # Gwynedd
+		
+		culture = welsh
+		
+		catholic = 300 # Crusade target weight
+		
+		welsh = "Brythoniaid"
+		pictish = "Brythoniaid"
+		breton = "Kembre"
+		irish = "Bhreatain Bheag"
+		roman = Demetia
+
+		allow = {
+			hidden_tooltip = {
+				OR = {
+					ai = no
+					culture_group = celtic
+				}
+			}
+		}
+		
+		d_gwynedd = {
+			color={ 172 99 22 }
+			color2={ 255 255 255 }
+			
+			capital = 64 # Gwynedd
+			
+			c_gwynedd = {
+				color={ 175 80 10 }
+				color2={ 255 255 255 }
+				
+				b_caernarfon = {
+				}
+				b_degannwy = {
+				}
+				b_bangor_fawr = {
+				}
+				b_harlech = {
+				}
+				b_abergwyngregyn = {
+				}
+				b_conwy = {
+				}
+				b_llanrhos = {
+				}
+			}
+			c_anglesey = {
+				color={ 175 75 20 }
+				color2={ 255 255 255 }
+				
+				b_aberffraw = {
+					norwegian = Ongullsøy
+					english = Anglesey
+					saxon = Anglesey
+				}
+				b_llanfaes = {
+				}
+				b_holyhead = {
+				}
+				b_llangefni = {
+				}
+				b_benllech = {
+				}
+				b_amlwch = {
+				}
+				b_beaumaris = {
+				}
+			}
+			c_perfeddwlad = {
+				color={ 175 85 15 }
+				color2={ 255 255 255 }
+				
+				b_denbigh = {
+				}
+				b_rhuddlan = {
+				}
+				b_llanelwy = {
+				}
+				b_flint = {
+				}
+				b_ruthin = {
+				}
+				b_basingwerk = {
+				}
+				b_ewloe = {
+				}
+				b_hawarden = {
+				}
+			}
+		}
+		d_powys = {
+			color={ 180 130 0 }
+			color2={ 255 255 255 }
+				
+			capital = 66 # Shrewsbury
+
+			allow = {
+				conditional_tooltip = {
+					trigger = {
+						d_powys = {
+							is_titular = yes
+						}
+					}
+					d_powys = {
+						is_titular = no
+					}
+				}
+				hidden_tooltip = {
+					OR = {
+						ai = no
+						culture = welsh
+						culture = irish
+						culture = breton
+					}
+				}
+			}
+
+			c_powys = {
+				color={ 175 90 20 }
+				color2={ 255 255 255 }
+				
+				b_caersws = {
+				}
+				b_mathrafal = {
+				}
+				b_llangollen = {
+				}
+				b_llandinam = {
+				}
+				b_glascwm = {
+				}
+				b_radnor = {
+				}
+				b_montgomery = {
+				}
+				b_rhayader = {
+				}
+			}
+			c_builth = {
+				color={ 172 85 15 }
+				color2={ 255 255 255 }
+				
+				b_builth = {
+				}
+				b_llanafan_fawr = {
+				}
+				b_llandrindod = {
+				}
+				b_abergwesyn = {
+				}
+				b_llanwrtyd = {
+				}
+				b_aberedw = {
+				}
+				b_llangammarch = {
+				}
+			}
+			c_shrewsbury = {
+				color={ 241 55 25 }
+				color2={ 255 255 255 }
+				
+				welsh = Pengwern
+				saxon = Shropshire
+				english = Shrewsbury
+			
+				b_shrewsbury = {
+				}
+				b_clun = {
+				}
+				b_wenlock = {
+				}
+				b_ludlow = {
+				}
+				b_whitchurch = {
+				}
+				b_bridgnorth = {
+				}
+				b_oswestry = {
+				}
+				b_chirk = {
+				}
+			}
+			c_hereford = {
+				color={ 241 50 20 }
+				color2={ 255 255 255 }
+				
+				welsh = Ergyng
+			
+				b_st_ethelberts = {
+				}
+				b_hereford = {
+					welsh = "Din Aricon"
+				}
+				b_leominster = {
+				}
+				b_archenfield = {
+				}
+				b_ewyas_harold = {
+				}
+				b_ledbury = {
+				}
+				b_clifford = {
+				}
+				b_brobury = {
+				}
+			}
+		}
+		d_deheubarth = {
+			color={ 240 167 91 }
+			color2={ 255 255 255 }
+			
+			capital = 18 # Dyfed
+			
+			c_dyfed = {
+				color={ 155 75 5 }
+				color2={ 255 255 255 }
+			
+				b_pembroke = {
+				}
+				b_st_davids = {
+					welsh = Tyddewi
+					norwegian = "Ramsøy"
+				}
+				b_penycwm = {
+				}
+				b_llanstadwell = {
+				}
+				b_tenby = {
+				}
+				b_narberth = {
+				}
+				b_haverford = {
+				}
+			}
+			c_ceredigion = {
+				color={ 155 84 20 }
+				color2={ 255 255 255 }
+			
+				b_cardigan = {
+				}
+				b_llanbadarn = {
+				}
+				b_aberystwyth = {
+				}
+				b_aberaeron = {
+				}
+				b_llanddewi_brefi = {
+				}
+				b_tregaron = {
+				}
+				b_lampeter = {
+				}
+			}
+			c_gower = {
+				color={ 155 70 15 }
+				color2={ 255 255 255 }
+
+				welsh = Gwyr
+			
+				b_carmarthen = {
+				}
+				b_dinefwr = {
+				}
+				b_llandeilo = {
+				}
+				b_kidwelly = {
+					welsh = Cydweli
+				}
+				b_swansea = {
+				}
+				b_caerphilly_gower = {
+				}
+				b_loughor = {
+				}
+			}
+		}
+		d_gwent = {
+			color={ 163 141 42 }
+			color2={ 255 255 255 }
+			
+			capital = 20 # Gwent
+			
+			c_gwent = {
+				color={ 160 75 5 }
+				color2={ 255 255 255 }
+			
+				b_caerwent = {
+				}
+				b_chepstow = {
+				}
+				b_abergavenny = {
+				}
+				b_monmouth = {
+				}
+				b_caerleon = {
+				}
+				b_newport = {
+				}
+				b_tintern = {
+				}
+			}
+			c_glamorgan = {
+				color={ 155 120 15 }
+				color2={ 255 255 255 }
+
+				welsh = Morgannwg
+			
+				b_cardiff = {
+				}
+				b_neath = {
+				}
+				b_llandaff = {
+				}
+				b_caerphilly = {
+				}
+				b_st_donats = {
+				}
+				b_margam = {
+				}
+				b_ogmore = {
+				}
+			}
+			c_brycheiniog = {
+				color={ 157 105 20 }
+				color2={ 255 255 255 }
+
+				norman = Breconshire
+				english = Breconshire
+			
+				b_brecon = {
+				}
+				b_talgarth = {
+				}
+				b_merthyr_tydfil = {
+				}
+				b_cradoc = {
+				}
+				b_llanddew = {
+				}
+				b_tretower = {
+				}
+				b_crickhowell = {
+				}
+			}
+		}
+		d_cornwall = {
+			color={ 181 60 10 }
+			color2={ 255 255 255 }
+			
+			capital = 31 # Cornwall
+			
+			c_cornwall = {
+				color={ 150 40 15 }
+				color2={ 255 255 255 }
+				
+				b_bodmin = {
+				}
+				b_launceston = {
+				}
+				b_st_germans = {
+				}
+				b_truro = {
+				}
+				b_liskeard = {
+				}
+				b_tintagel = {
+				}
+				b_st_michael = {
+				}
+				b_restormel = {
+				}
+			}
+			c_devon = {
+				color={ 135 35 25 }
+				color2={ 255 255 255 }
+				
+				b_lydford = {
+				}
+				b_exeter = {
+				}
+				b_crediton = {
+				}
+				b_totnes = {
+				}
+				b_axminster = {
+				}
+				b_tavistock = {
+				}
+				b_buckfast = {
+				}
+				b_dartmouth = {
+				}
+			}
+		}
+	}
+	
+	k_scotland = {
+		color={ 20 80 162 }
+		color2={ 255 255 255 }
+		
+		capital = 43 #Gowrie
+		
+		culture = scottish
+		
+		catholic = 300 # Crusade target weight
+		norse_pagan_reformed = 200 # Crusade target weight
+		
+		norse = Skotland
+		swedish = Skottland
+		danish = Skotland
+		norwegian = Skottland
+		welsh = Alban
+		irish = Alba
+		breton = Alba
+		pictish = Pictland
+		roman = Caledonia
+		
+		d_the_isles = {
+			color={ 10 48 243 }
+			color2={ 255 255 255 }
+
+			capital = 54 # Isle of Man
+			
+			welsh = Manaw
+			norwegian = "Mann"
+			danish = "Mann"
+			swedish = "Mann"
+			norse = "Mann"
+			pictish = "Manu"
+			irish = "Mhannin"
+			
+			c_isle_of_man = {
+				color={ 25 65 243 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Mann"
+				danish = "Mann"
+				swedish = "Mann"
+				norse = "Mann"
+				pictish = "Insee Manu"
+				welsh = "Ynys Manaw"
+				irish = "Ellan Mhannin"
+				
+				b_peel = {
+					norwegian = "Pålø"
+					danish = "Pålø"
+					swedish = "Pålø"
+					norse = "Pålø"
+					pictish = "Pirtinsee"
+					welsh = "Porth Ynys"
+					irish = "Purt ny h-Inshey"
+				}
+				b_rushen = {
+					pictish = "Resan"
+					welsh = "Resyn"
+					irish = "Rosien"
+				}
+				b_maughold = {
+					pictish = "Mauugan"
+					welsh = "Mawgan Sant"
+					irish = "Macaille"
+				}
+				b_douglas = {
+					pictish = "Duunglasc"
+					welsh = "Duonglassafon"
+					irish = "Duboglassio"
+				}
+				b_kirk_michael = {
+					pictish = "Icluasc Mihagal"
+					welsh = "Eglwys Mihangel"
+					irish = "Cill Micheál"
+				}
+				b_sulby = {
+					pictish = "Drauuglan"
+					welsh = "Drywglyn"
+					irish = "Druígleann"
+					norwegian = "Sõlabyr"
+					danish = "Sõlabyr"
+					swedish = "Sõlabyr"
+				}
+				b_inis_patraic = {
+					pictish = "Inees Pedric"
+					welsh = "Ynys Padric"
+					irish = "Inis Pátraic"
+				}
+				b_laxey = {
+					pictish = "Ahonugad"
+					welsh = "Afoneogiaid"
+					irish = "Uisge Bradán"
+				}
+			}
+		}
+		d_galloway = {
+			color={ 77 116 208 }
+			color2={ 255 255 255 }
+			
+			capital = 50 # Galloway
+			
+			welsh = Strathclyde
+			pictish = "Nouantia"
+			irish = "Gall-Ghaidhealaibh"
+			
+			c_galloway = {
+				color={ 15 185 243 }
+				color2={ 255 255 255 }
+				
+				pictish = "Nouantia"
+				welsh = "Nofant"
+				irish = "Na Rannaibh"
+				saxon = "Rhinns"
+
+				b_dumfries = {
+					pictish = "Dunrad"
+					welsh = "Dinrhyd"
+					irish = "Dùn Phris"
+				}
+				b_dunragit = {
+					pictish = "Dunreget"
+					welsh = "Din Rheged"
+					irish = "Dùn Reicheit"
+				}
+				b_whithorn = {
+					pictish = "Taiuuan"
+					welsh = "Tygwyn"
+					irish = "Taigh Mhàrtainn"
+				}
+				b_dunrod = {
+					pictish = "Dun Brin"
+					welsh = "Din Brenin"
+					irish = "Dùn Droighnein"
+				}
+				b_kirkcudbright = {
+					pictish = "Cuthberbatu"
+					welsh = "Cuddbertbetws"
+					irish = "Cill Chuithbeirt"
+				}
+				b_glenluce = {
+					pictish = "Ulanchuan"
+					welsh = "Glynchwyn"
+					irish = "Ghlinn Lus"
+				}
+				b_wigtown = {
+					pictish = "Betrah"
+					welsh = "Faetref"
+					irish = "Baile na h-Ùige"
+				}
+				b_threave = {
+					pictish = "Insee Datrah"
+					welsh = "Ynys Dytref"
+					irish = "Eilean na h-Uisge Dhè"
+				}
+			}
+			c_carrick = {
+				color={ 50 185 243 }
+				color2={ 255 255 255 }
+				
+				pictish = "Ueron"
+				welsh = "Aeron"
+				irish = "A' Charraig"
+				
+				b_turnberry = {
+					pictish = "Dun Ueron"
+					welsh = "Din Aeron"
+					irish = "Dùn Àir"
+				}
+				b_dunure = {
+					pictish = "Dunauen"
+					welsh = "Din Ywen"
+					irish = "Dùn Iùbhair"
+				}
+				b_maybole = {
+					pictish = "Maescanatan"
+					welsh = "Y Maes Ynfytyn"
+					irish = "Am Magh Baoghail"
+				}
+				b_crossraguel = {
+					pictish = "Crosc Ruagal"
+					welsh = "Croes Rhygal"
+					irish = "Crois Riagal"
+				}
+				b_loch_doon = {
+					scottish = "Balloch"
+					pictish = "Landun"
+					welsh = "Llyndin"
+					irish = "Loch Dhùin"
+				}
+				b_ballantrae = {
+					pictish = "Tretrah"
+					welsh = "Traethtref"
+					irish = "Baile na Tràgha"
+				}
+				b_culzean = {
+					pictish = "Pinaglan"
+					welsh = "Pennyglyn"
+					irish = "Ceann na Gleann"
+				}
+				b_greenan = {
+					pictish = "Abereron"
+					welsh = "Aberaeron"
+					irish = "Inbhir Àir"
+				}
+			}
+			c_clydesdale = {
+				color={ 5 140 240 }
+				color2={ 255 255 255 }
+				
+				pictish = "Damnunia"
+				welsh = "Alt Clut"
+				irish = "Dail Chluaidh"
+				
+				b_renfrew = {
+					pictish = "Bregurun"
+					welsh = "Brigffroen"
+					irish = "Rinn Friù"
+				}
+				b_st_kentigern = {
+					pictish = "Cantearn"
+					welsh = "Cyndeyrn Sant"
+					irish = "Cill Mungo"
+				}
+				b_glasgow = {
+					pictish = "Catuuris"
+					welsh = "Cathures"
+					irish = "Glaschu"
+				}
+				b_lanark = {
+					pictish = "Lanirc"
+					welsh = "Lanerc"
+					irish = "Lannraig"
+				}
+				b_cadzow = {
+					pictish = "Uuohan"
+					welsh = "Guofan"
+					irish = "Bàile Ghobhainn"
+				}
+				b_bothwell = {
+					pictish = "Mamuanon"
+					welsh = "Mamffynnon"
+					irish = "Tobar na Màthar"
+				}
+				b_lesmahagow = {
+					pictish = "Lanmahau"
+					welsh = "Llanmahagw"
+					irish = "Lios MoChuda"
+				}
+				b_dumbarton = {
+					pictish = "Alcluit"
+					welsh = "Alt Clut"
+					irish = "Dùn Breatainn"
+				}
+			}
+		}
+		d_western_isles = {
+			color = { 6 42 127 }
+			color2 = { 255 255 255 }
+			capital = 35 # Inse Gall
+			
+			norwegian = "Søreyar"
+			danish = "Søreyar"
+			swedish = "Söröarna"
+			norse = "Suðreyjar"
+			pictish = "Insee Hilth"
+			welsh = "Ynysoedd Heledd"
+			irish = "Dál Riata"
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 8
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+			
+			c_innse_gall = {
+				color={ 20 60 243 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Søreyar"
+				danish = "Søreyar"
+				swedish = "Söröarna"
+				norse = "Suðreyjar"
+				pictish = "Carnonac"
+				welsh = "Ynysoedd Heledd"
+				irish = "Innse Gall"
+				scottish = "Innse Gall"
+				
+				b_snizort = {
+					pictish = "Lantalarc"
+					welsh = "Llantalarican"
+					irish = "Cill Targhlain"
+				}
+				b_stornoway = {
+					norwegian = "Stornavåg"
+					danish = "Stornavik"
+					swedish = "Stornavik"
+					norse = "Stornavik"
+					pictish = "Laueube"
+					welsh = "Llywiobae"
+					irish = "Steòrnabhagh"
+				}
+				b_uig = {
+					norwegian = "Vik"
+					danish = "Vik"
+					swedish = "Vik"
+					norse = "Vik"
+					pictish = "Betret"
+					welsh = "Baetraeth"
+					irish = "Càrnais Ùige"
+				}
+				b_dunvegan = {
+					pictish = "Dun Bachain"
+					welsh = "Din Bychan"
+					irish = "Dùn Bheagain"
+				}
+				b_kiltaraglen = {
+				}
+				b_sleat = {
+				}
+				b_kisimul = {
+				}
+			}
+			c_iona = {
+				color={ 25 85 247 }
+				color2={ 255 255 255 }
+				
+				pictish = "Auenle"
+				welsh = "Ywenlle"
+				
+				b_iona = {
+					pictish = "Auenle"
+					welsh = "Ywenlle"
+					irish = "Ì Chaluim Chille"
+				}
+				b_finlaggan = {
+					pictish = "Inseepirt"
+					welsh = "Ynysporth"
+					irish = "Port an Eilein"
+				}
+				b_laggan = {
+					pictish = "Nuuathuchel"
+					welsh = "Neuadduchel"
+					irish = "Àird Talla"
+				}
+				b_dunyveg = {
+					pictish = "Dun Galiuu"
+					welsh = "Din Galïau"
+					irish = "Dùn Naomhaig"
+				}
+				b_tobermory = {
+				}
+				b_scarinish = {
+				}
+				b_arinagour = {
+				}
+			}
+			c_argyll = {
+				color={ 15 150 240 }
+				color2={ 255 255 255 }
+				
+				pictish = "Ebithan"
+				welsh = "Epiddant"
+				irish = "Airer Goídel"
+				
+				b_st_moluag = {
+					pictish = "Malluoc"
+					welsh = "Malluoc Sant"
+					irish = "Naomh Moluóc"
+				}
+				b_dunollie = {
+					pictish = "Dun Ugastel"
+					welsh = "Din Ogystal"
+					irish = " Dùn Ollaigh"
+				}
+				b_loch_awe = {
+					pictish = "Lanahon"
+					welsh = "Llynafon"
+					irish = "Loch Obha"
+				}
+				b_sween = {
+					pictish = "Caer Sauunae"
+					welsh = "Caer Sywny"
+					irish = "Dùn Suibhne"
+				}
+				b_dunstaffnage = {
+					pictish = "Dun Stapan"
+					welsh = "Din Staffpentir"
+					irish = "Dùn Stafhainis"
+				}
+				b_ardchattan = {
+					pictish = "Uchdarcathan"
+					welsh = "Uchdercaddan"
+				}
+				b_kilmun = {
+					pictish = "Caer Muun"
+					welsh = "Caer Munn"
+					irish = "Cill Mhunna"
+				}
+				b_inverary = {
+					pictish = "Aberera"
+					welsh = "Aberaera"
+					irish = "Inbhir Aora"
+				}
+				b_argh = {
+				}
+			}
+		}
+		d_lothian = {
+			color = { 16 62 157 }
+			color2={ 255 255 255 }
+			
+			capital = 48 # Lothian
+			
+			pictish = "Lut"
+			welsh = "Gododdin"
+			irish = "Labhdaidh"
+			
+			c_lothian = {
+				color = { 16 62 160 }
+				color2={ 255 255 255 }
+				
+				pictish = "Lut"
+				welsh = "Lleuddiniawn"
+				irish = "Labhdaidh"
+	
+				b_edinburgh = {
+					pictish = "Dun Eidan"
+					welsh = "Din Eidyn"
+					irish = "Dùn Eideann"
+				}
+				b_stirling = {
+					pictish = "Iutheu"
+					welsh = "Iuddeu"
+					irish = "Sruighlea"
+				}
+				b_abercorn = {
+					pictish = "Abercarn"
+					welsh = "Abercarnedd"
+					irish = "Obar Chùirnidh"
+				}
+				b_linlithgow = {
+					pictish = "Glanaluu"
+					welsh = "Glynallwedd"
+					irish = "Gleann Iucha"
+				}
+				b_falkirk = {
+					pictish = "Ecclescbret"
+					welsh = "Ecclesbrith"
+					irish = "An Eaglais Bhreac"
+				}
+				b_stow_of_wedale = {
+					pictish = "Gallath"
+					welsh = "Galladd"
+					irish = "An Geal Àth"
+				}
+				b_leith = {
+					pictish = "Aberlath"
+					welsh = "Aberlydd"
+					irish = "Inverlìte"
+				}
+				b_torphichen = {
+					pictish = "Trehechan"
+					welsh = "Treffechan"
+					irish = "Tóir Féichín"
+				}
+			}
+			c_dunbar = {
+				color = { 30 69 172 }
+				color2={ 255 255 255 }
+				
+				pictish = "Utudina"
+				welsh = "Din Baer"
+				irish = "Dùn Bár"
+	
+				b_dunbar = {
+					pictish = "Dun Ber"
+					welsh = "Din Baer"
+					irish = "Dùn Bár"
+				}
+				b_berwick = {
+					pictish = "Caer Brinech"
+					welsh = "Caer Bryneich"
+					irish = "Bearaig"
+				}
+				b_thirlestane = {
+					pictish = "Lauuether"
+					welsh = "Lauwedder"
+					irish = "Labhdar"
+				}
+				b_tyninghame = {
+					pictish = "Pisctaltreh"
+					welsh = "Pistylltref"
+					irish = "Linnebaile"
+				}
+				b_gordon = {
+					pictish = "Gor Dun"
+					welsh = "Gor Din"
+					irish = "Gòr Dùn"
+				}
+				b_huntly = {
+					pictish = "Istrad Bach"
+					welsh = "Ystrath Bach"
+					irish = "Srath Bhalgaidh"
+				}
+				b_coldingham = {
+					pictish = "Lanbrin"
+					welsh = "Llanbryn"
+					irish = "Cillecnoc"
+				}
+				b_crichton = {
+					pictish = "Finuultreh"
+					welsh = "Ffinioltref"
+					irish = "Criochdún"
+				}
+			}
+			c_teviotdale = {
+				color = { 11 51 145 }
+				color2={ 255 255 255 }
+				
+				pictish = "Heluua"
+				welsh = "Guendoleu"
+				irish = "Cealsaidh"
+				
+				b_jedburgh = {
+					pictish = "Dungod"
+					welsh = "Dingod"
+					irish = "Dùngot"
+				}
+				b_roxburgh = {
+					pictish = "Iaartreh"
+					welsh = "Iârtref"
+					irish = "Baile na h-Cearc"
+				}
+				b_peebles = {
+					pictish = "Peball"
+					welsh = "Pebyll"
+					irish = "Na Pùballan"
+				}
+				b_melrose = {
+					pictish = "Maelruusan"
+					welsh = "Mailrhosan"
+					irish = "Maol Ros"
+				}
+				b_kelso = {
+					pictish = "Calchanith"
+					welsh = "Calchfynydd"
+					irish = "Cealsaidh"
+				}
+				b_selkirk = {
+					pictish = "Halchraig"
+					welsh = "Halchraig"
+					irish = "Salcraig"
+				}
+				b_maxwell = {
+					pictish = "Mabfanon"
+					welsh = "Mabffynnon"
+					irish = "Tobar na Mac"
+				}
+				b_ednam = {
+					pictish = "Aethontreh"
+					welsh = "Aeddantref"
+					irish = "Baile na h-Aodhàn"
+				}
+			}
+		}
+		d_albany = {
+			color={ 25 85 160 }
+			color2={ 255 255 255 }
+			
+			capital = 43 # Gowrie
+			
+			pictish = "Alban"
+			welsh = "Alban"
+			irish = "Albanigh"
+			
+			c_gowrie = {
+				color={ 23 87 162 }
+				color2={ 255 255 255 }
+				
+				pictish = "Circinn"
+				welsh = "Caer Cinn"
+				irish = "Gobharaidh"
+				
+				b_scone = {
+					pictish = "Sguun"
+					welsh = "Sgon"
+					irish = "Sgoinde"
+				}
+				b_dunkeld = {
+					pictish = "Dun Celadon"
+					welsh = "Din Celyddon"
+					irish = "Dùn Chailleann"
+				}
+				b_perth = {
+				}
+				b_forteviot = {
+					pictish = "Nan Aruadocet"
+					welsh = "Nant Arwyddocâd"
+					irish = "Fothair Tabhaicht"
+				}
+				b_dundee = {
+					pictish = "Orrea"
+					welsh = "Dindân"
+					irish = "Dùn Dèagh"
+				}
+				b_abernethy = {
+					pictish = "Aber Naiton"
+					welsh = "Aber Neithon"
+					irish = "Obar Neithich"
+				}
+				b_clunie = {
+					pictish = "Luned"
+					welsh = "Llynaedd"
+					irish = "Cluainidh"
+				}
+				b_errol = {
+					pictish = "Landafan"
+					welsh = "Llandyffryn"
+					irish = "Lannfothir"
+				}
+			}
+			c_fife = {
+				color={ 20 80 152 }
+				color2={ 255 255 255 }
+				
+				pictish = "Fib"
+				welsh = "Gwidd"
+				irish = "Fìobha"
+				
+				b_dunfermline = {
+					pictish = "Dunfurlan"
+					welsh = "Dinfirllyn"
+					irish = "Dùn Phàrlain"
+				}
+				b_cupar = {
+					pictish = "Cafredun"
+					welsh = "Cyffredin"
+					irish = "Compàirt"
+				}
+				b_st_andrews = {
+					pictish = "Pinbed"
+					welsh = "Pennbaedd"
+					irish = "Cill Rígmonaid"
+				}
+				b_kirkcaldy = {
+					pictish = "Caercaled"
+					welsh = "Caer Caledin"
+					irish = "Cair Chaladain"
+				}
+				b_kinross = {
+					pictish = "Pinhadlen"
+					welsh = "Pennhadllin"
+					irish = "Ceann Rois"
+				}
+				b_leuchars = {
+					pictish = "Luchar"
+					welsh = "Brwyn"
+					irish = "Luachar"
+				}
+				b_lochore = {
+					pictish = "Laner"
+					welsh = "Llynaer"
+					irish = "Locháir"
+				}
+				b_falkland = {
+					pictish = "Maluen"
+					welsh = "Malfin"
+					irish = "Fháclainne"
+				}
+			}
+			c_strathearn = {
+				color={ 15 66 145 }
+				color2={ 255 255 255 }
+				
+				pictish = "Uuanun"
+				welsh = "Ystrad Iwerddon"
+				irish = "Srath Èireann"
+				
+				b_crieff = {
+					pictish = "Coiden"
+					welsh = "Coeden"
+					irish = "Craoibh"
+				}
+				b_dunblane = {
+					pictish = "Dul Blaan"
+					welsh = "Dinblyne"
+					irish = "Dùn Bhlàthain"
+				}
+				b_tullibardine = {
+					pictish = "Duunrud"
+					welsh = "Duonrhyd"
+					irish = "Dubhàth"
+				}
+				b_auchterarder = {
+					pictish = "Uchel"
+					welsh = "Hufenaruchel"
+					irish = "Uachdar Ardair"
+				}
+				b_madderty = {
+					pictish = "Pintu"
+					welsh = "Penndu"
+					irish = "Ceanndubh"
+				}
+				b_doune = {
+					pictish = "I Dun"
+					welsh = "Y Din"
+					irish = "An Dùn"
+				}
+				b_inchaffray = {
+					pictish = "Insee Ufirin"
+					welsh = "Ynys Offeren"
+					irish = "Innis Oifrend"
+				}
+				b_kenmore = {
+					pictish = "Bilauc"
+					welsh = "Belauc"
+					irish = "Bealach"
+				}
+			}
+			c_atholl = {
+				color={ 30 95 172 }
+				color2={ 255 255 255 }
+				
+				pictish = "Fotla"
+				welsh = "Focla"
+				irish = "Athfhotla"
+				
+				b_blair_atholl = {
+					pictish = "Athfocla"
+					welsh = "Brwydr Focla"
+					irish = "Blàr Athfhotla"
+				}
+				b_glen_dochart = {
+					pictish = "Lanuan"
+					welsh = "Llangwyn"
+					irish = "Cillefhinn"
+				}
+				b_pitlochry = {
+					pictish = "Moulin"
+					welsh = "Porth Craig"
+					irish = "Mhaothlinne"
+				}
+				b_fortingall = {
+					pictish = "Iuenlan"
+					welsh = "Ywenllan"
+					irish = "Iubharcille"
+				}
+				b_grandtully = {
+					pictish = "Uuag"
+					welsh = "Gwag y Rhwdfa"
+					irish = "Lag an Ratha"
+				}
+				b_rannoch = {
+					pictish = "Redan"
+					welsh = "Rhedyn"
+					irish = "Raineach"
+				}
+				b_strathardle = {
+					pictish = "Istrad Ardle"
+					welsh = "Ystrad Aerdôl"
+					irish = "Strath Àrdail"
+				}
+				b_struan = {
+					pictish = "Aberfel"
+					welsh = "Aberfelly"
+					irish = "Obar Pheallaidh"
+				}
+				b_anthrachs = {
+				}
+			}
+		}
+		d_moray = {
+			color={ 10 81 243 }
+			color2={ 255 255 255 }
+			
+			capital = 40 # Moray
+			
+			pictish = "Fortriu"
+			welsh = "Gwrturio"
+			irish = "Muireb"
+			
+			c_moray = {
+				color={ 20 85 243 }
+				color2={ 255 255 255 }
+				
+				pictish = "Fortriu"
+				welsh = "Gwrturio"
+				irish = "Muireb"
+				
+				b_forres = {
+					pictish = "Uerris"
+					welsh = "Gwerrys"
+					irish = "Farrais"
+				}
+				b_cawdor = {
+					pictish = "Caerdurn"
+					welsh = "Caerdwrn"
+					irish = "Caladar"
+				}
+				b_elgin = {
+					pictish = "Eruan"
+					welsh = "Aergwyn"
+					irish = "Ailgin"
+				}
+				b_nairn = {
+					pictish = "Abernard"
+					welsh = "Abernard"
+					irish = "Inbhir Narann"
+				}
+				b_inverness = {
+					pictish = "Abernis"
+					welsh = "Abernis"
+					irish = "Inbhir Nis"
+				}
+				b_lochindorb = {
+					pictish = "Lansildod"
+					welsh = "Llyn y Sildod"
+					irish = "Loch nan Doirb"
+				}
+				b_kinloss = {
+					pictish = "Canalosc"
+					welsh = "Cynyddullosg"
+					irish = "Cinnlois"
+				}
+				b_urquhart = {
+					pictish = "Urcarthen"
+					welsh = "Aercardden"
+					irish = "Airdchartdan"
+				}
+			}
+			c_ross = {
+				color={ 15 55 243 }
+				color2={ 255 255 255 }
+				
+				pictish = "Fidach"
+				welsh = "Gwidauc"
+				irish = "Ros"
+				
+				b_applecross = {
+					pictish = "Aporcrosan"
+					welsh = "Aporcrosan"
+					irish = "Obar Crosain"
+				}
+				b_dingwall = {
+					norwegian = "Tingvall"
+					danish = "Tingvall"
+					swedish = "Tingvall"
+					norse = "Tingvall"
+					pictish = "Aberpis"
+					welsh = "Aberpeffry"
+					irish = "Inbhir Pheofharain"
+				}
+				b_rosemarkie = {
+					pictish = "Rosanmairch"
+					welsh = "Rhosan Meirchnant"
+					irish = "Ros Mhaircnidh"
+				}
+				b_fortrose = {
+					pictish = "Caerrosan"
+					welsh = "Caerrhosan"
+					irish = "Dùnrois"
+				}
+				b_fearn = {
+					pictish = "Manech Rasan"
+					welsh = "Mynachdy Rhosan"
+					irish = "Manachainn Rois"
+				}
+				b_tain = {
+					welsh = "Duthactref"
+					irish = "Baile Dubhthaich"
+				}
+				b_cromarty = {
+					pictish = "Crucabachu"
+					welsh = "Crwcabachwy"
+					irish = "Crombati"
+				}
+				b_avoch = {
+					pictish = "Aberauc"
+					welsh = "Aberauc"
+					irish = "Abhach"
+				}
+			}
+			c_buchan = {
+				color={ 40 227 250 }
+				color2={ 255 255 255 }
+				
+				pictish = "Cei"
+				welsh = "Cai"
+				irish = "Beanaomh"
+				
+				b_aberdeen = {
+					welsh = "Aberdwyafon"
+					irish = "Obar Dabhuin"
+				}
+				b_banff = {
+					pictish = "Banaugluas"
+					welsh = "Benywglwys"
+					irish = "Beanaomh"
+				}
+				b_deer = {
+					pictish = "Ceiru"
+					welsh = "Ceirw"
+					irish = "Fiadh"
+				}
+				b_kintore = {
+					pictish = "Pintar"
+					welsh = "Penntyrau"
+					irish = "Ceann Tòrr"
+				}
+				b_inverurie = {
+					pictish = "Aberury"
+					welsh = "Aberury"
+					irish = "Inbhir Uraidh"
+				}
+				b_fyvie = {
+					pictish = "Carubran"
+					welsh = "Carwbryn"
+					irish = "Fiachein"
+				}
+				b_ellon = {
+					pictish = "Inseeol"
+					welsh = "Ynysol"
+					irish = "Eilean"
+				}
+				b_st_machar = {
+					pictish = "Mabaur"
+					welsh = "Mabfawr Sant"
+					irish = "Naomh Machar"
+				}
+			}
+			c_caithness = {
+				color={ 30 95 243 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Katanes"
+				danish = "Katanæs"
+				swedish = "Katanäs"
+				norse = "Katanæs"
+				pictish = "Cait"
+				welsh = "Caitnys"
+				irish = "Cataibh"
+				
+				b_wick = {
+					norwegian = "Vik"
+					danish = "Vik"
+					swedish = "Vik"
+					norse = "Vik"
+					pictish = "Aberbachuu"
+					welsh = "Aberbachwy"
+					irish = "Inbhir Ùige"
+				}
+				b_dunbeath = {
+					pictish = "Dunbathac"
+					welsh = "Dinbyddag"
+					irish = "Dùn Beithe"
+				}
+				b_dornoch = {
+					pictish = "Dirnfeth"
+					welsh = "Dyrnfedd"
+					irish = "Dòrnach"
+				}
+				b_thurso = {
+					swedish = "Tjurså"
+					danish = "Tyrså"
+					norwegian = "Tyrså"
+					norse = "Tyrså"
+					pictish = "Aberteuafon"
+					welsh = "Abertaewafon"
+					irish = "Inbhir Tarbhainn"
+				}
+				b_dunrobin = {
+					pictish = "Dunrubert"
+					welsh = "Dinraibeart"
+					irish = "Dùnrhobert"
+				}
+				b_freswick = {
+					swedish = "Fresvik"
+					danish = "Fresvik"
+					norwegian = "Fresvik"
+					norse = "Fresvik"
+					pictish = "Aberfauur"
+					welsh = "Aberfawr"
+					irish = "Obar Àrdair"
+				}
+				b_latheron = {
+					pictish = "Lathaeron"
+					welsh = "Lladdaeron"
+					irish = "Latharan"
+				}
+				b_golspie = {
+					pictish = "Fostreh"
+					welsh = "Ffostref"
+					irish = "Goillspidh"
+				}
+			}
+		}
+	}
+	
+	k_ireland = {
+		color={ 6 127 2 }
+		color2={ 255 255 255 }
+		
+		capital = 11 # Dublin
+		
+		culture = irish
+		
+		catholic = 300 # Crusade target weight
+		norse_pagan_reformed = 200 # Crusade target weight
+		
+		norse = Irland
+		swedish = Irland
+		danish = Irland
+		norwegian = Irland
+		irish = Éire
+		pictish = Iuerthon
+		welsh = Iwerddon
+		breton = Iwerzhon
+		roman = Hibernia
+		
+		d_ulster = {
+			color={ 5 222 31 }
+			color2={ 255 255 255 }
+			
+			capital = 5 # Ulster
+			
+			norwegian = Strangfjord
+			swedish = Strangfjord
+			danish = Strangfjord
+			norse = Strangfjorðr
+			irish = Ulaidh
+			
+			c_ulster = {
+				color={ 25 230 35 }
+				color2={ 255 255 255 }
+				
+				norwegian = Strangfjord
+				swedish = Strangfjord
+				danish = Strangfjord
+				norse = Strangfjorðr
+				irish = Ulaidh
+			
+				b_downpatrick = {
+					norwegian = Strangfjord
+					swedish = Strangfjord
+					danish = Strangfjord
+					norse = Strangfjorðr
+					irish = "Dún Pádraig"
+				}
+				b_dunseverick = {
+					irish = "Dún Sobhairce"
+				}
+				b_bangor = {
+					irish = "Inbhear Beg"
+				}
+				b_carrickfergus = {
+					irish = "Carraig Fhearghais"
+				}
+				b_connor = {
+					irish = "Con Doire"
+				}
+				b_dromore = {
+					irish = "Druim Mór"
+				}
+				b_larne = {
+					irish = "Latharna"
+				}
+				b_dunluce = {
+					irish = "Dún Libhse"
+				}
+			}
+			c_oriel = {
+				color={ 30 180 45 }
+				color2={ 255 255 255 }
+	
+				irish = Airgíalla
+				
+				b_clones = {
+					irish = "Cluain Eois"
+				}
+				b_armagh = {
+					irish = "Ard Mhacha"
+				}
+				b_dundalk = {
+					norwegian = Kerlingfjord
+					swedish = Kerlingfjord
+					danish = Kerlingfjord
+					norse = Kerlingfjorðr
+					irish = "Dún Dealgan"
+				}
+				b_clogher = {
+					irish = "Clochar"
+				}
+				b_drogheda = {
+					irish = "Droichead Átha"
+				}
+				b_monaghan = {
+					irish = "Muineachán"
+				}
+				b_olouth = {
+					irish = "Lúghbhaidh"
+				}
+				b_ardee = {
+					irish = "Baile Átha Fhirdhia"
+				}
+			}
+			c_tyrone = {
+				color={ 66 157 22 }
+				color2={ 255 255 255 }
+				
+				irish = "Tír Eoghain"
+	
+				b_coleraine = {
+					irish = "Cúil Rathain"
+				}
+				b_dungannon = {
+					irish = "Dún Geanainn"
+				}
+				b_aileach = {
+					irish = "Ailech"
+				}
+				b_maghera = {
+					irish = "Machaire Rátha"
+				}
+				b_derry = {
+					irish = "Daire Coluimb Chille"
+				}
+				b_omagh = {
+					irish = "An Óghmaigh"
+				}
+				b_tullyhogue = {
+					irish = "Tulaigh Óg"
+				}
+				b_dungiven = {
+					irish = "Dún Geimhin"
+				}
+			}
+			c_tyrconnell = {
+				color={ 25 190 31 }
+				color2={ 255 255 255 }
+				
+				irish = "Tír Chonaill"
+			
+				b_gartan = {
+					irish = "Gartán"
+				}
+				b_moville = {
+					irish = "Magh Bhile"
+				}
+				b_raphoe = {
+					irish = "Ráth Bhoth"
+				}
+				b_fahan = {
+					irish = "Fathain"
+				}
+				b_donegal = {
+					irish = "Dún na nGall"
+				}
+				b_ballyshannon = {
+					irish = "Béal Átha Seanaidh"
+				}
+				b_kilmacrenan = {
+					irish = "Cill Mhic nEanain"
+				}
+				b_ballymacswiney = {
+					irish = "Baile Mhic Suibhne"
+				}
+			}
+		}
+		d_connacht = {
+			color={ 43 229 108 }
+			color2={ 255 255 255 }
+			
+			capital = 9 # Connacht
+			
+			irish = "Connachta"
+		
+			c_breifne = {
+				color={ 40 230 65 }
+				color2={ 255 255 255 }
+				
+				irish = "Bréifne"
+	
+				b_dromahair = {
+					irish = "Droim Áth Thiar"
+				}
+				b_kilmore = {
+					irish = "Cill Mhór"
+				}
+				b_cavan = {
+					irish = "An Cabhán"
+				}
+				b_longford = {
+					irish = "An Longphort"
+				}
+				b_ardagh = {
+					irish = "Ardachadh"
+				}
+				b_leitrim = {
+					irish = "Liatroim"
+				}
+				b_drumcliffe = {
+					irish = "Droim Chliabh"
+				}
+				b_kells = {
+					irish = "Ceann Lios"
+				}
+			}
+			c_connacht = {
+				color={ 45 230 70 }
+				color2={ 255 255 255 }
+				
+				irish = "Iarthar Connachta"
+	
+				b_galway = {
+					irish = "Dún Bhun na Gaillimhe"
+				}
+				b_elphin = {
+					irish = "Ail Finn"
+				}
+				b_tuam = {
+					irish = "Tuaim Dá Ghualann"
+				}
+				b_clonfert = {
+					irish = "Cluain Fearta"
+				}
+				b_roscommon = {
+					irish = "Ros Comáin"
+				}
+				b_killala = {
+					irish = "Cill Ala"
+				}
+				b_anchory = {
+					irish = "Baile Uí Fhiacháin"
+				}
+			}
+			c_ui_fiachrach = {
+				color={ 50 240 80 }
+				color2={ 255 255 255 }
+
+				irish = "Muaidhe"
+
+				b_mayo = {
+					irish = "Maigh Eo"
+				}
+				b_aughagower = {
+					irish = "Achadh Ghobhair"
+				}
+				b_ballintubber = {
+					irish = "Baile an Tobair"
+				}
+				b_errew = {}
+				b_cong = {}
+				b_mullet = {
+					irish = "Mhuirthead"
+				}
+				b_inishkea = {
+					irish = "Inis Gé"
+				}
+			}
+			c_hy_many = {
+				color={ 55 245 75 }
+				color2={ 255 255 255 }
+
+				irish = "Uí Maine"
+
+				b_cruachu = {}
+				b_delbna = {}
+				b_rathmore = {}
+				b_rathnadarve = {
+					irish = "Rath na dTarbh"
+				}
+				b_relignaree = {
+					irish = "Reilig na Rí"
+				}
+				b_oweynagat = {
+					irish = "Uaimh na gCat"
+				}
+				b_rathbeg = {}
+			}
+		}
+		d_meath = {
+			color={ 49 249 72 }
+			color2={ 255 255 255 }
+			
+			capital = 11 # Dublin
+			
+			norwegian = Dublin
+			danish = Dublin
+			swedish = Dublin
+			norse = Dyflinn
+			irish = Mide
+			
+			pagan_coa = {
+				template = 0
+				layer = {
+					texture = 2
+					texture_internal = 3
+					emblem = 0
+					color = 0
+					color = 0
+					color = 0
+				}
+				religion = "norse_pagan"
+			}
+		
+			c_kildare = {
+				color={ 102 248 65 }
+				color2={ 255 255 255 }
+				
+				irish = "Cill Dara"
+	
+				b_knockaulin = {
+					irish = "Dún Ailinne"
+				}
+				b_athlone = {
+					irish = "Baile Átha Luain"
+				}
+				b_kildare = {
+					irish = "Cill Dara"
+				}
+				b_maynooth = {
+					irish = "Maigh Nuad"
+				}
+				b_st_brigit = {
+					irish = "Naomh Brigid"
+				}
+				b_rathangan = {
+					irish = "Ráth Iomgháin"
+				}
+				b_durrow = {
+					irish = "Darú"
+				}
+				b_clonard = {
+					irish = "Cluain Ioraird"
+				}
+			}
+			c_dublin = {
+				color={ 55 250 85 }
+				color2={ 255 255 255 }
+				
+				norse = Dyflinn
+				irish = Dubhlinn
+				welsh = Dulyn
+
+				
+				b_dublin = {
+					norse = Dyflinn
+					irish = Dubhlinn
+					welsh = Dulyn
+				}
+				b_clondalkin = {
+				}
+				b_finglas = {
+					irish = "Fionnghlas"
+				}
+				b_wicklow = {
+					irish = "Cill Mhantáin"
+				}
+				b_ath_cliath = {
+					irish = "Baile Átha Cliath"
+				}
+				b_christ_church = {
+					irish = "Ardeaglais Chríost"
+				}
+				b_mellifont = {
+					irish = "An Mhainistir Mhór"
+				}
+				b_trim = {
+					irish = "Baile Átha Troim"
+				}
+			}
+			c_meath = {
+				color={ 50 255 70 }
+				color2={ 255 255 255 }
+
+				b_tara_meath = {}
+				b_forradh = {}
+				b_knowth = {}
+				b_raith_laoghaire = {}
+				b_raith_na_seanadh = {}
+				b_saint_patricks = {}
+				b_ciannachta = {}
+				b_raith_na_riogh = {}
+			}
+			c_westmeath = {
+				color={ 45 250 90 }
+				color2={ 255 255 255 }
+
+				b_westmeath = {}
+				b_birr = {}
+				b_uisnech = {}
+				b_frewin = {
+					irish = "Frémainn"
+				}
+				b_fir_cell = {}
+				b_cenel_fiachach = {}
+				b_tethba = {}
+			}
+		}
+		d_leinster = {
+			color={ 85 211 27 }
+			color2={ 255 255 255 }
+			
+			capital = 16 # Leinster
+			
+			norwegian = Veisafjord
+			swedish = Veisafjord
+			danish = Veisafjord
+			norse = Veisafjorðr
+			irish = Laigin
+			
+			c_leinster = {
+				color={ 65 210 85 }
+				color2={ 255 255 255 }
+				
+				norwegian = Veisafjord
+				swedish = Veisafjord
+				danish = Veisafjord
+				norse = Veisafjorðr
+				irish = Laigin
+	
+				b_wexford = {
+					norwegian = Veisafjord
+					swedish = Veisafjord
+					danish = Veisafjord
+					norse = Veisafjorðr
+					irish = "Loch Garman"
+				}
+				b_leighlin = {
+					irish = "Leithghlinn"
+				}
+				b_arklow = {
+					irish = "An tInbhear Mór"
+				}
+				b_carlow = {
+					irish = "Ceatharlach"
+				}
+				b_ferns = {
+					irish = "Fearna Mór Maedhóg"
+				}
+				b_glendalough = {
+					irish = "Gleann Dá Loch"
+				}
+				b_naas = {
+					irish = "Nás na Ríogh"
+				}
+				b_enniscorthy = {
+					irish = "Inis Córthaidh"
+				}
+			}
+			c_ossory = {
+				color={ 60 210 80 }
+				color2={ 255 255 255 }
+				
+				irish = "Osraige"
+		
+				b_kilkenny = {
+					irish = "Cill Chainnigh"
+				}
+				b_gowran = {
+					irish = "Gabhrán"
+				}
+				b_clonmacnoise = {
+					irish = "Cluain Mhic Nóis"
+				}
+				b_aghaboe = {
+					irish = "Achadh Bhó"
+				}
+				b_jerpoint = {
+					irish = "Sheireapúin"
+				}
+				b_callan = {
+					irish = "Callainn"
+				}
+				b_grennan = {
+					irish = "An Ghrianán"
+				}
+				b_grannagh = {
+					irish = "An Greannach"
+				}
+			}
+			c_leix = {
+				color={ 60 200 90 }
+				color2={ 255 255 255 }
+
+				b_leix = {}
+				b_loigis = {}
+				b_timahoe = {}
+				b_dun_masc = {}
+				b_dunamase = {}
+				b_mountrath = {}
+				b_ui_bainche = {}
+			}
+		}
+		d_munster = {
+			color={ 16 157 12 }
+			color2={ 255 255 255 }
+			
+			capital = 13 # Thomond
+			
+			norwegian = "Hlymrek"
+			danish = "Lymrek"
+			swedish = "Lymrek"
+			norse = "Hlymrek"
+			irish = "Mumu"
+		
+			c_thomond = {
+				color={ 90 221 111 }
+				color2={ 255 255 255 }
+				
+				norwegian = "Hlymrek"
+				danish = "Lymrek"
+				swedish = "Lymrek"
+				norse = "Hlymrek"
+				irish = "Tuadhmhumhain"
+		
+				b_limerick = {
+					norwegian = "Hlymrek"
+					danish = "Lymrek"
+					swedish = "Lymrek"
+					norse = "Hlymrek"
+					irish = "Luimneach"
+				}
+				b_bunratty = {
+					irish = "Bun na Raite"
+				}
+				b_killaloe = {
+					irish = "Cill Dálua"
+				}
+				b_emly = {
+					irish = "Imleach Iubhair"
+				}
+				b_ennis = {
+					irish = "Inis"
+				}
+				b_kilfenora = {
+					irish = "Cill Fhionnúrach"
+				}
+				b_askeaton = {
+					irish = "Eas Géitine"
+				}
+				b_adare = {
+				}
+			}
+			c_ormond = {
+				color={ 95 221 121 }
+				color2={ 255 255 255 }
+				
+				norwegian = Vedrafjord
+				swedish = Vedrafjord
+				danish = Vedrafjord
+				norse = Veðrafjorðr
+				irish = Urmhumhain
+		
+				b_waterford = {
+					norwegian = Vedrafjord
+					swedish = Vedrafjord
+					danish = Vedrafjord
+					norse = Veðrafjorðr
+					irish = "Port Láirge"
+				}
+				b_cahir = {
+					irish = "Cathair Dhún Iascaigh"
+				}
+				b_cashel = {
+					irish = "Dún Caiseal"
+				}
+				b_clonmel = {
+					irish = "Cluain Meala"
+				}
+				b_lismore = {
+					irish = "Lios Mór"
+				}
+				b_roscrea = {
+					irish = "Ros Cré"
+				}
+				b_nenagh = {
+					irish = "Aonach Urmhumhan"
+				}
+				b_fethard = {
+					irish = "Fiodh Ard"
+				}
+			}
+			c_desmond = {
+				color={ 100 221 90 }
+				color2={ 255 255 255 }
+				
+				irish = "Deasmhumhain"
+		
+				b_cork = {
+					irish = "Corcaigh"
+				}
+				b_dunasead = {
+					irish = "Dún na Séad"
+				}
+				b_clone = {
+				}
+				b_youghal = {
+					irish = "Eochaill"
+				}
+				b_kilbrittain = {
+				}
+				b_cloyne = {
+					irish = "Cluain"
+				}
+				b_fermoy = {
+					irish = "Mainistir Fhear Maí"
+				}
+				b_blarney = {
+					irish = "An Bhlarna"
+				}
+			}
+			c_iarmond = {
+				color={ 105 221 100 }
+				color2={ 255 255 255 }
+				
+				irish = "Iarmhumhain"
+				english = Kerry
+		
+				b_cahersiveen = {
+				}
+				b_innisfallen = {
+				}
+				b_ross = {
+					irish = "Ros Ó gCairbre"
+				}
+				b_killarney = {
+				}
+				b_ardfert = {
+					irish = "Ard Fhearta"
+				}
+				b_tralee = {
+				}
+				b_skellig = {
+				}
+			}
+		}
+	}
+}
+e_mali = {
+	color={ 138 148 55 }
+	color2={ 255 255 255 }
+	
+	capital = 911 # Timbuktu
+	
+	culture = manden
+	
+	west_african_pagan_reformed = 500
+	
+	# Creation/usurpation trigger
+	allow = {
+		hidden_tooltip = {
+			OR = {
+				ai = no
+				culture_group = west_african
+			}
+		}
+	}
+	
+	k_mali = {
+		color={ 158 188 61 }
+		color2={ 255 255 255 }
+		
+		capital = 925 # Mali/Niani
+		
+		culture = manden
+		
+		d_mali = { # Manding
+			color={ 130 180 61 } #80 120 70
+			color2={ 255 255 255 }
+	
+			capital = 925 # Mali/Niani
+			
+			c_mali = { # Niani
+				color={ 108 170 48 }
+				color2={ 255 255 255 }
+				
+				b_niani = {}
+				b_selegon = {}
+				b_kamaro = {}
+				b_tabou = {}
+				b_safo = {}
+				b_baguineda = {}
+				b_dialakoro = {}
+				b_bougouni = {}
+				b_soussa = {}
+			}
+			c_bure = {
+				color={ 145 195 51 }
+				color2={ 255 255 255 }
+				
+				b_bure = {}
+				b_siguiri = {}
+				b_kouroussa = {}
+				b_kankan = {}
+				b_kamina = {} # Fictional, for prosperity
+				b_boeganiola = {} # Fictional, for prosperity
+				b_galadiou = {} # Fictional, for prosperity
+			}
+			c_dodugu = {
+				color={ 158 200 84 }
+				color2={ 255 255 255 }
+				
+				b_bamako = {}
+				b_sibi_mali = {}
+				b_kangaba = {}
+				b_ndantari = {} # Fictional, for prosperity
+				b_tichilit = {} # Fictional, for prosperity
+				b_namandiguina = {} # Fictional, for prosperity
+				b_manankoro = {} # Fictional, for prosperity
+			}
+			c_kiri = {
+				color={ 92 193 76 }
+				color2={ 255 255 255 }
+				
+				b_kita = {}
+				b_nioro = {}
+				b_diakha = {}
+				b_dakadiala = {}
+				b_dianguinare = {} # Fictional, for prosperity
+				b_serne = {} # Fictional, for prosperity
+				b_kassiola = {} # Fictional, for prosperity
+			}
+		}
+		d_bambuk = {
+			color={ 80 120 70 } #202 224 128
+			color2={ 255 255 255 }
+			
+			capital = 926 # Bambuk
+			
+			c_bambuk = {
+				color={ 90 138 64 }
+				color2={ 255 255 255 }
+			
+				b_bambuk = {}
+				b_yaresna = {}
+				b_ghiyaru = {}
+				b_diouboye = {}
+				b_goundafal = {}
+				b_sankaran = {}
+				b_kiffa = {}
+			}
+			c_diafunu = {
+				color={ 102 117 85 }
+				color2={ 255 255 255 }
+				
+				b_diafunu = {}
+				b_guidimaka = {}
+				b_galam = {}
+				b_tinngoba = {} # Fictional, for prosperity
+				b_missiribougou = {} # Fictional, for prosperity
+				b_kokoye = {} # Fictional, for prosperity
+				b_siela = {} # Fictional, for prosperity
+			}
+			c_kantor = {
+				color={ 62 103 54 }
+				color2={ 255 255 255 }
+				
+				b_kantor = {}
+				b_goudiourou = {}
+				b_ouli = {}
+				b_soliko = {} # Fictional, for prosperity
+				b_bidangala = {} # Fictional, for prosperity
+				b_kamindalah = {} # Fictional, for prosperity
+				b_badogo = {} # Fictional, for prosperity
+				b_mandio = {} # Fictional, for prosperity
+			}
+		}
+		d_yatenga = {
+			color={ 128 163 13 }
+			color2={ 255 255 255 }
+			
+			capital = 1757 # Yatenga
+			
+			c_yatenga = {
+				color={ 108 148 13 }
+				color2={ 255 255 255 }
+				
+				b_yatenga = {}
+				b_dubare = {}
+				b_zondoma = {}
+				b_giti = {}
+				b_walguyo = {}
+				b_direlabe = {} # Fictional, for prosperity
+				b_kotola = {} # Fictional, for prosperity
+			}
+			c_bobo_dyulasso = {
+				color={ 95 171 21 }
+				color2={ 255 255 255 }
+				
+				b_bobo_dyulasso = {}
+				b_taba = {}
+				b_sikasso = {}
+				b_bountoumba = {} # Fictional, for prosperity
+				b_kikele = {} # Fictional, for prosperity
+				b_kongola = {} # Fictional, for prosperity
+				b_awadi = {} # Fictional, for prosperity
+			}
+			c_wagadougou = {
+				color={ 138 186 27 }
+				color2={ 255 255 255 }
+				
+				b_wagadougou = {}
+				b_po = {}
+				b_gursi = {}
+				b_boboye = {} # Fictional, for prosperity
+				b_balangoka = {} # Fictional, for prosperity
+				b_niamalo = {} # Fictional, for prosperity
+				b_diba = {} # Fictional, for prosperity
+			}
+		}
+	}
+	
+	k_ghana = {
+		color={ 78 144 237 } #0 160 163   247 187 22
+		color2={ 255 255 255 }
+		
+		capital = 913 # Ghana
+		
+		culture = manden
+		
+		d_ghana = {
+			color={ 62 150 247 }
+			color2={ 255 255 255 }
+	
+			capital = 913 # Ghana/Wagadu
+		
+			c_ghana = { # Wagadu
+				color={ 52 130 227 }
+				color2={ 255 255 255 }
+				
+				holy_site = west_african_pagan
+				holy_site = west_african_pagan_reformed
+				holy_site = pagan
+				
+				b_el_ghaba = {}
+				b_koumbi_saleh = {}
+				b_diara = {}
+				b_baghena = {}
+				b_goumbou = {}
+				b_kughah = {}
+				b_nema = {}
+			}
+			c_mema = {
+				color={ 81 167 241 }
+				color2={ 255 255 255 }
+				
+				b_mema = {}
+				b_dia = {}
+				b_kabora = {}
+				b_macina = {}
+				b_bakara = {} #Fictional, for prosperity
+				b_sadiabougouda = {} #Fictional, for prosperity
+				b_perge = {} #Fictional, for prosperity
+			}
+			c_djenne = {
+				color={ 75 143 212 }
+				color2={ 255 255 255 }
+			
+				b_bindugu = {}
+				b_djenne = {}
+				b_bandiagara = {}
+				b_mopti = {}
+				b_korienza = {}
+				b_pondori = {}
+				b_femaye = {}
+				b_derary = {}
+			}
+			c_soso = {
+				color={ 83 160 241 }
+				color2={ 255 255 255 }
+				
+				b_soso = {}
+				b_kirina = {}
+				b_sama = {}
+				b_segou = {}
+				b_diado = {} #Modern placeholder, for prosperity
+				b_koio = {} #Modern placeholder, for prosperity
+				b_sebete = {} #Modern placeholder, for prosperity
+			}
+		}
+		d_tagant = {
+			color={ 13 98 191 }
+			color2={ 255 255 255 }
+			
+			capital = 912 # Aoudaghost
+			
+			c_aoudaghost = {
+				color={ 10 88 176 }
+				color2={ 255 255 255 }
+			
+				b_hodh = {}
+				b_aoudaghost = {}
+				b_moudjeria  = {}
+				b_ksarelbarka = {}
+				b_kedama = {}
+				b_sarel = {} #Fictional, for prosperity
+				b_ichga = {} #Fictional, for prosperity
+			}
+			c_tagant = {
+				color={ 5 116 182 }
+				color2={ 255 255 255 }
+			
+				b_tagant  = {}
+				b_tichitt  = {}
+				b_tibogona = {} #Fictional, for prosperity
+				b_nyinuito = {} #Fictional, for prosperity
+				b_apowa = {} #Fictional, for prosperity
+				b_dawba = {} #Fictional, for prosperity
+				b_bagble = {} #Fictional, for prosperity
+			}
+		}
+		d_timbuktu = {
+			color={ 45 90 224 }
+			color2={ 255 255 255 }
+	
+			capital = 911 # Timbuktu			
+		
+			c_timbuktu = {
+				color={ 35 75 209 }
+				color2={ 255 255 255 }	
+				
+				b_timbuktu = {}
+				b_tirakka = {}
+				b_sankore = {}
+				b_safanqu = {}
+				b_kabara = {}
+				b_tendirma = {}
+				b_dire = {}
+				b_gundam = {}
+			}
+			c_oualata = {
+				color={ 53 81 203 }
+				color2={ 255 255 255 }
+			
+				b_oualata = {}
+				b_biru = {}
+				b_neiguiat = {}
+				b_konou = {}
+				b_birnsara = {}
+				b_tizert = {}
+				b_tarhalet = {}
+				b_fassekra = {}
+			}
+			c_araouane = {
+				color={ 64 108 235 }
+				color2={ 255 255 255 }
+			
+				b_araouane = {}
+				b_tessalit = {}
+				b_aguelhok = {}
+				b_abalessa = {}
+				b_tinzaouten = {}
+				b_guezzam = {}
+				b_tamanrasset = {}
+				b_tazrouk = {}
+			}
+		}
+	}
+	
+	k_songhay = {
+		color={ 178 76 81 }
+		color2={ 255 255 255 }
+		
+		capital = 914 # Gao
+		
+		culture = manden
+		
+		d_songhay = {
+			color={ 210 82 89 }
+			color2={ 255 255 255 }
+			
+			capital = 914 # Gao
+			
+			c_songhay = {
+				color={ 225 92 79 }
+				color2={ 255 255 255 }
+				
+				b_ansongo = {}
+				b_kukiya = {}
+				b_tillaberi = {}
+				b_falakoro = {} #Fictional, for prosperity
+				b_tiende = {} #Fictional, for prosperity
+				b_domossela = {} #Fictional, for prosperity
+				b_boumoundo = {} #Fictional, for prosperity
+			}
+			c_gao = {
+				color={ 195 72 64 }
+				color2={ 255 255 255 }
+				
+				holy_site = west_african_pagan
+				holy_site = west_african_pagan_reformed
+				
+				b_gao = {}
+				b_sarnah = {}
+				b_gaosaney = {}
+				b_bourem = {}
+				b_menaka = {}
+				b_gabero = {}
+				b_anchawadi = {}
+			}
+			c_tadmekka = {
+				color={ 205 92 59 }
+				color2={ 255 255 255 }
+			
+				b_tadmekka = {}
+				b_essako = {}
+				b_kidal = {}
+				b_kidako = {} #Fictional, for prosperity
+				b_eskako = {} #Fictional, for prosperity
+				b_djila = {} #Fictional, for prosperity
+				b_dongossela = {} #Fictional, for prosperity
+			}
+			c_kurumba = {
+				color={ 187 77 98 }
+				color2={ 255 255 255 }
+				
+				b_kissi = {}
+				b_aribinda = {}
+				b_dori = {}
+				b_douentza = {}
+				b_ouario_ouario = {} # Fictional, for prosperity
+				b_gourel_bassirou = {} # Fictional, for prosperity
+				b_seriwala = {} # Fictional, for prosperity
+			}
+		}
+		d_gurma = {
+			color={ 171 121 124 }
+			color2={ 255 255 255 }
+			
+			capital = 928 # Gurma
+			
+			c_gurma = {
+				color={ 161 101 104 }
+				color2={ 255 255 255 }
+				
+				b_gurma = {}
+				b_bilanga = {}
+				b_nungu = {}
+				b_tenkudugo = {}
+				b_zorgho = {}
+				b_hounde = {}
+				b_yrgo = {} #Fictional, for prosperity
+				b_halogo = {} #Fictional, for prosperity
+				b_wagulo = {} #Fictional, for prosperity
+				b_zenande = {} #Fictional, for prosperity
+			}
+			c_dendi = {
+				color={ 186 106 114 }
+				color2={ 255 255 255 }
+				
+				b_niamey = {}
+				b_bura = {}
+				b_say = {}
+				b_jidu = {} #Fictional, for prosperity
+				b_kimtir = {} #Fictional, for prosperity
+				b_isuachara = {} #Fictional, for prosperity
+				b_langay = {} #Fictional, for prosperity
+			}
+		}
+	}
+}
+
+e_kanem = {
+	color={ 50 230 235 }
+	color2={ 255 255 255 }
+	
+	k_kanem = {
+		color={ 10 215 225 }
+		color2={ 255 255 255 }
+		
+		capital = 1739 # Djimi
+		
+		d_bornu = {
+			color={ 96 120 185 }
+			color2={ 255 255 255 }
+			
+			capital = 1743 # Bornu
+			
+			c_bornu = {
+				color={ 81 105 170 }
+				color2={ 255 255 255 }
+				
+				b_ngazargamu = {}
+				b_kukawa = {}
+				b_zamtam = {}
+				b_fika = {}
+				b_sao = {}
+				b_yao = {}
+				b_marzouga = {} # Fictional - For Prosperity
+			}
+			c_kagha = {
+				color={ 72 115 193 }
+				color2={ 255 255 255 }
+				
+				b_amcaka = {}
+				b_kotoko = {}
+				b_ngala = {}
+				b_atemaga = {} # Fictional - For Prosperity
+				b_gidan_taka = {} # Fictional - For Prosperity
+				b_ikot_obio_nsu = {} # Fictional - For Prosperity
+				b_bauni = {} # Fictional - For Prosperity
+			}
+			c_munio = {
+				color={ 118 135 197 }
+				color2={ 255 255 255 }
+				
+				b_nguru = {}
+				b_diaka = {}
+				b_mashina = {}
+				b_gumsa = {}
+				b_amalget = {} # Fictional - For Prosperity
+				b_ikot_enebong = {} # Fictional - For Prosperity
+				b_tsaskiya = {} # Fictional - For Prosperity
+			}
+			c_masseniya = {
+				color={ 91 102 214 }
+				color2={ 255 255 255 }
+				
+				b_masseniya = {}
+				b_malfe = {}
+				b_ategbe = {} # Fictional - For Prosperity
+				b_umu_okohia = {} # Fictional - For Prosperity
+				b_bale_agbe = {} # Fictional - For Prosperity
+				b_oganga = {} # Fictional - For Prosperity
+				b_chutar_buki = {} # Fictional - For Prosperity
+			}
+			c_makari = {
+				color={ 76 139 178 }
+				color2={ 255 255 255 }
+				
+				b_makari = {}
+				b_diama = {}
+				b_kussiri = {}
+				b_gambila = {}
+				b_gegu = {} # Fictional - For Prosperity
+				b_gidan_hunu = {} # Fictional - For Prosperity
+				b_chilaro = {} # Fictional - For Prosperity
+			}
+			c_bauchi = {
+				color={ 90 125 173 }
+				color2={ 255 255 255 }
+				
+				b_bauchi = {}
+				b_kazaure = {} # Fictional - For Prosperity
+				b_bakinkuja = {} # Fictional - For Prosperity
+				b_danmadahun = {} # Fictional - For Prosperity
+				b_zar = {} # Fictional - For Prosperity
+				b_kadira = {} # Fictional - For Prosperity
+				b_ruwan_jema = {} # Fictional - For Prosperity
+			}
+		}
+		d_kanem = {
+			color={ 80 195 205 }
+			color2={ 255 255 255 }
+			
+			capital = 1739 # Djimi
+			
+			c_djimi = {
+				color={ 70 185 190 }
+				color2={ 255 255 255 }
+				
+				holy_site = west_african_pagan
+				holy_site = west_african_pagan_reformed
+				
+				b_djimi = {}
+				b_auno = {}
+				b_dagolu = {}
+				b_kagusti = {}
+				b_mao = {}
+				b_muli_fuli = {}
+				b_sandu = {}
+			}
+			c_manan = {
+				color={ 93 207 191 }
+				color2={ 255 255 255 }
+				
+				b_manan = {}
+				b_furtu = {}
+				b_goyawa = {}
+				b_garoumele = {}
+				b_tchoukoutoli = {} # Fictional - For Prosperity
+				b_nankassa = {} # Fictional - For Prosperity
+				b_arkolo = {} # Fictional - For Prosperity
+			}
+			c_bilma = {
+				color={ 85 180 221 }
+				color2={ 255 255 255 }
+				
+				b_bilma = {}
+				b_gouam = {} # Fictional - For Prosperity
+				b_tigue = {} # Fictional - For Prosperity
+				b_libasso = {} # Fictional - For Prosperity
+				b_danouala = {} # Fictional - For Prosperity
+				b_kiroungou = {} # Fictional - For Prosperity
+				b_mateukous = {} # Fictional - For Prosperity
+			}
+		}
+		d_fezzan = {
+			color={ 25 160 150 }
+			color2={ 255 255 255 }
+			
+			capital = 1730 # Murzuk
+			
+			c_murzuk = {
+				color={ 15 146 129 }
+				color2={ 255 255 255 }
+				
+				b_murzuk = {}
+				b_tassawa = {}
+				b_sebna = {}
+				b_djarma = {}
+				b_ash_shurraf = {} # Fictional - For Prosperity
+				b_massah = {} # Fictional - For Prosperity
+				b_tmessa = {} # Fictional - For Prosperity
+			}
+			c_zawila = {
+				color={ 33 172 138 }
+				color2={ 255 255 255 }
+				
+				b_zawila = {}
+				b_zalha = {}
+				b_zizau = {} # Fictional - For Prosperity
+				b_sciaua = {} # Fictional - For Prosperity
+				b_jikheira = {} # Fictional - For Prosperity
+				b_et_tuebia = {} # Fictional - For Prosperity
+				b_petras_maior = {} # Fictional - For Prosperity
+			}
+			c_djado = {
+				color={ 27 197 173 }
+				color2={ 255 255 255 }
+				
+				b_djado = {}
+				b_tummo = {}
+				b_el_bedan = {} # Fictional - For Prosperity
+				b_al_qalah = {} # Fictional - For Prosperity
+				b_msus = {} # Fictional - For Prosperity
+				b_grennah = {} # Fictional - For Prosperity
+				b_djemmari = {} # Fictional - For Prosperity
+			}
+		}
+		d_wadai = {
+			color={ 17 237 189 }
+			color2={ 255 255 255 }
+			
+			capital = 1770 # Wadai
+			
+			c_fitri = {
+				color={ 32 212 170 }
+				color2={ 255 255 255 }
+				
+				b_gaska = {}
+				b_kuka = {}
+				b_ndoye = {} # Fictional - For Prosperity
+				b_atourda = {} # Fictional - For Prosperity
+				b_sambourou = {} # Fictional - For Prosperity
+				b_manouachi = {} # Fictional - For Prosperity
+				b_troan = {} # Fictional - For Prosperity
+			}
+			c_wadai = {
+				color={ 27 247 201 }
+				color2={ 255 255 255 }
+				
+				b_wara = {}
+				b_abeche = {}
+				b_nimro = {}
+				b_koulkoule = {} # Fictional - For Prosperity
+				b_yue = {} # Fictional - For Prosperity
+				b_gourmoga = {} # Fictional - For Prosperity
+				b_asafik = {} # Fictional - For Prosperity
+			}
+			c_ennedi = {
+				color={ 10 205 162 }
+				color2={ 255 255 255 }
+				
+				b_kobbai = {}
+				b_kebkabiya = {}
+				b_shaiqab = {} # Fictional - For Prosperity
+				b_bandarbi = {} # Fictional - For Prosperity
+				b_esh_sharafa = {} # Fictional - For Prosperity
+				b_sabu = {} # Fictional - For Prosperity
+				b_et_taba = {} # Fictional - For Prosperity
+			}
+		}
+	}
+	
+	k_hausaland = {
+		color={ 133 40 191 } #245 120 20   75 190 165
+		color2={ 255 255 255 }
+		
+		capital = 1746 # Kano
+		
+		d_hausaland = {
+			color={ 179 85 237 }
+			color2={ 255 255 255 }
+			
+			capital = 1746 # Kano
+			
+			c_kano = {
+				color={ 159 75 217 }
+				color2={ 255 255 255 }
+				
+				holy_site = west_african_pagan
+				holy_site = west_african_pagan_reformed
+				
+				b_kano = {}
+				b_hadejia = {}
+				b_nok = {}
+				b_turunku = {}
+				b_tigaro = {} # Fictional - For Prosperity
+				b_gamaja = {} # Fictional - For Prosperity
+				b_labozhi = {} # Fictional - For Prosperity
+			}
+			c_daura = {
+				color={ 185 105 205 }
+				color2={ 255 255 255 }
+				
+				b_daura = {}
+				b_maradi = {}
+				b_zinder = {}
+				b_itak_udara = {} # Fictional - For Prosperity
+				b_lapadi = {} # Fictional - For Prosperity
+				b_uper = {} # Fictional - For Prosperity
+				b_irahun = {} # Fictional - For Prosperity
+			}
+			c_gobir = {
+				color={ 161 62 203 }
+				color2={ 255 255 255 }
+				
+				b_gobir = {}
+				b_birnin_konni = {}
+				b_doba = {} # Fictional - For Prosperity
+				b_ierkpen = {} # Fictional - For Prosperity
+				b_kpem = {} # Fictional - For Prosperity
+				b_esuk_mesembe = {} # Fictional - For Prosperity
+				b_waja = {} # Fictional - For Prosperity
+			}
+			c_katsina = {
+				color={ 148 69 248 }
+				color2={ 255 255 255 }
+				
+				b_katsina = {}
+				b_zaria = {}
+				b_kaduna = {}
+				b_furana = {} # Fictional - For Prosperity
+				b_asani = {} # Fictional - For Prosperity
+				b_ogunde = {} # Fictional - For Prosperity
+				b_gausambe = {} # Fictional - For Prosperity
+			}
+			c_zamfara = {
+				color={ 192 94 229 }
+				color2={ 255 255 255 }
+				
+				b_datsi = {}
+				b_anka = {}
+				b_gusau = {}
+				b_horo_majakai = {} # Fictional - For Prosperity
+				b_kori = {} # Fictional - For Prosperity
+				b_jagbada = {} # Fictional - For Prosperity
+				b_uburukiti = {} # Fictional - For Prosperity
+			}
+		}
+		d_kebbi = {
+			color={ 139 51 149 }
+			color2={ 255 255 255 }
+			
+			capital = 1752 # Kebbi
+			
+			c_kebbi = {
+				color={ 124 41 134 }
+				color2={ 255 255 255 }
+				
+				b_kebbi = {}
+				b_argungu = {}
+				b_sokoto = {}
+				b_digira = {} #Fictional, for prosperity
+				b_tunga_yakana = {} #Fictional, for prosperity
+				b_gidan_ardo = {} #Fictional, for prosperity
+				b_ungwan_deri = {} #Fictional, for prosperity
+			}
+			c_tahoua = {
+				color={ 119 35 148 }
+				color2={ 255 255 255 }
+				
+				b_tahoua = {}
+				b_kurmin_dodo = {} #Fictional, for prosperity
+				b_kuanawa = {} #Fictional, for prosperity
+				b_rurum = {} #Fictional, for prosperity
+				b_gurumi = {} #Fictional, for prosperity
+				b_ago_adewale = {} #Fictional, for prosperity
+				b_okuaro = {} #Fictional, for prosperity
+			}
+			c_dyamare = {
+				color={ 148 67 172 }
+				color2={ 255 255 255 }
+				
+				b_dyamare = {}
+				b_dosso = {}
+				b_gaya_songhay = {}
+				b_sabarumowa = {} #Fictional, for prosperity
+				b_barakin_mari = {} #Fictional, for prosperity
+				b_aondaka = {} #Fictional, for prosperity
+				b_aletu = {} #Fictional, for prosperity
+			}
+			c_zarma = { # Yauri
+				color={ 135 41 156 }
+				color2={ 255 255 255 }
+				
+				b_zuru = {}
+				b_ouallam = {}
+				b_tera = {}
+				b_obora = {} #Fictional, for prosperity
+				b_tora = {} #Fictional, for prosperity
+				b_mangalam = {} #Fictional, for prosperity
+				b_abetam = {} #Fictional, for prosperity
+			}
+		}
+		d_air = {
+			color={ 100 10 165 }
+			color2={ 255 255 255 }
+			
+			capital = 1738 # Air
+			
+			c_air = {
+				color={ 85 10 135 }
+				color2={ 255 255 255 }
+				
+				b_agades = {}
+				b_takedda = {}
+				b_gabasour = {} # Fictional - For Prosperity
+				b_toumboula = {} # Fictional - For Prosperity
+				b_tchalta = {} # Fictional - For Prosperity
+				b_ngargue = {} # Fictional - For Prosperity
+				b_koufe = {} # Fictional - For Prosperity
+			}
+			c_fachi = {
+				color={ 127 10 186 }
+				color2={ 255 255 255 }
+				
+				b_fachi = {}
+				b_goulo = {} # Fictional - For Prosperity
+				b_kemkaga = {} # Fictional - For Prosperity
+				b_mbarou = {} # Fictional - For Prosperity
+				b_tiadam = {} # Fictional - For Prosperity
+				b_mitena = {} # Fictional - For Prosperity
+				b_geger = {} # Fictional - For Prosperity
+			}
+		}
+	}
+}
+
+
+# TITULAR DUCHIES
+d_abbasid = {
+	color = { 19 180 16 }
+	
+	allow = {
+		always = no
+	}
+}
+
+d_oxford = { # Obsolete
+	color={ 255 108 0 }
+	color2={ 255 255 255 }
+	capital = 22 # Oxford
+	allow = {
+		always = no
+	}
+}
+
+d_arabia_felix = {
+	color = { 163 254 56 }
+}
+d_arabs = {
+	color = { 38 157 35 }
+	culture = bedouin_arabic
+}
+d_assassin = {
+	color = { 58 97 57 }
+}
+d_balearic = {
+	color={ 13 170 54 }
+}
+d_belgrade = {
+	color = { 151 125 62 }
+}
+d_bergen = {
+	color = { 47 27 255 }
+}
+d_bordeaux = {
+	color = { 59 15 248 }
+}
+d_braganza = {
+	color = { 219 195 35 }
+}
+d_butrinto = {
+	color = { 148 68 154 }
+}
+d_campania = {
+	color = { 226 204 228 }
+}
+d_catalonia = {
+	color = { 255 210 57 }
+}
+d_chaldea = {
+	color = { 107 159 41 }
+}
+d_cumberland = {
+	color = { 31 186 244 }
+}
+d_curonian = {
+	color = { 141 55 29 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	capital	= 373 # Kurzeme
+	culture = lettigallish
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+# Pagan proto-Denmark
+d_danes = {
+	color={ 247 77 54 }
+	
+#	tribe = yes
+	
+	dignity = 10
+	
+	capital	= 266 # Sjaelland
+	
+	allow = {
+		always = no
+	}
+	
+	culture = norse
+}
+d_don = {
+	color = { 247 211 116 }
+}
+d_dorostotum = {
+	color = { 163 48 206 }
+}
+d_el_rif = {
+	color = { 29 241 64 }
+}
+d_el-arish = {
+	color = { 148 206 13 }
+}
+d_erzerum = {
+	color = { 103 84 255 }
+}
+d_estonia = {
+	color = { 94 60 22 }
+	
+	capital	= 378 # Reval
+	
+	allow = {
+		always = no
+	}
+	
+#	tribe = yes
+	
+	culture = ugricbaltic
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_galatia = {
+	color = { 244 75 185 }
+}
+d_georgia = {
+	color = { 251 184 184 }
+}
+#d_gilan = {
+#	color = { 65 90 137 }
+#}
+d_geats = {
+	color={ 35 57 180 }
+
+#	tribe = yes
+	
+	dignity = 8
+	
+	capital	= 297 # Västergötland
+	
+	allow = {
+		always = no
+	}
+	
+	culture = norse
+}
+d_hellas = {
+	color = { 213 73 165 }
+}
+d_ikonion = {
+	color = { 179 28 127 }
+}
+d_ingers = {
+	color={ 125 125 40 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = finnish
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_kajaneborg = { # Kvens
+	color = { 123 73 13 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = finnish
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_kappadokia = {
+	color = { 255 3 170 }
+}
+d_karnten = {
+	color = { 229 254 242 }
+}
+d_kexholm = {
+	color={ 121 98 20 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = finnish
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_khazars = {
+	color = { 246 217 137 }
+	
+	capital = 594 #	Sarkel
+	
+#	tribe = yes
+	
+	culture = khazar
+	
+	# Creation/Usurp Trigger
+	allow = {
+		always = no
+	}
+}
+
+d_kirkuk = {
+	color = { 142 182 255 }
+}
+d_sami = {
+	color = { 101 99 35 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = lappish
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_krakow = {
+	color = { 253 129 129 }
+}
+d_laodikeia = {
+	color = { 163 52 125 }
+}
+d_lettigalians = {
+	color = { 126 51 51 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = lettigallish
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_luristan = {
+	color = { 77 114 183 }
+}
+d_lut = {
+	color = { 119 170 29 }
+}
+d_lykia = {
+	color = { 121 42 93 }
+}
+d_mar = {
+	color = { 16 211 246 }
+}
+d_milano = {
+	color = { 252 238 227 }
+}
+#d_minsk = {
+#	color = { 175 44 44 }
+#}
+
+d_muromians = {
+	color = { 160 120 75 }
+	
+	capital = 581 # Murom
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = mordvin
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_nikomedeia = {
+	color = { 209 108 174 }
+}
+d_pechenegs = {
+	# OBSOLETE
+	color = { 173 150 43 }
+	color2 = { 0 128 128 }
+	
+	capital = 542 # Olvia
+	
+#	tribe = yes
+	culture = pecheneg
+	
+	allow = {
+		always = no
+	}
+}
+
+d_kimak = {
+	color={ 151 114 58 }
+	color2={ 255 255 255 }
+}
+
+d_kirghiz  = {
+	color={ 155 140 78 }
+	color2={ 255 255 255 }
+}
+
+d_kipchak = {
+	color={ 131 84 50 }
+	color2={ 255 255 255 }
+			
+	#pecheneg = "Pecheneg"
+}
+
+d_pressburg = {
+	color = { 218 70 70 }
+}
+d_pronsk = {
+	color = { 23 132 81 }
+}
+d_pruthenians = {
+	color = { 159 195 75 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	capital	= 370 # Marienburg
+	culture = prussian
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+	
+}
+d_qom = {
+	color = { 188 229 116 }
+}
+d_romagna = {
+	color = { 243 234 157 }
+}
+d_salamanca = {
+	color = { 251 229 34 }
+}
+
+d_sames = {
+	# Actually Samoyeds
+	color = { 101 70 34 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = samoyed
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_sandomiersk = {
+	color = { 253 137 137 }
+}
+d_satakunta = {
+	color = { 117 47 47 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = finnish
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+	
+}
+d_shiraz = {
+	color = { 155 189 97 }
+}
+d_sinope = {
+	color = { 255 6 172 }
+}
+d_slovakia = {
+	color = { 209 61 61 }
+}
+d_sweden = {
+	color={ 55 112 170 }
+
+#	tribe = yes
+	
+	dignity = 10
+	
+	capital	= 290 # Uppland
+	
+	allow = {
+		always = no
+	}
+	
+	culture = norse
+}
+d_swiss = {
+	color = { 255 1 1 }
+
+	capital = 246 # Schwyz
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				d_swiss = {
+					is_titular = yes
+				}
+			}
+
+			d_swiss = {
+				is_titular = no
+			}
+		}
+	}
+}
+d_tavasts = {
+	color = { 131 21 21 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = finnish
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_meryas = {
+	color = { 131 41 41 }
+	
+	capital = 574 # Rostov / Merya
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = mordvin
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_veps = {
+	color = { 120 90 40 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = mordvin
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_meshcheras = {
+	color = { 151 71 41 }
+	
+	capital = 580 # Ryazan
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = mordvin
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+d_drevlians = {
+	color = { 167 195 129 }
+	
+	capital = 548 # Turov
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = volhynian
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}			  
+d_varna = {
+	color = { 208 93 251 }
+}
+d_wielkopolska = {
+	color = { 252 144 144 }
+}
+d_vlachs = {
+	color = { 239 193 70 }
+}
+d_volga = {
+	color = { 168 135 47 }
+}
+d_votes = {
+	color = { 0 193 119 }
+	
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	culture = finnish
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+	
+}
+d_zara = {
+	color = { 203 217 255 }
+}
+d_zaragoza = {
+	color = { 80 220 10 }
+}
+d_zemigalians = {
+	color = { 183 21 21 }
+	culture = lettigallish
+#	tribe = yes
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_lendians = { # aka Ledzianie or Lechs
+	color={ 245 163 176 }
+	color2={ 255 255 255 }
+	culture = polish
+#	tribe = yes
+	
+	capital = 527 # Krakowskie
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_kryvians = { # aka Krivichi
+	color = { 128 133 104 }
+	color2={ 255 255 255 }
+	
+	culture = russian
+#	tribe = yes
+	
+	capital = 419 # Polotsk
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_ilmenians = { # aka Ilmen Slavs
+	color = { 70 120 40 }
+	color2={ 255 255 255 }
+	
+	culture = russian
+#	tribe = yes
+	
+	capital = 414 # Novgorod
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_severians = { # aka Severiane
+	color = { 120 155 40 }
+	color2={ 255 255 255 }
+	
+	culture = russian
+#	tribe = yes
+	
+	capital = 567 # Novgorod Seversky
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_vyatichi = {
+	color={ 169 183 125 }
+	color2={ 255 255 255 }
+	
+	culture = russian
+#	tribe = yes
+	
+	capital = 570 # Tver
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_dregovichi = { 
+	color={ 100 100 20 }
+	color2={ 255 255 255 }
+	
+	culture = russian
+#	tribe = yes
+	
+	capital = 548 # Pinsk
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_radimichi = { 
+	color={ 110 136 68 }
+	color2={ 255 255 255 }
+	
+	culture = russian
+#	tribe = yes
+	
+	capital = 551 # Mstislavl
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_glomacze = { # Aka Dolomici
+	color={ 215 143 156 }
+	color2={ 255 255 255 }
+	
+	culture = pommeranian
+#	tribe = yes
+	
+	capital = 312 # Meissen
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_sorbs = {
+	color={ 170 205 110 }
+	color2={ 255 255 255 }
+	
+	culture = pommeranian
+#	tribe = yes
+	
+	capital = 364 # Luzycka
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_obotrites = {
+	color={ 100 110 20 }
+	color2={ 255 255 255 }
+	
+	culture = pommeranian
+#	tribe = yes
+	
+	capital = 260 # Mecklenburg
+	
+	allow = {
+		always = no
+	}
+	
+	title = "HIGH_CHIEF"
+	foa = "HIGH_CHIEF_FOA"
+}
+
+d_thessalia = {
+	color={ 198 28 139 }
+	color2={ 255 255 20 }
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				d_thessalia = {
+					is_titular = yes
+				}
+			}
+			d_thessalia = {
+				is_titular = no
+			}
+		}
+	}
+}
+
+d_peloponnese = {
+	color={ 196 35 140 }
+	color2={ 255 255 20 }
+
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				d_peloponnese = {
+					is_titular = yes
+				}
+			}
+			d_peloponnese = {
+				is_titular = no
+			}
+		}
+	}
+}
+
+# TITULAR KINGDOMS
+
+k_pechenegs = {
+	color = { 173 150 43 }
+	color2 = { 0 128 128 }
+	
+	capital = 543 # Oleshye
+	
+#	tribe = yes
+	culture = pecheneg
+	
+	allow = {
+		always = no
+	}
+}
+
+k_almohad = {
+	color = { 0 105 56 }
+}
+k_al-murabitids = {
+	color = { 10 105 56 }
+}
+
+k_beni_helal = {
+	color = { 128 163 56 }
+}
+k_fatimids = {
+	# OBSOLETE
+	color={ 10 140 4 }
+	color2={ 200 200 0 }
+#	capital	= 796 # Cairo
+	culture = egyptian_arabic
+	
+	allow = {
+		always = no
+	}
+}
+k_hammadid = {
+	color = { 149 180 17 }
+}
+k_kafsid = {
+	color = { 109 130 20 }
+}
+k_marinid = {
+	color = { 46 255 5 }
+}
+k_bosnia = {
+	color = { 16 125 74 }
+	culture = bosnian
+	
+	capital = 1971 # Vrhbosna	
+		allow = {
+			conditional_tooltip = {
+				trigger = {
+					k_bosnia = {
+						is_titular = yes
+					}
+				}
+				k_bosnia = {
+					is_titular = no
+				}
+			}	
+		}
+}
+
+e_seljuk_turks = { # Seljuk Turks
+	color={ 99 168 74 }
+	
+	short_name = yes
+	
+	capital = 646 # Esfahan
+	culture = turkish
+	
+#	tribe = yes
+	
+#	landless = yes
+	
+	allow = {
+		always = no
+	}
+}
+k_zenata = {
+	color = { 0 71 189 }
+}
+k_zirid = {
+	color = { 90 195 49 }
+}
+k_ziyanids = {
+	color = { 5 76 194 }
+}
+k_avaria = {
+	color={ 250 120 90 }  # Only for the CoA
+	culture = avar
+	
+	capital = 444 # Anhalt
+	
+	allow = {
+		always = no
+	}
+}
+k_lombardy = {
+	color={ 234 217 110 }  # Only for the CoA
+	culture = lombard
+	
+	capital = 234 # Anhalt
+	
+	allow = {
+		always = no
+	}
+}
+
+d_amalfi = {
+	color={ 140 200 230 }
+	capital = 935 # Amalfi
+	
+	dignity = 10
+	
+	allow = {
+		is_republic = yes
+	}
+}
+d_pechina = {
+	color={ 230 135 10 }
+	color2={ 255 255 255 }
+
+	capital = 168 # Almeria
+
+	allow = {
+		is_republic = yes
+	}
+}
+d_ragusa = {
+	color={ 133 98 17 }
+	color2={ 255 255 255 }
+
+	capital = 468
+
+	title = "RECTOR_TITLE"
+	title_female = "RECTOR_TITLE_FEMALE"
+
+	dignity = 10
+
+	allow = {
+		is_republic = yes
+	}
+}
+
+# TITULAR EMPIRES
+
+e_latin_empire = {
+	color = { 150 105 56 }
+	
+	capital = 496 # Byzantion
+	
+	short_name = yes
+	
+	
+	allow = {
+		OR = {
+			religion = catholic
+			is_heresy_of = catholic
+		}
+		e_byzantium = {
+			has_holder = no
+		}
+		e_roman_empire = {
+			has_holder = no
+		}
+		custom_tooltip = {
+			text = controls_kaliopolis_thrake
+			hidden_tooltip = {
+				495 = { # Kaliopolis
+					owner = {
+						OR = {
+							is_liege_or_above = ROOT
+							character = ROOT
+						}
+					}
+				}
+				497 = { # Thrake
+					owner = {
+						OR = {
+							is_liege_or_above = ROOT
+							character = ROOT
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+d_miaphysite = {
+	color={ 217 155 177 }
+	color2={ 220 220 0 }
+	
+	capital = 802 # Alexandria
+	
+	title = "POPE"
+	foa = "POPE_FOA"
+	
+	short_name = yes
+
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = miaphysite
+	
+	religion = miaphysite
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	# Regnal names
+	male_names = {
+		Abraham Alexandros Alexios Agatho Anastasios Andronikos Athanasios Benjamin Christodolos Cosmas Kyril Damian 
+		Demetrius Dioscorus Gabriel Yohannes Iosephos Isaakios Iakobos Makarios Markianos Markos Matheos Khail Mina 
+		Petros Philotheos Shenouda Simeon Theodoros Theophilus Timotheos Zacharias
+	}
+}
+
+d_monophysite = {
+	color={ 200 115 167 }
+	color2={ 220 220 0 }
+	
+	capital = 802 # Alexandria
+	
+	title = "POPE"
+	foa = "POPE_FOA"
+	
+	short_name = yes
+
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = monophysite
+	
+	religion = monophysite
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	# Regnal names
+	male_names = {
+		Abraham Alexandros Alexios Agatho Anastasius Andronicus Athanasios Benjamin Christodolos Cosmas Cyril Damian 
+		Demetrius Dioscorus Gabriel Ioannes Iosephos Isaakios Iakobos Makarios Markianos Matheos Michail Mina 
+		Petros Philotheos Shenouda Simeon Theodoros Theophilus Timotheos Zacharias
+	}
+}
+
+d_nestorian = {
+	color={ 180 137 97 }
+	color2={ 220 220 0 }
+	
+	capital = 693 # Baghdad
+	
+	title = "PATRIARCH_IN_THE_EAST"
+	foa = "ECUMENICAL_PATRIARCH_FOA"
+	
+	short_name = yes
+
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = nestorian
+	
+	religion = nestorian
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	# Regnal names
+	male_names = {
+		Aba Abraham Eliya Denha Emmanuel Giwargis Hnanisho Ishoyahb Makkikha 
+		Maremmeh Pethion Sabrisho Shemon Sargis Surin Theodosios Timotheos Yahballaha Yohannan
+	}
+}
+
+d_paulician = {
+	color={ 195 130 157 }
+	color2={ 255 255 255 }
+	
+	capital = 496 # Constantinople
+	
+	title = "PATRIARCH_CAP"
+	foa = "ECUMENICAL_PATRIARCH_FOA"
+	
+	short_name = yes
+
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = paulician
+	
+	religion = paulician
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	# Regnal names
+	male_names = {
+		Alexios Alexandros Anastasios Anthimos Athanasios Antonios Basileios Dionysios Dositheos 
+		Eustathios Eustratios Euthymios Gabriel Gennadios Georgios Gerasimos Germanos Gregorios Ieremias 
+		Ignatios Ioakeim Ioannes Ioseph Isidoros Kallinikos Kallistos Konstantinos Kosmas Kyrillos Leon 
+		Leontios Loukas Makarios Manuel Markos Matthaios Maximos Meletios Methodios Metrophanes Michael 
+		Neophytos Nephon Nikephoros Niketas Nikolaos Pavlos Petros Photios Polykarpos Sergios Stephanos 
+		Sophronios Theodoros Theodosios Theodotos Theophylaktos Thomas Timotheos
+	}
+}
+
+d_monothelite = {
+	color={ 180 170 65 }
+	color2={ 220 220 0 }
+	
+	capital = 764 # Antioch
+	
+	title = "PATRIARCH_CAP"
+	foa = "ECUMENICAL_PATRIARCH_FOA"
+	
+	short_name = yes
+
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = monothelite
+	
+	religion = monothelite
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	# Regnal names
+	male_names = {
+		Alexios Alexandros Anastasios Anthimos Athanasios Antonios Basileios Dionysios Dositheos 
+		Eustathios Eustratios Euthymios Gabriel Gennadios Georgios Gerasimos Germanos Gregorios Ieremias 
+		Ignatios Ioakeim Ioannes Ioseph Isidoros Kallinikos Kallistos Konstantinos Kosmas Kyrillos Leon 
+		Leontios Loukas Makarios Manuel Markos Matthaios Maximos Meletios Methodios Metrophanes Michael 
+		Neophytos Nephon Nikephoros Niketas Nikolaos Pavlos Petros Photios Polykarpos Sergios Stephanos 
+		Sophronios Theodoros Theodosios Theodotos Theophylaktos Thomas Timotheos
+	}
+}
+
+d_fraticelli = {
+	color={ 198 249 255 }
+	color2={ 220 220 0 }
+	
+	capital = 333 # Rome
+	
+	title = "POPE"
+	foa = "POPE_FOA"
+	short_name = yes
+	location_ruler_title = yes
+	
+	allow = {
+		always = no # Only by special decision
+	}
+	
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = fraticelli
+	
+	religion = fraticelli
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	# Regnal names
+	male_names = {
+		Alexander Anastasius Benedictus Caelestinus Callistus Clemens Eugenius Franciscus Leo
+		Gregorius Hadrianus Honorius Innocentius Ioannes Lucius Marinus Martinus
+		Nicolaus Sergius Silvester Stephanus Urbanus Victor
+	}
+}
+
+d_iconoclast = {
+	color={ 153 50 125 }
+	color2={ 220 220 0 }
+	
+	capital = 496 # Constantinople
+	
+	title = "ECUMENICAL_PATRIARCH"
+	foa = "ECUMENICAL_PATRIARCH_FOA"
+	short_name = yes
+	
+	allow = {
+		always = no # Only by special decision
+	}
+
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = iconoclast
+	
+	religion = iconoclast
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	# Regnal names
+	male_names = {
+		Alexios Alexandros Anastasios Anthimos Athanasios Antonios Basileios Dionysios Dositheos 
+		Eustathios Eustratios Euthymios Gabriel Gennadios Georgios Gerasimos Germanos Gregorios Ieremias 
+		Ignatios Ioakeim Ioannes Ioseph Isidoros Kallinikos Kallistos Konstantinos Kosmas Kyrillos Leon 
+		Leontios Loukas Makarios Manuel Markos Matthaios Maximos Meletios Methodios Metrophanes Michael 
+		Neophytos Nephon Nikephoros Niketas Nikolaos Pavlos Petros Photios Polykarpos Sergios Stephanos 
+		Sophronios Theodoros Theodosios Theodotos Theophylaktos Thomas Timotheos
+	}
+}
+
+d_yazidi = {
+	color={ 20 50 160 }
+	color2={ 220 220 0 }
+	
+	capital = 697 # Mosul
+	
+	dignity = 80 # Counted as having this many more counties than it does
+	
+	title = "SHEIKH"
+	title_female = "SHEIKHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion=yazidi
+	
+	# Controls a religion
+	controls_religion = yazidi
+	
+	allow = {
+		piety = 1000
+	}
+	
+	caliphate = yes
+	
+	coat_of_arms=
+	{
+		data=
+		{
+			0 0 3 0 0 11 11
+		}
+		religion=yazidi
+	}
+}
+
+d_ibadi = {
+	color={ 20 130 20 }
+	color2={ 220 220 0 }
+	
+	capital = 719 # Mecca
+	
+	creation_requires_capital = no
+	
+	dignity = 80 # Counted as having this many more counties than it does
+	
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion=ibadi
+	
+	# Controls a religion
+	controls_religion = ibadi
+	
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					has_alternate_start_parameter = { key = religion_names value = random }
+				}
+			}
+			OR = {
+				trait = mirza
+				trait = sayyid
+				piety = 1000
+			}
+			OR = {
+				AND = {
+					trait = sayyid
+					piety = 1000
+				}
+				conditional_tooltip = {
+					trigger = {
+						NOT = {
+							has_global_flag = destroyed_caliphates
+						}
+					}
+
+					custom_tooltip = { 
+						text = controls_mecca_medina
+						hidden_tooltip = {
+							719 = { # Mecca
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+							718 = { # Medina
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+						}
+					}
+				}
+				custom_tooltip = {
+					text = controls_jerusalem_damascus_baghdad
+					hidden_tooltip = {
+						774 = { # Jerusalem
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+						728 = { # Damascus
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+						693 = { # Baghdad
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_alternate_start_parameter = { key = religion_names value = random }
+			}
+			religion = ibadi
+			OR = {
+				trait = mirza
+				trait = sayyid
+				piety = 1000
+			}
+			custom_tooltip = {
+				text = THREE_HOLY_SITES_TT
+				hidden_tooltip = {
+					any_realm_title = {
+						count = 3
+						is_holy_site = ROOT
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_global_flag = destroyed_caliphates
+			}
+
+			custom_tooltip = {
+				text = controls_mecca_medina
+				hidden_tooltip = {
+					719 = { # Mecca
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+					718 = { # Medina
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	caliphate = yes
+	
+	coat_of_arms=
+	{
+		data=
+		{
+			0 0 0 8 0 2 2
+		}
+		religion=ibadi
+	}
+}
+
+d_kharijite = {
+	color={ 10 110 10 }
+	color2={ 220 220 0 }
+	
+	capital = 719 # Mecca
+	
+	creation_requires_capital = no
+	
+	dignity = 80 # Counted as having this many more counties than it does
+	
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion=kharijite
+	
+	# Controls a religion
+	controls_religion = kharijite
+	
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					has_alternate_start_parameter = { key = religion_names value = random }
+				}
+			}
+			piety = 1000
+			conditional_tooltip = {
+				trigger = {
+					NOT = {
+						has_global_flag = destroyed_caliphates
+					}
+				}
+
+				OR = {
+					custom_tooltip = { 
+						text = controls_mecca_medina
+						hidden_tooltip = {
+							719 = { # Mecca
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+							718 = { # Medina
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+						}
+					}
+					custom_tooltip = {
+						text = controls_jerusalem_damascus_baghdad
+						hidden_tooltip = {
+							774 = { # Jerusalem
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+							728 = { # Damascus
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+							693 = { # Baghdad
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_alternate_start_parameter = { key = religion_names value = random }
+			}
+			religion = kharijite
+			OR = {
+				trait = mirza
+				trait = sayyid
+				piety = 1000
+			}
+			custom_tooltip = {
+				text = THREE_HOLY_SITES_TT
+				hidden_tooltip = {
+					any_realm_title = {
+						count = 3
+						is_holy_site = ROOT
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_global_flag = destroyed_caliphates
+			}
+
+			custom_tooltip = {
+				text = controls_mecca_medina
+				hidden_tooltip = {
+					719 = { # Mecca
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+					718 = { # Medina
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	caliphate = yes
+	
+	coat_of_arms=
+	{
+		data=
+		{
+			0 0 0 8 0 2 2
+		}
+		religion=kharijite
+	}
+}
+
+d_hurufi = {
+	color={ 80 220 80 }
+	color2={ 220 220 0 }
+	
+	capital = 719 # Mecca
+	
+	creation_requires_capital = no
+	
+	dignity = 100 # Counted as having this many more counties than it does
+	
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion=hurufi
+	
+	# Controls a religion
+	controls_religion = hurufi
+	
+	allow = {
+		conditional_tooltip = {
+			trigger = {
+				NOT = {
+					has_alternate_start_parameter = { key = religion_names value = random }
+				}
+			}
+			OR = {
+				trait = mirza
+				trait = sayyid
+				piety = 1000
+			}
+			OR = {
+				AND = {
+					trait = sayyid
+					piety = 1000
+				}
+				conditional_tooltip = {
+					trigger = {
+						NOT = {
+							has_global_flag = destroyed_caliphates
+						}
+					}
+
+					custom_tooltip = {
+						text = controls_mecca_medina
+						hidden_tooltip = {
+							719 = { # Mecca
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+							718 = { # Medina
+								owner = {
+									OR = {
+										is_liege_or_above = ROOT
+										character = ROOT
+									}
+								}
+							}
+						}
+					}
+				}
+				custom_tooltip = {
+					text = controls_jerusalem_damascus_baghdad
+					hidden_tooltip = {
+						774 = { # Jerusalem
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+						728 = { # Damascus
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+						693 = { # Baghdad
+							owner = {
+								OR = {
+									is_liege_or_above = ROOT
+									character = ROOT
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_alternate_start_parameter = { key = religion_names value = random }
+			}
+			religion = hurufi
+			OR = {
+				trait = mirza
+				trait = sayyid
+				piety = 1000
+			}
+			custom_tooltip = {
+				text = THREE_HOLY_SITES_TT
+				hidden_tooltip = {
+					any_realm_title = {
+						count = 3
+						is_holy_site = ROOT
+					}
+				}
+			}
+		}
+		conditional_tooltip = {
+			trigger = {
+				has_global_flag = destroyed_caliphates
+			}
+
+			custom_tooltip = {
+				text = controls_mecca_medina
+				hidden_tooltip = {
+					719 = { # Mecca
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+					718 = { # Medina
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	caliphate = yes
+	
+	coat_of_arms=
+	{
+		data=
+		{
+			0 0 0 7 1 7 7
+		}
+		religion=hurufi
+	}
+}
+
+e_mexikha = {
+	color = { 255 127 0 }
+	
+	short_name = yes
+	
+#	capital = 1
+	
+	# Always exists
+	landless = yes
+	
+#	tribe = yes
+	
+	culture = nahuatl
+	religion = aztec
+}
+
+#d_hansa = {
+#	color={ 142 142 142 }
+#	color2={ 255 255 255 }
+#	
+#	allow = {
+#		always = no
+#	}
+#	
+#	capital = 262 # Lübeck
+#	
+#	dignity = 10
+#}	
+
+
+######################################
+# Historical Merchant Republic Palaces
+######################################
+
+# VENICE:
+
+b_dandolo = {
+	culture = italian
+	religion = catholic
+}
+
+b_contarini = {
+	culture = italian
+	religion = catholic
+}
+
+b_faliero = {
+	culture = italian
+	religion = catholic
+}
+
+b_morosini = {
+	culture = italian
+	religion = catholic
+}
+
+b_ziani = {
+	culture = italian
+	religion = catholic
+}
+
+b_candiano = {
+	culture = italian
+	religion = catholic
+}
+
+b_orsoleo = {
+	culture = italian
+	religion = catholic
+}
+
+b_participazio = {
+	culture = italian
+	religion = catholic
+}
+
+b_tribuno = {
+	culture = italian
+	religion = catholic
+}
+
+b_tradonico = {
+	culture = italian
+	religion = catholic
+}
+
+b_antenoreo = {
+	culture = italian
+	religion = catholic
+}
+
+b_galbaio = {
+	culture = italian
+	religion = catholic
+}
+
+b_monegario = {
+	culture = italian
+	religion = catholic
+}
+
+b_gaulo = {
+	culture = italian
+	religion = catholic
+}
+
+b_silvio = {
+	culture = italian
+	religion = catholic
+}
+
+b_mastropiero = {
+	culture = italian
+	religion = catholic
+}
+
+b_tiepolo = {
+	culture = italian
+	religion = catholic
+}
+
+# GENOA:
+
+b_doria = {
+	culture = italian
+	religion = catholic
+}
+
+b_spinola = {
+	culture = italian
+	religion = catholic
+}
+
+b_grimaldi = {
+	culture = italian
+	religion = catholic
+}
+
+b_fieschi = {
+	culture = italian
+	religion = catholic
+}
+
+b_embriaco = {
+	culture = italian
+	religion = catholic
+}
+
+# PISA:
+
+b_dappiano = {
+	culture = italian
+	religion = catholic
+}
+
+b_della_gherardesca = {
+	culture = italian
+	religion = catholic
+}
+
+b_visconti = {
+	culture = italian
+	religion = catholic
+}
+
+b_alliata = {
+	culture = italian
+	religion = catholic
+}
+
+b_caetani = {
+	culture = italian
+	religion = catholic
+}
+
+# LÜBECK:
+
+b_bardewik = {
+	culture = german
+	religion = catholic
+}
+
+b_vorrade = {
+	culture = german
+	religion = catholic
+}
+
+b_warendorp = {
+	culture = german
+	religion = catholic
+}
+
+b_pat_luneburg = {
+	culture = german
+	religion = catholic
+}
+
+b_wittenborg = {
+	culture = german
+	religion = catholic
+}
+
+# GOTLAND:
+
+b_stenkyrka = {
+	culture = swedish
+	religion = catholic
+}
+
+b_guldsmed = {
+	culture = swedish
+	religion = catholic
+}
+
+b_hejnum = {
+	culture = swedish
+	religion = catholic
+}
+
+b_gildehusen = {
+	culture = swedish
+	religion = catholic
+}
+
+b_strabain = {
+	culture = swedish
+	religion = catholic
+}
+
+# AMALFI:
+
+b_konstantios = {
+	culture = greek
+	religion = catholic
+}
+
+b_mauro = {
+	culture = italian
+	religion = catholic
+}
+
+b_musco = {
+	culture = italian
+	religion = catholic
+}
+
+b_polkarios = {
+	culture = greek
+	religion = catholic
+}
+
+b_urso = {
+	culture = italian
+	religion = catholic
+}
+
+b_amalfinos = {
+	culture = greek
+	religion = catholic
+}
+
+b_manginos = {
+	culture = greek
+	religion = catholic
+}
+
+b_kanakares = {
+	culture = greek
+	religion = catholic
+}
+
+b_sorrenti = {
+	culture = italian
+	religion = catholic
+}
+
+b_ravelli = {
+	culture = italian
+	religion = catholic
+}
+
+#Ancona
+b_kastriotis = {
+	culture = greek
+	religion = catholic
+}
+
+b_skleros = {
+	culture = italian
+	religion = catholic
+}
+
+b_monomachos = {
+	culture = italian 
+	religion = catholic
+}
+
+b_kourkoas = {
+	culture = greek
+	religion = catholic
+}
+
+b_scarponnois = {
+	culture = german
+	religion = catholic
+}
+
+# Ragusa
+b_babalio = {
+	culture = dalmatian
+	religion = catholic
+}
+
+b_benessa = {
+	culture = dalmatian
+	religion = catholic
+}
+
+b_salvius = {
+	culture = dalmatian
+	religion = catholic
+}
+
+b_pius = {
+	culture = dalmatian
+	religion = catholic
+}
+
+b_bonda = {
+	culture = dalmatian
+	religion = catholic
+}
+
+# Pechina
+b_al_gassani = {
+	culture = bedouin_arabic
+	religion = sunni
+}
+
+b_ruayn = {
+	culture = bedouin_arabic
+	religion = sunni
+}
+
+b_banu_sarray = {
+	culture = maghreb_arabic
+	religion = sunni
+}
+
+b_aswadid = {
+	culture = andalusian_arabic
+	religion = sunni
+}
+
+b_yeshayahu = {
+	culture = sephardi
+	religion = jewish
+}
+
+# Pagan heads of religion
+
+d_norse_pagan_reformed = {
+	color={ 155 155 235 }
+	color2={ 220 220 0 }
+	
+	capital = 290 #Uppland
+	
+	title = "FYLKIR"
+	title_female = "FYLKJA"
+	foa = "FYLKIR_FOA"
+	
+	creation_requires_capital = no
+	
+	allow = {
+		religion = norse_pagan_reformed
+		num_of_holy_sites = 3
+		piety = 500
+	}
+
+	short_name = yes
+	
+	# Always exists
+	landless = yes	
+	
+	dignity = 100 # Counted as having this many more counties than it does
+	
+	# Controls a religion
+	controls_religion = norse_pagan_reformed
+	
+	religion = norse_pagan_reformed
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_tengri_pagan_reformed = {
+	color={ 100 80 100 }
+	color2={ 220 220 0 }
+	
+	capital = 594 #	Sarkel
+	
+	title = "TENGRIKUT"
+	title_female = "TENGRIKIZ"
+	foa = "HEAD_PRIEST_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes	
+	
+	# Controls a religion
+	controls_religion = tengri_pagan_reformed
+	
+	religion = tengri_pagan_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_baltic_pagan_reformed = {
+	color={ 122 165 70 }
+	color2={ 220 220 0 }
+	
+	capital = 366 #Stettin
+	
+	title = "FIRST_VAIDILA"
+	title_female = "FIRST_VAIDILUTE"
+	foa = "HEAD_PRIEST_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes	
+	
+	# Controls a religion
+	controls_religion = baltic_pagan_reformed
+	
+	religion = baltic_pagan_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_finnish_pagan_reformed = {
+	color={ 240 240 220 }
+	color2={ 220 220 0 }
+	
+	capital = 381 # Uusimaa
+	
+	title = "TIETAJA"
+	title_female = "TIETAJA"
+	foa = "HEAD_PRIEST_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = finnish_pagan_reformed
+	
+	religion = finnish_pagan_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_slavic_pagan_reformed = {
+	color={ 175 50 136 }
+	color2={ 220 220 0 }
+	
+	capital = 515 # Tirgoviste
+	
+	title = "VELKY_VOLHV"
+	title_female = "VELKY_VOLHV"
+	foa = "HEAD_PRIEST_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes	
+	
+	# Controls a religion
+	controls_religion = slavic_pagan_reformed
+	
+	religion = slavic_pagan_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_aztec_reformed = {
+	color={ 245 245 135 }
+	color2={ 220 220 0 }
+	
+	capital = 1 #???????
+	
+	title = "TLATOANI"
+	title_female = "CIHUATLATOANI"
+	foa = "HEAD_PRIEST_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = aztec_reformed
+	
+	religion = aztec_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_west_african_pagan_reformed = {
+	color={ 91 49 13 }
+	color2={ 220 220 0 }
+	
+	capital = 925 # Mali
+	
+	title = "HEAD_AFRICAN_PRIEST"
+	title_female = "HEAD_AFRICAN_PRIESTESS"
+	foa = "HEAD_PRIEST_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = west_african_pagan_reformed
+	
+	religion = west_african_pagan_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_zun_pagan_reformed = {
+	color={ 220 255 0 }
+	color2={ 220 220 0 }
+	
+	capital = 1183 #	Bost
+	
+	title = "HEAD_ZUN_PRIEST"
+	title_female = "HEAD_ZUN_PRIESTESS"
+	foa = "HEAD_PRIEST_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes	
+	
+	# Controls a religion
+	controls_religion = zun_pagan_reformed
+	
+	religion = zun_pagan_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_zoroastrian = {
+	color={ 180 120 40 }
+	color2={ 220 220 0 }
+	
+	capital = 646 #	Esfahan
+	
+	title = "HEAD_MOABADAN_MOABAD"
+	foa = "POPE_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes	
+	
+	# Controls a religion
+	controls_religion = zoroastrian
+	
+	religion = zoroastrian
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_jewish = {
+	color = { 0 80 255 }
+	
+	capital = 774 #	Jerusalem
+	
+	title = "HEAD_KOHEN_GADOL"
+	foa = "POPE_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes	
+	
+	# Controls a religion
+	controls_religion = jewish
+	
+	religion = jewish
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+d_bon_reformed = {
+	color = { 141 130 77 }
+	
+	capital = 1498 # Lhasa
+	
+	title = "HEAD_DALAI_LAMA"
+	foa = "POPE_FOA"
+	
+	short_name = yes
+	
+	# Always exists
+	landless = yes	
+	
+	# Controls a religion
+	controls_religion = bon_reformed
+	
+	religion = bon_reformed
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+
+### INDIA ###
+
+e_india = {                      # Titular, created by special decision only if entire India is united
+	color = { 255 110 0 }
+
+	title = "SAMRAT_CHAKRAVARTIN"
+	title_female = "SAMRAJNI_CHAKRAVARTIN"
+
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	allow = {
+		always = no # Only created through special decision
+	}
+}
+
+e_rajastan = {
+	color={ 255 100 0 }
+	color2={ 255 255 255 }
+	
+	capital = 1356 # Kanyakubja
+	
+	k_sindh = {
+		color={ 225 135 20 }
+		color2={ 255 255 255 }
+		
+		capital = 1297 # Debul
+		
+		zun_pagan_reformed = 100 # Crusade target weight
+		zoroastrian_group = 50 # Crusade target weight
+		
+		d_sauvira = {
+			color={ 230 135 20 }
+			color2={ 255 255 255 }
+			
+			capital = 1297 # Debul
+			
+			c_debul = {
+				color={ 230 155 20 }
+				color2={ 255 255 255 }
+				
+				b_debul = {
+				}
+				b_banbhore = {
+				}
+				b_landhi = {
+				}
+				b_thatta = {
+				}
+				b_makli = {
+				}
+				b_shahbandar = {
+				}
+				b_kolachi = {
+				}
+				b_lari_bandar = {
+				}
+			}
+			c_sonda = {
+				color={ 230 115 20 }
+				color2={ 255 255 255 }
+				
+				b_sonda = {
+				}
+				b_nagarparkar = {
+				}
+				b_karoonjar = {
+				}
+				b_amarkot = {
+				}
+				b_mamhal = {
+				}
+				b_matli = {
+				}
+				b_badin = {
+				}
+			}
+			c_mansura = {
+				color={ 230 155 40 }
+				color2={ 255 255 255 }
+				
+				b_mansura = {
+				}
+				b_mirpur_khas = {
+				}
+				b_hala = {
+				}
+				b_nerunkot = {
+				}
+				b_matiari = {
+				}
+				b_nasarpur = {
+				}
+				b_mirman = {
+				}
+			}
+			c_ranikot = {
+				color={ 210 155 40 }
+				color2={ 255 255 255 }
+				
+				b_ranikot = {
+				}
+				b_sharusan = {
+				}
+				b_paat = {
+				}
+				b_khudabad = {
+				}
+				b_manhabari = {
+				}
+				b_jandar = {
+				}
+				b_abu = { # Fictional - For Prosperity
+				}
+			}
+			c_siwistan = {
+				color={ 250 155 40 }
+				color2={ 255 255 255 }
+				
+				b_siwistan = {
+				}
+				b_dahlilah = {
+				}
+				b_mir_rukan = {
+				}
+				b_guja = {
+				}
+				b_vicalapura = {
+				}
+				b_bahera = { # Fictional - For Prosperity
+				}
+				b_kamharia = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_bhakkar = {
+			color={ 200 105 18 }
+			color2={ 255 255 255 }
+			
+			capital = 1138 # Bhakkar
+			
+			c_bhakkar = {
+				color={ 220 105 18 }
+				color2={ 255 255 255 }
+				
+				b_bhakkar = {
+				}
+				b_larkana = {
+				}
+				b_sarkara = {
+				}
+				b_kalari = {
+				}
+				b_sialkot = {
+				}
+				b_shikarpur = {
+				}
+				b_mejia = { # Fictional - For Prosperity
+				}
+			}
+			c_aror = {
+				color={ 180 105 18 }
+				color2={ 255 255 255 }
+				
+				b_aror = {
+				}
+				b_sukkur = {
+				}
+				b_chak = {
+				}
+				b_basmak = {
+				}
+				b_siraj_ji_takri = {
+				}
+				b_allah_abad = {
+				}
+				b_mahokhar = { # Fictional - For Prosperity
+				}
+			}
+			c_rajanpur = {
+				color={ 200 115 18 }
+				color2={ 255 255 255 }
+				
+				b_rajanpur = {
+				}
+				b_rojhan = {
+				}
+				b_adhiwala = {
+				}
+				b_harrand = {
+				}
+				b_dajal = {
+				}
+				b_pottangi = { # Fictional - For Prosperity
+				}
+				b_sersandu = { # Fictional - For Prosperity
+				}
+			}
+			c_sibi = {
+				color={ 200 145 18 }
+				color2={ 255 255 255 }
+				
+				b_sibi = {
+				}
+				b_mastanj = {
+				}
+				b_walishtan = {
+				}
+				b_dadhar = {
+				}
+				b_saprenda = { # Fictional - For Prosperity
+				}
+				b_sardoi = { # Fictional - For Prosperity
+				}
+				b_valikondapuram = { # Fictional - For Prosperity
+				}
+			}
+			c_kandail = {
+				color={ 200 105 38 }
+				color2={ 255 255 255 }
+				
+				b_kandail = {
+				}
+				b_dadu = {
+				}
+				b_jhal = {
+				}
+				b_vinjamoor = { # Fictional - For Prosperity
+				}
+				b_wilong = { # Fictional - For Prosperity
+				}
+				b_xelvona = { # Fictional - For Prosperity
+				}
+				b_yamanpalli = { # Fictional - For Prosperity
+				}
+			}
+			c_quzdar = {
+				color={ 200 115 28 }
+				color2={ 255 255 255 }
+				
+				b_quzdar = {
+				}
+				b_bodein = {
+				}
+				b_sumandal = { # Fictional - For Prosperity
+				}
+				b_supa = { # Fictional - For Prosperity
+				}
+				b_suratgarh = { # Fictional - For Prosperity
+				}
+				b_talya = { # Fictional - For Prosperity
+				}
+				b_tekkumuri = { # Fictional - For Prosperity
+				}
+			}
+		}
+		
+	}
+	k_punjab = {
+		color={ 255 90 20 }
+		color2={ 255 255 255 }
+		
+		capital = 1362 # Lahur
+		
+		zun_pagan_reformed = 150 # Crusade target weight
+		zoroastrian_group = 50 # Crusade target weight
+	
+		d_multan = {
+			color={ 234 100 21 }
+			color2={ 255 255 255 }
+			
+			capital = 1338 # Multan
+			
+			c_multan = {
+				color={ 234 110 21 }
+				color2={ 255 255 255 }
+
+				holy_site = zun_pagan
+				holy_site = zun_pagan_reformed
+				
+				b_multan = {
+				}
+				b_mulasthana = {
+				}
+				b_kabirwala = {
+				}
+				b_tulamba = {
+				}
+				b_prahladpuri = {
+				}
+				b_alipur = {
+				}
+				b_makhdum_rashid = {
+				}
+			}
+			c_kafirkot = {
+				color={ 234 90 21 }
+				color2={ 255 255 255 }
+				
+				b_kafirkot = {
+				}
+				b_malot = {
+				}
+				b_bilot = {
+				}
+				b_maniot = {
+				}
+				b_dera_ghazi_khan = {
+				}
+				b_rupsi = { # Fictional - For Prosperity
+				}
+				b_sagra = { # Fictional - For Prosperity
+				}
+			}
+			c_uch = {
+				color={ 234 80 21 }
+				color2={ 255 255 255 }
+				
+				b_uch = {
+				}
+				b_chachran = {
+				}
+				b_mithankot = {
+				}
+				b_derawar = {
+				}
+				b_chaudari = {
+				}
+				b_sitpur = {
+				}
+				b_rardhu = { # Fictional - For Prosperity
+				}
+			}
+			c_karur = {
+				color={ 234 50 11 }
+				color2={ 255 255 255 }
+				
+				b_karur = {
+				}
+				b_askhanda = {
+				}
+				b_vehari = {
+				}
+				b_chishtian = {
+				}
+				b_marot = {
+				}
+				b_nyahalode = { # Fictional - For Prosperity
+				}
+				b_odalgaon = { # Fictional - For Prosperity
+				}
+			}
+			c_karor = {
+				color={ 255 120 21 }
+				color2={ 255 255 255 }
+				
+				b_karor = {
+				}
+				b_mankera = {
+				}
+				b_shadia = {
+				}
+				b_wan_bhachran = {
+				}
+				b_murwa = { # Fictional - For Prosperity
+				}
+				b_naithra = { # Fictional - For Prosperity
+				}
+				b_namchang = { # Fictional - For Prosperity
+				}
+			}
+			c_wana = { # Bori
+				color={ 244 80 5 }
+				color2={ 255 255 255 }
+				
+				b_bori = {
+				}
+				b_mun = { # Fictional - For Prosperity
+				}
+				b_nandulia = { # Fictional - For Prosperity
+				}
+				b_jua = { # Fictional - For Prosperity
+				}
+				b_junaghur = { # Fictional - For Prosperity
+				}
+				b_kakshar = { # Fictional - For Prosperity
+				}
+				b_kalamboli = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_lahore = {
+			color={ 180 110 41 }
+			color2={ 255 255 255 }
+			
+			capital = 1362 # Lahur
+			
+			c_lahur = {
+				color={ 180 130 41 }
+				color2={ 255 255 255 }
+				
+				b_lahur = {
+				}
+				b_sangla = {
+				}
+				b_kasur = {
+				}
+				b_samnabad = {
+				}
+				b_mehdiabad = {
+				}
+				b_chunian = {
+				}
+				b_data_darbar = {
+				}
+			}
+			c_dipalpur = {
+				color={ 190 100 41 }
+				color2={ 255 255 255 }
+				
+				b_pancapura = {
+				}
+				b_dipalpur = {
+				}
+				b_abohar = {
+				}
+				b_ajodhan = {
+				}
+				b_satghara = {
+				}
+				b_chichawatni = {
+				}
+				b_jongbandha = { # Fictional - For Prosperity
+				}
+			}
+			c_bhera = {
+				color={ 160 110 41 }
+				color2={ 255 255 255 }
+				
+				b_bhera = {
+				}
+				b_rampur = {
+				}
+				b_katasraj = {
+				}
+				b_girjakh = {
+				}
+				b_behak_maken = {
+				}
+				b_phalia = {
+				}
+				b_gorawas = { # Fictional - For Prosperity
+				}
+			}
+			c_shorkot = {
+				color={ 180 110 61 }
+				color2={ 255 255 255 }
+				
+				b_bhirr = {
+				}
+				b_shorkot = {
+				}
+				b_kamalia = {
+				}
+				b_chandrod = {
+				}
+				b_bhawana = {
+				}
+				b_jhang = {
+				}
+				b_rabwah = {
+				}
+			}
+		}
+		
+		d_trigarta = {
+			color={ 155 80 15 }
+			color2={ 255 255 255 }
+			
+			capital = 1193 # Trigarta
+			
+			c_trigarta = {
+				color={ 155 80 15 }
+				color2={ 255 255 255 }
+				
+				b_jalandhar = {
+				}
+				b_rahon = {
+				}
+				b_pathankot = {
+				}
+				b_kaparthula = {
+				}
+				b_milwat = {
+				}
+				b_sarwmanpur = {
+				}
+				b_ragnagar = {
+				}
+			}
+			c_sakala = {
+				color={ 180 120 21 }
+				color2={ 255 255 255 }
+				
+				b_sakala = {
+				}
+				b_jammu = {
+				}
+				b_bhuttar = {
+				}
+				b_bahu = {
+				}
+				b_vallapura = {
+				}
+				b_puran_nagar = {
+				}
+				b_pasrur = {
+				}
+			}
+			c_gurjaratra = {
+				color={ 140 120 41 }
+				color2={ 255 255 255 }
+				
+				b_gurjaratra = {
+				}
+				b_jhelum = {
+				}
+				b_kharian = {
+				}
+				b_kunjah = {
+				}
+				b_hakla = {
+				}
+				b_tibbi = {
+				}
+				b_karianwala = {
+				}
+				b_bhaddar = {
+				}
+			}
+		}
+		
+		d_gandhara = {
+			color={ 255 150 31 }
+			color2={ 255 255 255 }
+			
+			capital = 1180 # Udabhanda
+			
+			c_udabhanda = {
+				color={ 255 130 31 }
+				color2={ 255 255 255 }
+				
+				holy_site = taoist
+				holy_site = manichean # Site of Mani's first learning trip
+				
+				b_udabhanda = {
+				}
+				b_charsada = {
+				}
+				b_oddiyana = {
+				}
+				b_attak = {
+				}
+				b_mankiala = {
+				}
+				b_rawal = {
+				}
+				b_ohind = {
+				}
+			}
+			c_purushapura = {
+				color={ 235 150 31 }
+				color2={ 255 255 255 }
+				
+				b_purushapura = {
+				}
+				b_shah_ji_dheri = {
+				}
+				b_nowshera = {
+				}
+				b_ali_masjid = {
+				}
+				b_bajaur = {
+				}
+				b_mardan = {
+				}
+				b_shergarh = {
+				}
+			}
+			c_nandana = {
+				color={ 255 150 11 }
+				color2={ 255 255 255 }
+				
+				b_nandana = {
+				}
+				b_hund = {
+				}
+				b_lund2 = {
+				}
+				b_simhapura = {
+				}
+				b_khushab = {
+				}
+				b_tulaja = {
+				}
+				b_khewra = {
+				}
+			}
+			c_bannu = {
+				color={ 9 150 51 } #265 modulo 256 is 9
+				color2={ 255 255 255 }
+				
+				b_bannu = {
+				}
+				b_hangu = {
+				}
+				b_karrak = {
+				}
+				b_kohat = {
+				}
+				b_dinkot = {
+				}
+				b_kalabagh = {
+				}
+				b_hindolia = { # Fictional - For Prosperity
+				}
+			}
+		}
+	}
+	k_delhi = {
+		color={ 220 150 75 }
+		color2={ 255 255 255 }
+		
+		capital = 1365 # Delhi
+	
+		d_kuru = {
+			color={ 210 65 13 }
+			color2={ 255 255 255 }
+			
+			capital = 1365 # Delhi
+			
+			c_delhi = {
+				color={ 230 65 12 }
+				color2={ 255 255 255 }
+				
+				b_indraprastha = {
+				}
+				b_dhilika = {
+				}
+				b_mehrauli = {
+				}
+				b_lalkot = {
+				}
+				b_narela = {
+				}
+				b_siri = {
+				}
+				b_jahanpanah = {
+				}
+			}
+			c_hastinapura = {
+				color={ 190 65 12 }
+				color2={ 255 255 255 }
+				
+				b_hastinapura = {
+				}
+				b_pandeshwar = {
+				}
+				b_pankot = {
+				}
+				b_indrasthana = {
+				}
+				b_mirath = {
+				}
+				b_baran = {
+				}
+				b_hapur = {
+				}
+			}
+			c_sthanisvara = {
+				color={ 210 65 12 }
+				color2={ 255 255 255 }
+				
+				b_saharanpur = {
+				}
+				b_sthanisvara = {
+				}
+				b_shakumbhri_devi = {
+				}
+				b_sirhind = {
+				}
+				b_karnal = {
+				}
+				b_samana = {
+				}
+				b_panipat = {
+				}
+			}
+		}
+		d_haritanaka = {
+			color={ 100 25 3 }
+			color2={ 255 255 255 }
+			
+			capital = 1364 # Tribandapura
+			
+			c_hisar = {
+				color={ 100 25 23 }
+				color2={ 255 255 255 }
+				
+				b_asigarh = {
+				}
+				b_asika = {
+				}
+				b_surajkund = {
+				}
+				b_rohtak = {
+				}
+				b_hisar = {
+				}
+				b_kalanaur = {
+				}
+				b_agroha = {
+				}
+			}
+			c_tribandapura = {
+				color={ 130 25 3 }
+				color2={ 255 255 255 }
+				
+				b_tribandapura = {
+				}
+				b_sunam = {
+				}
+				b_jaintpuri = {
+				}
+				b_kartikeya = {
+				}
+				b_amin = {
+				}
+				b_chitwye = { # Fictional - For Prosperity
+				}
+				b_dabthala = { # Fictional - For Prosperity
+				}
+			}
+			c_sarasvati = {
+				color={ 100 55 3 }
+				color2={ 255 255 255 }
+				
+				b_sarasvati = {
+				}
+				b_bhadra = {
+				}
+				b_bhatnir = {
+				}
+				b_tarain = {
+				}
+				b_bukar = { # Fictional - For Prosperity
+				}
+				b_chakarpura = { # Fictional - For Prosperity
+				}
+				b_chandara = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_mathura = {
+			color={ 150 45 10 }
+			color2={ 255 255 255 }
+			
+			capital = 1359 # Mathura
+			
+			c_mathura = {
+				color={ 170 45 20 }
+				color2={ 255 255 255 }
+				
+				holy_site = hindu
+				
+				b_mathura = {
+				}
+				b_krishnajanmabhoomi = {
+				}
+				b_govardhan = {
+				}
+				b_vrindavan = {
+				}
+				b_mankameshwar = {
+				}
+				b_agra = {
+				}
+				b_khanwa = {
+				}
+				b_dhanauli = {
+				}
+			}
+			c_kol = {
+				color={ 150 65 10 }
+				color2={ 255 255 255 }
+				
+				b_dor = {
+				}
+				b_kol = {
+				}
+				b_soron = {
+				}
+				b_nilavati = {
+				}
+				b_etah = {
+				}
+				b_barauli = {
+				}
+				b_dalmau = { # Fictional - For Prosperity
+				}
+			}
+			c_sripatha = {
+				color={ 110 45 10 }
+				color2={ 255 255 255 }
+				
+				b_sripatha = {
+				}
+				b_bayana = {
+				}
+				b_dhavalapuri = {
+				}
+				b_dholeshwar_mahadev = {
+				}
+				b_abanhagari = {
+				}
+				b_durpa = { # Fictional - For Prosperity
+				}
+				b_firozpur = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_vodamayutja = {
+			color={ 195 90 0 }
+			color2={ 255 255 255 }
+			
+			capital = 1358 # Vodamayuta
+			
+			c_vodamayutja = {
+				color={ 195 90 10 }
+				color2={ 255 255 255 }
+				
+				b_vodamayutja = {
+				}
+				b_ahichatra = {
+				}
+				b_tilokpur = {
+				}
+				b_anwala = {
+				}
+				b_bareily = {
+				}
+				b_sheikhupur = {
+				}
+				b_gegha = { # Fictional - For Prosperity
+				}
+			}
+			c_sambhal = {
+				color={ 195 90 30 }
+				color2={ 255 255 255 }
+				
+				b_sambhal = {
+				}
+				b_tattandapura = {
+				}
+				b_ujhani = {
+				}
+				b_amroha = {
+				}
+				b_sirsi = {
+				}
+				b_bachhraon = {
+				}
+				b_gokal = { # Fictional - For Prosperity
+				}
+			}
+			c_katehar = {
+				color={ 165 90 0 }
+				color2={ 255 255 255 }
+				
+				b_mandawar = {
+				}
+				b_bijnor = {
+				}
+				b_gangadvara = {
+				}
+				b_rishikesh = {
+				}
+				b_nehtaur = {
+				}
+				b_jageshwar = {
+				}
+				b_dusajabad = { # Fictional, for prosperity
+				}
+			}
+		}
+	}
+	k_gujarat = {
+		color={ 155 80 28 }
+		color2={ 255 255 255 }
+		
+		capital = 1292 # Sarasvata Mandala
+	
+		d_gurjara_mandala = {
+			color={ 175 80 20 }
+			color2={ 255 255 255 }
+			
+			capital = 1292 # Sarasvata Mandala
+			
+			c_sarasvata_mandala = {
+				color={ 155 80 20 }
+				color2={ 255 255 255 }
+				
+				b_anahilapataka = {
+				}
+				b_vadnagar = {
+				}
+				b_siddhapura = {
+				}
+				b_kamboika = {
+				}
+				b_modhera = {
+				}
+				b_kheralu = {
+				}
+				b_shertha = {
+				}
+			}
+			c_khetaka = {
+				color={ 175 80 40 }
+				color2={ 255 255 255 }
+				
+				b_khetaka = {
+				}
+				b_khambhat = {
+				}
+				b_dholka = {
+				}
+				b_tarapur = {
+				}
+				b_ashaval = {
+				}
+				b_nadiad = {
+				}
+				b_bhadran = {
+				}
+				b_sanand = {
+				}
+			}
+			c_mohadavasaka = {
+				color={ 175 100 20 }
+				color2={ 255 255 255 }
+				
+				b_mohadavasaka = {
+				}
+				b_jhalod = {
+				}
+				b_lunawada = {
+				}
+				b_shamlaji = {
+				}
+				b_idar = {
+				}
+				b_unjha = {
+				}
+				b_danta = {
+				}
+			}
+		}
+		d_anartta = {
+			color={ 195 50 10 }
+			color2={ 255 255 255 }
+			
+			capital = 1136 # Dvaraka
+			
+			c_dhamalpur = {
+				color={ 195 50 30 }
+				color2={ 255 255 255 }
+				
+				b_dhamalpur = {
+				}
+				b_morvi = {
+				}
+				b_lakhota = {
+				}
+				b_khasta = {
+				}
+				b_dhrol = {
+				}
+				b_hurshi = { # Fictional - For Prosperity
+				}
+				b_jade = { # Fictional - For Prosperity
+				}
+			}
+			c_dvaraka = {
+				color={ 175 50 10 }
+				color2={ 255 255 255 }
+				
+				holy_site = hindu
+				
+				b_dvaraka = {
+				}
+				b_lalpur = {
+				}
+				b_dwarakadheesh = {
+				}
+				b_gomati = {
+				}
+				b_bhanvad = {
+				}
+				b_huljanti = { # Fictional - For Prosperity
+				}
+				b_jakar = { # Fictional - For Prosperity
+				}
+			}
+			c_kutch = {
+				color={ 195 70 10 }
+				color2={ 255 255 255 }
+				
+				b_kanthakota = {
+				}
+				b_anjar = {
+				}
+				b_dhaneti = {
+				}
+				b_bhuj = {
+				}
+				b_holavanhalli = { # Fictional - For Prosperity
+				}
+				b_hora = { # Fictional - For Prosperity
+				}
+				b_hukampura = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_saurashtra = {
+			color={ 220 100 50 }
+			color2={ 255 255 255 }
+			
+			capital = 1134 # Bhumilka
+			
+			c_bhumilka = {
+				color={ 220 120 50 }
+				color2={ 255 255 255 }
+				
+				holy_site = jain
+				
+				b_vamanasthali = {
+				}
+				b_bhumilka = {
+				}
+				b_girnar = {
+				}
+				b_uperkot = {
+				}
+				b_bhavnat = {
+				}
+				b_mangrol = {
+				}
+				b_shrinagar = {
+				}
+			}
+			c_somnath = {
+				color={ 220 32 50 } #800 modulo 256 = 32
+				color2={ 255 255 255 }
+				
+				b_vejalkot = {
+				}
+				b_somnath = {
+				}
+				b_delvada = {
+				}
+				b_diu = {
+				}
+				b_veraval = {
+				}
+				b_kanjetar = {
+				}
+				b_moherak = {
+				}
+			}
+			c_vardhamana = {
+				color={ 240 100 50 }
+				color2={ 255 255 255 }
+				
+				b_vardhamana = {
+				}
+				b_amarvalli = {
+				}
+				b_halvad = {
+				}
+				b_ranpur = {
+				}
+				b_hardi = { # Fictional - For Prosperity
+				}
+				b_harpura = { # Fictional - For Prosperity
+				}
+				b_jakhri = { # Fictional - For Prosperity
+				}
+			}
+			c_valabhi = {
+				color={ 200 100 60 }
+				color2={ 255 255 255 }
+				
+				b_valabhi = {
+				}
+				b_gundigar = {
+				}
+				b_sihor = {
+				}
+				b_palatina = { # Jain Holy Site
+				}
+				b_shatrunjaya = {
+				}
+				b_dhandhuka = {
+				}
+				b_madya = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_lata = {
+			color={ 200 150 90 }
+			color2={ 255 255 255 }
+			
+			capital = 1133 # Vadodara
+			
+			c_navasarika = {
+				color={ 200 120 90 }
+				color2={ 255 255 255 }
+				
+				b_akruresvara = {
+				}
+				b_navasarika = {
+				}
+				b_bharuch = {
+				}
+				b_surat = {
+				}
+				b_rander = {
+				}
+				b_dharampur = {
+				}
+				b_variav = {
+				}
+				b_rajpipla = {
+				}
+				b_tadkeshwar = {
+				}
+			}
+			c_daman = {
+				color={ 220 150 90 }
+				color2={ 255 255 255 }
+				
+				b_daman = {
+				}
+				b_sanjan = {
+				}
+				b_surparaka = {
+				}
+				b_nagar_haveli = {
+				}
+				b_pardi = {
+				}
+				b_bulsar = {
+				}
+				b_ramnagar = {
+				}
+			}
+			c_vadodara = {
+				color={ 200 150 110 }
+				color2={ 255 255 255 }
+				
+				b_vadodara = {
+				}
+				b_ankotakka = {
+				}
+				b_kayavarohan = {
+				}
+				b_vatpatrak = {
+				}
+				b_darbhavati = {
+				}
+				b_nasvadi = {
+				}
+				b_lilam = { # Fictional - For Prosperity
+				}
+			}
+			
+			coat_of_arms=
+			{
+				data=
+				{
+					0 0 0 34 10 0 0
+				}
+				religion=hindu
+			}
+		}
+	}
+	k_rajputana = {
+		
+		color={ 200 70 0 }
+		color2={ 255 255 255 }
+		
+		capital = 1346 # Ajayameru
+	
+		d_maru = {
+			color={ 194 67 10 }
+			color2={ 255 255 255 }
+			
+			capital = 1130 # Mandavyapura
+			
+			c_mandavyapura = {
+				color={ 194 87 10 }
+				color2={ 255 255 255 }
+				
+				b_mandavyapura = {
+				}
+				b_siwana = {
+				}
+				b_osian = {
+				}
+				b_sanderaka = {
+				}
+				b_korta = {
+				}
+				b_mathania = {
+				}
+				b_ghaneraov = {
+				}
+				b_naddula = {
+				}
+			}
+			c_medantaka = {
+				color={ 194 67 30 }
+				color2={ 255 255 255 }
+				
+				b_medantaka = {
+				}
+				b_purnatallakapura = {
+				}
+				b_phalarddhi = {
+				}
+				b_sanjoo = {
+				}
+				b_oudh = { # Fictional - For Prosperity
+				}
+				b_pachaur = { # Fictional - For Prosperity
+				}
+				b_pakal = { # Fictional - For Prosperity
+				}
+			}
+			c_godwad = {
+				color={ 174 67 10 }
+				color2={ 255 255 255 }
+				
+				holy_site = jain
+				
+				b_candravati = {
+				}
+				b_bhillamala = {
+				}
+				b_jalor = {
+				}
+				b_barodiya = {
+				}
+				b_achalgarh = {
+				}
+				b_khudala = {
+				}
+				b_nibnutvadi = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_jangladesh = {
+			color={ 144 47 0 }
+			color2={ 255 255 255 }
+			
+			capital = 1354 # Nagauda
+			
+			c_vikramapura = {
+				color={ 144 47 20 }
+				color2={ 255 255 255 }
+				
+				b_vikramapura = {
+				}
+				b_kolayat = {
+				}
+				b_bhurupal = {
+				}
+				b_bhandasar = {
+				}
+				b_shekhsar = {
+				}
+				b_odur = { # Fictional - For Prosperity
+				}
+				b_pallikondai = { # Fictional - For Prosperity
+				}
+			}
+			c_reni = {
+				color={ 124 47 0 }
+				color2={ 255 255 255 }
+				
+				b_reni = {
+				}
+				b_dadrewa = {
+				}
+				b_mandir = {
+				}
+				b_bidasar = {
+				}
+				b_sidhmukh = {
+				}
+				b_niralapalli = { # Fictional - For Prosperity
+				}
+				b_palshet = { # Fictional - For Prosperity
+				}
+			}
+			c_nagauda = {
+				color={ 144 67 0 }
+				color2={ 255 255 255 }
+				
+				b_ahichhatrapur = {
+				}
+				b_nagauda = {
+				}
+				b_ladnu = {
+				}
+				b_makrana = {
+				}
+				b_ladnun = {
+				}
+				b_kuchaman = {
+				}
+				b_mundwa = {
+				}
+			}
+		}
+		d_stravani = {
+			color={ 150 60 30 }
+			color2={ 255 255 255 }
+			
+			capital = 1304 # Ludrava
+			
+			c_ludrava = {
+				color={ 170 60 30 }
+				color2={ 255 255 255 }
+				
+				b_ludrava = {
+				}
+				b_phalavardhika = {
+				}
+				b_lanela = {
+				}
+				b_jaisalmer = {
+				}
+				b_ranakpur = {
+				}
+				b_runjha = { # Fictional - For Prosperity
+				}
+				b_sahna = { # Fictional - For Prosperity
+				}
+			}
+			c_vijnot = {
+				color={ 150 60 50 }
+				color2={ 255 255 255 }
+				
+				b_vijnot = {
+				}
+				b_bhatiya = {
+				}
+				b_kishangarh = {
+				}
+				b_ghotki = {
+				}
+				b_ravel = { # Fictional - For Prosperity
+				}
+				b_saitual = { # Fictional - For Prosperity
+				}
+				b_sakyang = { # Fictional - For Prosperity
+				}
+			}
+			c_satyapura = {
+				color={ 150 40 30 }
+				color2={ 255 255 255 }
+				
+				b_kiratakupa = {
+				}
+				b_satyapura = {
+				}
+				b_kiradu = {
+				}
+				b_juna_barmer = {
+				}
+				b_srungavarapukota = { # Fictional - For Prosperity
+				}
+				b_tiklik = { # Fictional - For Prosperity
+				}
+				b_timmanayanipela = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_medapata = {
+			color={ 136 66 32 }
+			color2={ 255 255 255 }
+			
+			capital = 1345 # Medapata
+			
+			c_medapata = {
+				color={ 136 86 32 }
+				color2={ 255 255 255 }
+				
+				b_aghata = {
+				}
+				b_eklingji = {
+				}
+				b_nagahrada = {
+				}
+				b_bagar = {
+				}
+				b_jagadamba = {
+				}
+				b_sas_bahu = {
+				}
+				b_rishabhdeo = {
+				}
+			}
+			c_chitrakut = {
+				color={ 136 66 52 }
+				color2={ 255 255 255 }
+				
+				b_chitrakut = {
+				}
+				b_rampura = {
+				}
+				b_baroli = {
+				}
+				b_bhainsrorgarh = {
+				}
+				b_mandalgarh = {
+				}
+				b_nagari = {
+				}
+				b_saunk = { # Fictional - For Prosperity
+				}
+			}
+			c_kota = {
+				color={ 156 66 32 }
+				color2={ 255 255 255 }
+				
+				b_kota = {
+				}
+				b_koshvardhan = {
+				}
+				b_ramgarh = {
+				}
+				b_bundi = {
+				}
+				b_ului = { # Fictional - For Prosperity
+				}
+				b_vairampatti = { # Fictional - For Prosperity
+				}
+				b_vana = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_ajmer = {
+			color={ 230 190 51 }
+			color2={ 255 255 255 }
+			
+			capital = 1346 # Ajayameru
+			
+			c_ajayameru = {
+				color={ 210 190 51 }
+				color2={ 255 255 255 }
+				
+				b_shakambhari = {
+				}
+				b_pushkar = {
+				}
+				b_ajayameru = {
+				}
+				b_taragarh = {
+				}
+				b_dhanop = {
+				}
+				b_nareli = {
+				}
+				b_lawah = {
+				}
+			}
+			c_ranthambore = {
+				color={ 230 170 51 }
+				color2={ 255 255 255 }
+				
+				b_ranthambore = {
+				}
+				b_gangapur = {
+				}
+				b_tonkra = {
+				}
+				b_utgir = {
+				}
+				b_mandrael = {
+				}
+				b_sheopur = {
+				}
+				b_sendamarani = { # Fictional - For Prosperity
+				}
+			}
+			c_vairata = {
+				color={ 230 190 71 }
+				color2={ 255 255 255 }
+				
+				b_harshnath = {
+				}
+				b_vairata = {
+				}
+				b_sanganer = {
+				}
+				b_amer = {
+				}
+				b_dhosi = {
+				}
+				b_jhunjhunu = {
+				}
+				b_jeenmata = {
+				}
+				b_khatushyam = {
+				}
+			}
+			c_gwalior = {
+				color={ 220 180 41 }
+				color2={ 255 255 255 }
+				
+				b_gwalior = {
+				}
+				b_sahastrabahu = {
+				}
+				b_dabra = {
+				}
+				b_bateshwar = {
+				}
+				b_narwar = {
+				}
+				b_sabalgarh = {
+				}
+				b_vijaypur = {
+				}
+			}
+		}
+	}
+	k_malwa = {
+		color={ 255 200 25 }
+		color2={ 200 0 0 }
+		
+		capital = 1288 # Ujjayini
+	
+		d_dadhipadra = { # Avanti
+			color={ 245 200 20 }
+			color2={ 255 255 255 }
+			
+			capital = 1288 # Ujjayini
+			
+			c_dadhipadra = {
+				color={ 245 200 40 }
+				color2={ 255 255 255 }
+				
+				b_dadhipadra = {
+				}
+				b_pavagadh = {
+				}
+				b_champaner = {
+				}
+				b_godhra = {
+				}
+				b_kalika_mata = {
+				}
+				b_jawad = {
+				}
+				b_bamanlapalli = { # Fictional - For Prosperity
+				}
+			}
+			c_dhara = {
+				color={ 225 200 20 }
+				color2={ 255 255 255 }
+				
+				b_dhara = {
+				}
+				b_betma = {
+				}
+				b_dharampuri = {
+				}
+				b_indore = {
+				}
+				b_depalpur = {
+				}
+				b_jobat = {
+				}
+				b_sailana = {
+				}
+			}
+			c_dasapura = {
+				color={ 225 180 20 }
+				color2={ 255 255 255 }
+				
+				b_dasapura = {
+				}
+				b_sondani = {
+				}
+				b_dharmrajeshwar = {
+				}
+				b_hinglajgarh = {
+				}
+				b_taxakeshwar = {
+				}
+				b_chinchwad = { # Fictional - For Prosperity
+				}
+				b_dalu = { # Fictional - For Prosperity
+				}
+			}
+			c_ujjayini = {
+				color={ 205 200 30 }
+				color2={ 255 255 255 }
+				
+				holy_site = hindu
+				
+				b_ujjayini = {
+				}
+				b_agar = {
+				}
+				b_mahakaleshwar = {
+				}
+				b_mehidpur = {
+				}
+				b_dewas = {
+				}
+				b_maksi = {
+				}
+				b_akodia = {
+				}
+			}
+		}
+		d_akara_dasarna = {
+			color={ 210 150 15 }
+			color2={ 255 255 255 }
+			
+			capital = 1170 # Vidisa
+			
+			c_sarangpur = {
+				color={ 210 150 35 }
+				color2={ 255 255 255 }
+				
+				b_sarangpur = {
+				}
+				b_ashta = {
+				}
+				b_sidhhapur = {
+				}
+				b_gagraun = {
+				}
+				b_rajgarh = {
+				}
+				b_jhalawar = {
+				}
+				b_bhoilymbong = { # Fictional - For Prosperity
+				}
+			}
+			c_vidisa = {
+				color={ 190 150 15 }
+				color2={ 255 255 255 }
+				
+#				holy_site = buddhist
+				
+				b_vidisa = {
+				}
+				b_sanchi = {
+				}
+				b_sironj = {
+				}
+				b_bijamandal = {
+				}
+				b_raisin = {
+				}
+				b_bhojpur = {
+				}
+				b_mangla_devi = {
+				}
+			}
+			c_chanderi = {
+				color={ 210 130 15 }
+				color2={ 255 255 255 }
+				
+				b_chanderi = {
+				}
+				b_jhansi = {
+				}
+				b_luacchagiri = {
+				}
+				b_garh_kundar = {
+				}
+				b_jarai_ka_math = {
+				}
+				b_khurai = {
+				}
+				b_aharji = {
+				}
+			}
+			c_candhoba = {
+				color={ 210 160 25 }
+				color2={ 255 255 255 }
+				
+				b_candhoba = {
+				}
+				b_sipri = {
+				}
+				b_guna = {
+				}
+				b_kadwaya = {
+				}
+				b_charmuria = { # Fictional - For Prosperity
+				}
+				b_charwadih = { # Fictional - For Prosperity
+				}
+				b_tilosingi = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_anupa = {
+			color={ 150 110 5 }
+			color2={ 255 255 255 }
+			
+			capital = 1147 # Mandapika
+			
+			c_mandapika = {
+				color={ 150 130 5 }
+				color2={ 255 255 255 }
+				
+				b_mandapika = {
+				}
+				b_bawangaja = {
+				}
+				b_maheshwar = {
+				}
+				b_borgarh = {
+				}
+				b_avasgarh = {
+				}
+				b_bordhoman = { # Fictional - For Prosperity
+				}
+				b_datrauda = { # Fictional - For Prosperity
+				}
+			}
+			c_asirgarh = {
+				color={ 140 110 15 }
+				color2={ 255 255 255 }
+				
+				b_asirgarh = {
+				}
+				b_khandwa = {
+				}
+				b_khargone = {
+				}
+				b_mandleshwar = {
+				}
+				b_sanawad = {
+				}
+				b_hansla = { # Fictional - For Prosperity
+				}
+				b_jakpur = { # Fictional - For Prosperity
+				}
+			}
+			c_burhanpur = {
+				color={ 150 90 5 }
+				color2={ 255 255 255 }
+				
+				b_burhanpur = {
+				}
+				b_erandol = {
+				}
+				b_vaghli = {
+				}
+				b_changdev = {
+				}
+				b_yawal = {
+				}
+				b_halgeri = { # Fictional - For Prosperity
+				}
+				b_jargaon = { # Fictional - For Prosperity
+				}
+			}
+			c_thalner = {
+				color={ 160 100 15 }
+				color2={ 255 255 255 }
+				
+				b_thalner = {
+				}
+				b_balasane = {
+				}
+				b_sindkheda = {
+				}
+				b_bhamer = {
+				}
+				b_jhodga = {
+				}
+				b_laling = {
+				}
+				b_amalner = {
+				}
+			}
+		}
+	}
+	k_kosala = {
+		color={ 205 60 10 }
+		color2={ 255 255 255 }
+		
+		capital = 1356 # Kanyakubja
+	
+		d_kanyakubja = {
+			color={ 225 155 77 }
+			color2={ 255 255 255 }
+			
+			capital = 1356 # Kanyakubja
+			
+			c_kanyakubja = {
+				color={ 225 135 77 }
+				color2={ 255 255 255 }
+				
+				b_kanyakubja = {
+				}
+				b_jajmau = {
+				}
+				b_bithor = {
+				}
+				b_etawah = {
+				}
+				b_swargdwari = {
+				}
+				b_kampil = {
+				}
+				b_jai_chandra = {
+				}
+			}
+			c_lakhnau = {
+				color={ 235 155 67 }
+				color2={ 255 255 255 }
+				
+				b_lakhnau = {
+				}
+				b_jasnaul = {
+				}
+				b_satrikh = {
+				}
+				b_hardoi = {
+				}
+				b_zaidpur = {
+				}
+				b_ganeshpur = { # Fictional - For Prosperity
+				}
+				b_gangabana = { # Fictional - For Prosperity
+				}
+			}
+			c_kalpi = {
+				color={ 205 155 77 }
+				color2={ 255 255 255 }
+				
+				b_kalpi = {
+				}
+				b_jalaun = {
+				}
+				b_lahar = {
+				}
+				b_oirai = {
+				}
+				b_kurara = {
+				}
+				b_konch = {
+				}
+				b_galleborgao = { # Fictional - For Prosperity
+				}
+			}
+			c_bharauli = {
+				color={ 225 135 77 }
+				color2={ 255 255 255 }
+				
+				b_bharauli = {
+				}
+				b_manikpur = {
+				}
+				b_lalganj = {
+				}
+				b_bhadri = {
+				}
+				b_gotitoria = { # Fictional - For Prosperity
+				}
+				b_haktsarpur = { # Fictional - For Prosperity
+				}
+				b_jevargi = { # Fictional - For Prosperity
+				}
+			}
+			c_asni = {
+				color={ 225 155 97 }
+				color2={ 255 255 255 }
+				
+				b_asni2 = {
+				}
+				b_bhitargaon = {
+				}
+				b_kora = {
+				}
+				b_musanagar = {
+				}
+				b_shivrajpur = {
+				}
+				b_bindki = {
+				}
+				b_khaga = {
+				}
+			}
+			c_prayaga = {
+				color={ 215 165 67 }
+				color2={ 255 255 255 }
+				
+				b_prayaga = {
+				}
+				b_daraganj = {
+				}
+				b_alopibagh = {
+				}
+				b_kausambi = {
+				}
+				b_chowk = {
+				}
+				b_kara = {
+				}
+				b_dariyabad = {
+				}
+			}
+		}
+		d_saryupara = {
+			color={ 180 110 40 }
+			color2={ 255 255 255 }
+			
+			capital = 1250 # Ayodhya
+			
+			c_naimisa = {
+				color={ 180 110 60 }
+				color2={ 255 255 255 }
+				
+				b_naimisa = {
+				}
+				b_bahraich = {
+				}
+				b_gonda = {
+				}
+				b_lakhimpur = {
+				}
+				b_sitapur = {
+				}
+				b_misrikh = {
+				}
+				b_durbate = { # Fictional - For Prosperity
+				}
+			}
+			c_sravasti = {
+				color={ 160 110 60 }
+				color2={ 255 255 255 }
+				
+				b_sravasti = {
+				}
+				b_barohiya = {
+				}
+				b_jetavana = {
+				}
+				b_amorha = {
+				}
+				b_gorakhnath_math = {
+				}
+				b_gorakhpur = {
+				}
+				b_maghar = {
+				}
+			}
+			c_ayodhya = {
+				color={ 180 130 60 }
+				color2={ 255 255 255 }
+				
+				b_ayodhya = {
+				}
+				b_ramkot = {
+				}
+				b_ram_janmabhoomi = {
+				}
+				b_nageshwarnath = {
+				}
+				b_hanuman_garhi = {
+				}
+				b_faizabad = {
+				}
+				b_sarairasi = {
+				}
+			}
+		}
+		d_jejakabhukti = {
+			color={ 120 50 10 }
+			color2={ 255 255 255 }
+			
+			capital = 1301 # Mahoba
+			
+			c_mahoba = {
+				color={ 140 50 10 }
+				color2={ 255 255 255 }
+				
+				b_mahoba = {
+				}
+				b_chitrakuta = {
+				}
+				b_hamirpur = {
+				}
+				b_ajaigarh = {
+				}
+				b_rath = {
+				}
+				b_jhammanpur = { # Fictional - For Prosperity
+				}
+				b_kamodh = { # Fictional - For Prosperity
+				}
+			}
+			c_kalanjara = {
+				color={ 120 70 10 }
+				color2={ 255 255 255 }
+				
+				b_kalinjar = {
+				}
+				b_khajuraho = {
+				}
+				b_jayapura = {
+				}
+				b_bhatta = {
+				}
+				b_panna = {
+				}
+				b_devendranagar = {
+				}
+				b_longching = { # Fictional - For Prosperity
+				}
+			}
+			c_damoh = {
+				color={ 110 50 30 }
+				color2={ 255 255 255 }
+				
+				b_damoh = {
+				}
+				b_dhamoni = {
+				}
+				b_nohta = {
+				}
+				b_singrampur = {
+				}
+				b_narsinghgarh = {
+				}
+				b_nimora = { # Fictional - For Prosperity
+				}
+				b_panwel = { # Fictional - For Prosperity
+				}
+			}
+			c_gurgi = {
+				color={ 150 255 91 }
+				color2={ 255 255 255 }
+				
+				b_gurgi = {
+				}
+				b_satna = {
+				}
+				b_bathgahora = {
+				}
+				b_chandrehi = {
+				}
+				b_sathon = { # Fictional - For Prosperity
+				}
+				b_shankargarh = { # Fictional - For Prosperity
+				}
+				b_sharog = { # Fictional - For Prosperity
+				}
+			}
+		}
+	}
+}
+
+e_bengal = {
+	color={ 0 120 40 }
+	color2={ 255 255 20 }
+	
+	capital = 1151 # Laksmanavati
+
+	short_name = yes
+	
+	k_gondwana = {
+		color = { 32 128 55 }
+		color2={ 255 255 255 }
+			
+		capital = 1271 # Tripuri
+		
+		d_dahala = {
+			color = { 30 125 55 }
+			color2={ 255 255 255 }
+			
+			capital = 1271 # Tripuri
+			
+			c_tripuri = {
+				color = { 50 125 55 }
+				color2={ 255 255 255 }
+				
+				b_tripuri = {
+				}
+				b_mandla = {
+				}
+				b_garha = {
+				}
+				b_tungaturti = { # Fictional - For Prosperity
+				}
+				b_velan = { # Fictional - For Prosperity
+				}
+				b_rasidpur = { # Fictional - For Prosperity
+				}
+				b_samdong = { # Fictional - For Prosperity
+				}
+			}
+			c_chauragarh = {
+				color = { 30 125 35 }
+				color2={ 255 255 255 }
+				
+				b_chauragarh = {
+				}
+				b_bohani = {
+				}
+				b_barman = {
+				}
+				b_sirsali = { # Fictional - For Prosperity
+				}
+				b_siruvachur = { # Fictional - For Prosperity
+				}
+				b_tingra = { # Fictional - For Prosperity
+				}
+				b_hainsasar = { # Fictional - For Prosperity
+				}
+			}
+			
+			coat_of_arms=
+			{
+				data=
+				{
+					0 0 0 35 0 10 10
+				}
+				religion=jain
+			}
+		}
+		d_ratanpur = {
+			color = { 36 175 65 }
+			color2={ 255 255 255 }
+			
+			capital = 1272 # Ratanpur
+			
+			c_tummana = {
+				color = { 56 175 65 }
+				color2={ 255 255 255 }
+				
+				b_tummana = {
+				}
+				b_amarkantak = {
+				}
+				b_manendragarh = {
+				}
+				b_shumhi = { # Fictional - For Prosperity
+				}
+				b_torxem = { # Fictional - For Prosperity
+				}
+				b_tualbung = { # Fictional - For Prosperity
+				}
+				b_vij = { # Fictional - For Prosperity
+				}
+			}
+			c_ratanpur = {
+				color = { 36 155 65 }
+				color2={ 255 255 255 }
+				
+				b_ratanpur = {
+				}
+				b_pali = {
+				}
+				b_saravpur = {
+				}
+				b_savarinarayana = {
+				}
+				b_shegaon = { # Fictional - For Prosperity
+				}
+				b_shirwal = { # Fictional - For Prosperity
+				}
+				b_yellandu = { # Fictional - For Prosperity
+				}
+			}
+			c_bandhugadha = {
+				color = { 30 125 75 }
+				color2={ 255 255 255 }
+				
+				b_bandhugadha = {
+				}
+				b_shahdol = {
+				}
+				b_virateshwar = {
+				}
+				b_bahoriband = {
+				}
+				b_motibennur = { # Fictional - For Prosperity
+				}
+				b_muhri = { # Fictional - For Prosperity
+				}
+				b_nandwas = { # Fictional - For Prosperity
+				}
+			}
+		}
+	}
+	k_bengal = {
+		color = { 40 160 40 }
+		color2={ 255 255 255 }
+		
+		capital = 1151 # Laksmanavati
+		
+		d_vanga = {
+			color = { 35 190 35 }
+			color2={ 255 255 255 }
+			
+			capital = 1319 # Bikrampur
+			
+			c_bikrampur = {
+				color = { 35 220 35 }
+				color2={ 255 255 255 }
+				
+				b_bikrampur = {
+				}
+				b_sutrapur = {
+				}
+				b_dhakeshwari_jatiya_mandir = {
+				}
+				b_loricol = {
+				}
+				b_shakhari_bazar = {
+				}
+				b_hajiganj = {
+				}
+				b_meddappakkam = { # Fictional - For Prosperity
+				}
+			}
+			c_kumara_mandala = {
+				color = { 55 165 35 }
+				color2={ 255 255 255 }
+				
+				b_kumarakhali = {
+				}
+				b_fathabad = {
+				}
+				b_ekdala = {
+				}
+				b_katasgarh = {
+				}
+				b_molvailup = { # Fictional - For Prosperity
+				}
+				b_naneli = { # Fictional - For Prosperity
+				}
+				b_betmangala = { # Fictional - For Prosperity
+				}
+			}
+			c_candradvipa = {
+				color = { 35 165 55 }
+				color2={ 255 255 255 }
+				
+				b_candradvipa = {
+				}
+				b_khulna = {
+				}
+				b_sathkira = {
+				}
+				b_bagerhat = {
+				}
+				b_bakarganj = {
+				}
+				b_bilkhet = { # Fictional - For Prosperity
+				}
+				b_dattapulia = { # Fictional - For Prosperity
+				}
+			}
+			c_samatata = {
+				color = { 35 145 35 }
+				color2={ 255 255 255 }
+				
+				b_devaparvata = {
+				}
+				b_chatigama = {
+				}
+				b_candranatha = {
+				}
+				b_garmali = { # Fictional - For Prosperity
+				}
+				b_gond = { # Fictional - For Prosperity
+				}
+				b_kanaoudi = { # Fictional - For Prosperity
+				}
+				b_kandalike = { # Fictional - For Prosperity
+				}
+			}
+			c_karmanta = {
+				color = { 45 155 45 }
+				color2={ 255 255 255 }
+				
+				b_karmanta = {
+				}
+				b_mainamati = {
+				}
+				b_unakoti = {
+				}
+				b_udaipur = {
+				}
+				b_lavangi = { # Fictional - For Prosperity
+				}
+				b_mahalpur = { # Fictional - For Prosperity
+				}
+				b_latembarcem = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_varendra = {
+			color = { 20 125 20 }
+			color2={ 255 255 255 }
+			
+			capital = 1381 # Pundravardhana
+			
+			c_madhupur = {
+				color = { 40 125 20 }
+				color2={ 255 255 255 }
+				
+				b_madhupur = {
+				}
+				b_pabna = {
+				}
+				b_bogra = {
+				}
+				b_baghabarihat = {
+				}
+				b_kursu = { # Fictional - For Prosperity
+				}
+				b_kutra = { # Fictional - For Prosperity
+				}
+				b_lahpatra = { # Fictional - For Prosperity
+				}
+			}
+			c_pundravardhana = {
+				color = { 20 125 40 }
+				color2={ 255 255 255 }
+				
+				b_pundravardhana = {
+				}
+				b_mahasthangarh = {
+				}
+				b_somapura_mahavihara = {
+				}
+				b_totaram_panditer_dhap = {
+				}
+				b_khulnar_dhap = {
+				}
+				b_bhimer_jangal = {
+				}
+				b_ghoraghat = {
+				}
+			}
+			c_suvarnagram = {
+				color = { 20 105 20 }
+				color2={ 255 255 255 }
+				
+				b_narikella = {
+				}
+				b_suvarnagram = {
+				}
+				b_satkhira = {
+				}
+				b_susanga = {
+				}
+				b_bokainagar = {
+				}
+				b_lakshmipuro = { # Fictional - For Prosperity
+				}
+				b_mahendragarh = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_gauda = {
+			color = { 60 200 60 }
+			color2={ 255 255 255 }
+			
+			capital = 1151 # Laksmanavati
+			
+			c_gauda = {
+				color = { 60 180 60 }
+				color2={ 255 255 255 }
+				
+				b_karnasubarna = {
+				}
+				b_raktamrittika = {
+				}
+				b_tarapith = {
+				}
+				b_adinatha_mandir = {
+				}
+				b_agmahl = {
+				}
+				b_teliagarhi = {
+				}
+				b_kumhaul = { # Fictional - For Prosperity
+				}
+			}
+			c_radha = {
+				color = { 60 180 60 }
+				color2={ 255 255 255 }
+				
+				b_lakhnor = {
+				}
+				b_kalyaneshwari = {
+				}
+				b_katwa = {
+				}
+				b_rampur_boalia = {
+				}
+				b_gopbhum = {
+				}
+				b_ichhai_ghoshgarh = {
+				}
+				b_hirapur = {
+				}
+			}
+			c_laksmanavati = {
+				color = { 70 190 70 }
+				color2={ 255 255 255 }
+				
+				b_laksmanavati = {
+				}
+				b_gaur = {
+				}
+				b_malda = {
+				}
+				b_pankak = {
+				}
+				b_banan = {
+				}
+				b_shukla = {
+				}
+				b_puthia = {
+				}
+			}
+			c_kotivarsa = {
+				color={ 58 200 41 }
+				color2={ 255 255 255 }
+				
+				b_ramavati = {
+				}
+				b_devkot = {
+				}
+				b_bangarh = {
+				}
+				b_jagaddala = {
+				}
+				b_korat = {
+				}
+				b_siliguri = {
+				}
+				b_purena = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_nadia = {
+			color = { 100 255 100 }
+			color2={ 255 255 255 }
+			
+			capital = 1323 # Nabadwipa
+			
+			c_nabadwipa = {
+				color = { 120 255 100 }
+				color2={ 255 255 255 }
+				
+				b_nabadwipa = {
+				}
+				b_krishnagar = {
+				}
+				b_pancharatna = {
+				}
+				b_bidhyanandikathi = {
+				}
+				b_madhyadwip = {
+				}
+				b_godrumdwip = {
+				}
+				b_ritudwip = {
+				}
+			}
+			c_saptagrama = {
+				color = { 100 255 80 }
+				color2={ 255 255 255 }
+				
+				b_saptagrama = {
+				}
+				b_bansberia = {
+				}
+				b_chinsura = {
+				}
+				b_mahanad = {
+				}
+				b_pandua = {
+				}
+				b_tribeni = {
+				}
+				b_shantipur = {
+				}
+			}
+			c_vijayapura = {
+				color = { 110 245 100 }
+				color2={ 255 255 255 }
+				
+				b_vijayapura = {
+				}
+				b_begunia = {
+				}
+				b_patuli = {
+				}
+				b_kalna = {
+				}
+				b_churulia = {
+				}
+				b_dishergarh = {
+				}
+				b_mohammadnagar = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_suhma = {
+			color = { 10 100 10 }
+			color2={ 255 255 255 }
+			
+			capital = 1238 # Mallabhum
+			
+			c_tamralipti = {
+				color = { 20 100 20 }
+				color2={ 255 255 255 }
+				
+				b_tamralipti = {
+				}
+				b_sagardwip = {
+				}
+				b_jahajghata = {
+				}
+				b_chandraketugarh = {
+				}
+				b_ishwaripur = {
+				}
+				b_meltraipara = { # Fictional - For Prosperity
+				}
+				b_narota = { # Fictional - For Prosperity
+				}
+			}
+			c_midnapore = {
+				color = { 10 80 10 }
+				color2={ 255 255 255 }
+				
+				b_midnapore = {
+				}
+				b_moghalmari = {
+				}
+				b_dantan = {
+				}
+				b_kashipur = {
+				}
+				b_hilji = {
+				}
+				b_parodi = { # Fictional - For Prosperity
+				}
+				b_nimon = { # Fictional - For Prosperity
+				}
+			}
+			c_mallabhum = {
+			color = { 10 120 10 }
+				color2={ 255 255 255 }
+				
+				b_bishnupur = {
+				}
+				b_dihar = {
+				}
+				b_baghmundi = {
+				}
+				b_mandaran = {
+				}
+				b_chandrakona = {
+				}
+				b_garhbeta = {
+				}
+				b_arch = { # Fictional - For Prosperity
+				}
+			}
+		}
+	}
+	k_kamarupa = {
+		color={ 6 127 80 }
+		color2={ 255 255 255 }
+	
+		capital = 1321 # Kamarupanagara
+		
+		d_kamarupanagara = {
+			color={ 15 140 50 }
+			color2={ 255 255 255 }
+			
+			capital = 1321 # Kamarupanagara
+			
+			c_kamarupanagara = {
+				color={ 15 120 50 }
+				color2={ 255 255 255 }
+				
+				b_kamarupanagara = {
+				}
+				b_pragyotisapura = {
+				}
+				b_madan_kamdev = {
+				}
+				b_hajo = {
+				}
+				b_durjaya = {
+				}
+				b_manikuta = {
+				}
+				b_dariyaon = {
+				}
+			}
+			c_kamatapur = {
+				color={ 25 140 40 }
+				color2={ 255 255 255 }
+				
+				b_kamatapur = {
+				}
+				b_nalrajar_garh = {
+				}
+				b_mainaguri = {
+				}
+				b_japyesvara = {
+				}
+				b_bhitagarh = {
+				}
+				b_avadiyarkoil = { # Fictional - For Prosperity
+				}
+				b_babnergarh = { # Fictional - For Prosperity
+				}
+			}
+			c_sikkim = {
+				color={ 150 90 0 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Denzong"
+
+				b_gangdoz = {
+				}
+				b_mangan = {
+				}
+				b_gyalshing = {
+				}
+				b_namchi = {
+				}
+				b_rumtheg = {
+				}
+				b_ralang = {
+				}
+				b_rangpo = {
+				}
+			}
+		}
+		d_para_lauhitya = {
+			color={ 15 220 80 }
+			color2={ 255 255 255 }
+			
+			capital = 1246 # Goalpara
+			
+			c_goalpara = {
+				color={ 15 200 80 }
+				color2={ 255 255 255 }
+				
+				b_goalpara = {
+				}
+				b_sri_surya_pahar = {
+				}
+				b_kamakhya = {
+				}
+				b_dhubri = {
+				}
+				b_amauli = { # Fictional - For Prosperity
+				}
+				b_amla = { # Fictional - For Prosperity
+				}
+				b_digha = { # Fictional - For Prosperity
+				}
+			}
+			c_dimapur = {
+				color={ 15 220 60 }
+				color2={ 255 255 255 }
+				
+				b_dimapur = {
+				}
+				b_herombial = {
+				}
+				b_oddiyana2 = {
+				}
+				b_maibong = {
+				}
+				b_dindori = { # Fictional - For Prosperity
+				}
+				b_askot = { # Fictional - For Prosperity
+				}
+				b_bagchara = { # Fictional - For Prosperity
+				}
+			}
+			c_srihatta = {
+				color={ 25 210 80 }
+				color2={ 255 255 255 }
+				
+				b_srihatta = {
+				}
+				b_habiganj = {
+				}
+				b_egarosindur = {
+				}
+				b_nasirabad = {
+				}
+				b_jangalbari = {
+				}
+				b_azampur = { # Fictional - For Prosperity
+				}
+				b_kunnau = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_sutiya = {
+			color={ 150 200 40 }
+			color2={ 255 255 255 }
+			
+			capital = 1418 # Haruppeswara
+			
+			c_haruppeswara = {
+				color={ 60 200 150 }
+				color2={ 255 255 255 }
+				
+				b_haruppeswara = {
+				}
+				b_numaligarh = {
+				}
+				b_dibarumukh = {
+				}
+				b_charaideo = {
+				}
+				b_kunnatur = { # Fictional - For Prosperity
+				}
+				b_kuppar = { # Fictional - For Prosperity
+				}
+				b_malabar = { # Fictional - For Prosperity
+				}
+			}
+			c_kundina = {
+				color={ 40 180 150 }
+				color2={ 255 255 255 }
+				
+				b_kundina = {
+				}
+				b_prithiminagar = {
+				}
+				b_sadiya = {
+				}
+				b_tinsukia = {
+				}
+				b_nauli = { # Fictional - For Prosperity
+				}
+				b_nijhar = { # Fictional - For Prosperity
+				}
+				b_paravar = { # Fictional - For Prosperity
+				}
+			}
+			c_monyul = {
+				color={ 60 170 135 }
+				color2= { 255 255 255 }
+
+				b_tawang = {
+				}
+				b_itanagar = {
+				}
+				b_sepla = {
+				}
+				b_bameng = {
+				}
+				b_bomdila = {
+				}
+				b_koloriang = {
+				}
+				b_joram = {
+				}
+			}
+			c_lhoyu = {
+				color={ 30 170 100 }
+				color2= { 255 255 255 }
+
+				b_lhoyu = {
+				}
+				b_anini = {
+				}
+				b_dambuk = {
+				}
+				b_namsai = {
+				}
+				b_diyun = {
+				}
+				b_yingkiong = {
+				}
+				b_hawai = {
+				}
+			}
+		}
+	}
+	k_orissa = {
+		color={ 110 145 40 }
+		color2={ 255 255 23 }
+		
+		capital = 1129 # Kataka
+		
+		d_daksina_kosala = {
+			color={ 105 150 41 }
+			color2={ 255 255 255 }
+			
+			capital = 1160 # Rayapura
+			
+			c_sripuri = {
+				color={ 125 150 41 }
+				color2={ 255 255 255 }
+				
+				b_sripuri = {
+				}
+				b_rajiva_lochana = {
+				}
+				b_nuapada = {
+				}
+				b_bagbahara = {
+				}
+				b_basna = {
+				}
+				b_rajauli = { # Fictional - For Prosperity
+				}
+				b_sanjeli = { # Fictional - For Prosperity
+				}
+			}
+			c_rayapura = {
+				color={ 105 150 61 }
+				color2={ 255 255 255 }
+				
+				b_rayapura = {
+				}
+				b_rajim = {
+				}
+				b_shivapura = {
+				}
+				b_shivadurga = {
+				}
+				b_nandgram = {
+				}
+				b_putukipali = { # Fictional - For Prosperity
+				}
+				b_rabluto = { # Fictional - For Prosperity
+				}
+			}
+			c_suvarnapura = {
+				color={ 105 140 31 }
+				color2={ 255 255 255 }
+				
+				b_suvarnapura = {
+				}
+				b_kalahandi = {
+				}
+				b_yajatinagara = {
+				}
+				b_vinitapura = {
+				}
+				b_agalpur = {
+				}
+				b_patna = {
+				}
+				b_bargarh = {
+				}
+			}
+			c_sambalpur = {
+				color={ 95 155 41 }
+				color2={ 255 255 255 }
+				
+				b_sambalpur = {
+				}
+				b_ranipur = {
+				}
+				b_samaleswari = {
+				}
+				b_rajgangpur = {
+				}
+				b_bimaleswar = {
+				}
+				b_maneswar = {
+				}
+				b_sarugani = { # Fictional - For Prosperity
+				}
+			}
+			c_kiranapura = {
+				color = { 36 175 85 }
+				color2={ 255 255 255 }
+				
+				b_kiranapura = {
+				}
+				b_balaghat = {
+				}
+				b_lanji = {
+				}
+				b_dorkang = { # Fictional - For Prosperity
+				}
+				b_durgi = { # Fictional - For Prosperity
+				}
+				b_gangrar = { # Fictional - For Prosperity
+				}
+				b_kankauli = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_tosali = {
+			color={ 115 190 30 }
+			color2={ 255 255 255 }
+			
+			capital = 1129 # Kataka
+			
+			c_kataka = {
+				color={ 135 190 30 }
+				color2={ 255 255 255 }
+				
+				b_katak = {
+				}
+				b_bhubaneswar = {
+				}
+				b_konarak = {
+				}
+				b_dhauli = {
+				}
+				b_athgarh = {
+				}
+				b_sarala = {
+				}
+				b_sakshigopal = {
+				}
+			}
+			c_viraja = {
+				color={ 115 190 50 }
+				color2={ 255 255 255 }
+				
+				b_viraja = {
+				}
+				b_raibania = {
+				}
+				b_mahavinayak = {
+				}
+				b_bhadrak = {
+				}
+				b_anandpur = {
+				}
+				b_soro = {
+				}
+				b_baleshvara = {
+				}
+			}
+			c_khinjali_mandala = {
+				color={ 115 170 25 }
+				color2={ 255 255 255 }
+				
+				b_khinjali = {
+				}
+				b_nilamadhav = {
+				}
+				b_nayagarh = {
+				}
+				b_baramba = {
+				}
+				b_kujar = { # Fictional - For Prosperity
+				}
+				b_kunian = { # Fictional - For Prosperity
+				}
+				b_malther = { # Fictional - For Prosperity
+				}
+			}
+			c_kodalaka_mandala = {
+				color={ 135 190 25 }
+				color2={ 255 255 255 }
+				
+				b_kodalaka = {
+				}
+				b_bajrakot = {
+				}
+				b_deogarh = {
+				}
+				b_talcher = {
+				}
+				b_dhenkanal = {
+				}
+				b_kapilash = {
+				}
+				b_joranda_gadhi = {
+				}
+				b_karamul = {
+				}
+			}
+			c_khijjingakota = {
+				color={ 125 175 30 }
+				color2={ 255 255 255 }
+				
+				b_khijjinga = {
+				}
+				b_asanapat = {
+				}
+				b_sitabhinji = {
+				}
+				b_kirianagar = {
+				}
+				b_bahalda = {
+				}
+				b_baripada = {
+				}
+				b_ghatagaon = {
+				}
+			}
+		}
+		d_kalinga = {
+			color={ 70 220 115 }
+			color2={ 255 255 255 }
+			
+			capital = 1224 # Kalinganagar
+			
+			c_puri = {
+				color={ 60 220 135 }
+				color2={ 255 255 255 }
+				
+				b_puri = {
+				}
+				b_buguda = {
+				}
+				b_jaugada = {
+				}
+				b_aska = {
+				}
+				b_ganjam = {
+				}
+				b_taratarini = {
+				}
+				b_gopalpur = {
+				}
+			}
+			c_swetaka_mandala = {
+				color={ 70 200 115 }
+				color2={ 255 255 255 }
+				
+				b_swetakapura = {
+				}
+				b_rayagada = {
+				}
+				b_umerkote = {
+				}
+				b_badakhemundi = {
+				}
+				b_kharki = { # Fictional - For Prosperity
+				}
+				b_khed = { # Fictional - For Prosperity
+				}
+				b_khijaria = { # Fictional - For Prosperity
+				}
+			}
+			c_kalinganagar = {
+				color={ 100 220 115 }
+				color2={ 255 255 255 }
+				
+				b_mandasa = {
+				}
+				b_kalinganagara = {
+				}
+				b_kalingapattanam = {
+				}
+				b_srikurmam = {
+				}
+				b_srikakulam = {
+				}
+				b_kotra = { # Fictional - For Prosperity
+				}
+				b_manappakkam = { # Fictional - For Prosperity
+				}
+			}
+			c_vizagipatam = {
+				color={ 70 220 95 }
+				color2={ 255 255 255 }
+				
+				b_vizagipatam = {
+				}
+				b_simhachalam = {
+				}
+				b_anakapalle = {
+				}
+				b_kotipalli = {
+				}
+				b_bavikonda = {
+				}
+				b_bheemunipatnam = {
+				}
+				b_khuig = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_dandakaranya = {
+			color={ 38 150 70 }
+			color2={ 255 255 255 }
+			
+			capital = 1227 # Cakrakuta
+			
+			c_cakrakuta = {
+				color={ 58 150 70 }
+				color2={ 255 255 255 }
+				
+				b_cakrakuta = {
+				}
+				b_jagdalpur = {
+				}
+				b_kanker = {
+				}
+				b_pudunagram = { # Fictional - For Prosperity
+				}
+				b_purbbadulki = { # Fictional - For Prosperity
+				}
+				b_raigarh = { # Fictional - For Prosperity
+				}
+				b_sankarpur = { # Fictional - For Prosperity
+				}
+			}
+			c_barasuru = {
+				color={ 38 150 100 }
+				color2={ 255 255 255 }
+				
+				b_barasuru = {
+				}
+				b_dantewada = {
+				}
+				b_barsoor = {
+				}
+				b_konokjora = { # Fictional - For Prosperity
+				}
+				b_korandh = { # Fictional - For Prosperity
+				}
+				b_kothaguda = { # Fictional - For Prosperity
+				}
+				b_manghech = { # Fictional - For Prosperity
+				}
+			}
+			c_nandapur = {
+				color={ 48 140 70 }
+				color2={ 255 255 255 }
+				
+				b_nandapur = {
+				}
+				b_dharamgarh = {
+				}
+				b_koraput = {
+				}
+				b_junagarh = {
+				}
+				b_jeypore = {
+				}
+				b_kilpadappai = { # Fictional - For Prosperity
+				}
+				b_marhia = { # Fictional - For Prosperity
+				}
+			}
+		}
+	}
+	k_bihar = {
+		color={ 68 208 51 }
+		color2={ 255 255 255 }
+	
+		capital = 1154 # Magadha
+		
+		d_tirabhukti = {
+			color={ 58 178 41 }
+			color2={ 255 255 255 }
+			
+			capital = 1419 # Mithila
+			
+			c_mithila = {
+				color={ 58 158 41 }
+				color2={ 255 255 255 }
+				
+				b_mithila = {
+				}
+				b_yavamajjhaka = {
+				}
+				b_saligrama = {
+				}
+				b_sugauna = {
+				}
+				b_darbhanga = {
+				}
+				b_hajipur = {
+				}
+				b_siwan = {
+				}
+			}
+			c_kusinagara = {
+				color={ 58 178 61 }
+				color2={ 255 255 255 }
+				
+				b_kusinagara = {
+				}
+				b_padrauna = {
+				}
+				b_ramagrama = {
+				}
+				b_pava = {
+				}
+				b_chapra = {
+				}
+				b_alampura = { # Fictional - For Prosperity
+				}
+				b_trinabad = { # Fictional - For Prosperity
+				}
+			}
+			c_simaramapura = {
+				color={ 78 178 41 }
+				color2={ 255 255 255 }
+				
+				b_simaramapura = {
+				}
+				b_kesaria = {
+				}
+				b_bhaktagrama = {
+				}
+				b_pattana = {
+				}
+				b_bettiah = {
+				}
+				b_vaid = {
+				}
+				b_skanderabad = { # Fictional, for prosperity
+				}
+			}
+		}
+		d_kasi = {
+			color={ 150 235 91 }
+			color2={ 255 255 255 }
+			
+			capital = 1166 # Jaunpur
+			
+			c_varanasi = {
+				color={ 140 235 101 }
+				color2={ 255 255 255 }
+				
+				holy_site = hindu
+				holy_site = buddhist
+				
+				b_varanasi = {
+				}
+				b_sarnath = {
+				}
+				b_bhadohi = {
+				}
+				b_ballia = {
+				}
+				b_durga_mandir = {
+				}
+				b_kashi_vishwanath = {
+				}
+				b_aleppi = { # Fictional - For Prosperity
+				}
+			}
+			c_jaunpur = {
+				color={ 150 215 91 }
+				color2={ 255 255 255 }
+				
+				b_kerarkot = {
+				}
+				b_gadhipuri = {
+				}
+				b_dohrighat = {
+				}
+				b_jaunpur = {
+				}
+				b_amethi = {
+				}
+				b_haldi = {
+				}
+				b_tanda = {
+				}
+			}
+			c_chunar = {
+				color={ 170 235 91 }
+				color2={ 255 255 255 }
+				
+				b_chunar = {
+				}
+				b_vindhyachal = {
+				}
+				b_kantit = {
+				}
+				b_bidadi = { # Fictional - For Prosperity
+				}
+				b_bidh = { # Fictional - For Prosperity
+				}
+				b_bilikore = { # Fictional - For Prosperity
+				}
+				b_daudpur = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_jharkand = {
+			color={ 48 138 31 }
+			color2={ 255 255 255 }
+			
+			capital = 1248 # Munda
+			
+			c_jharkand = {
+				color={ 58 138 41 }
+				color2={ 255 255 255 }
+				
+				b_koriya = {
+				}
+				b_kandra = {
+				}
+				b_ambikapur = {
+				}
+				b_bhagva = { # Fictional - For Prosperity
+				}
+				b_bhambiya = { # Fictional - For Prosperity
+				}
+				b_bhasma = { # Fictional - For Prosperity
+				}
+				b_dhamtari = { # Fictional - For Prosperity
+				}
+			}
+			c_rothas = {
+				color={ 48 158 31 }
+				color2={ 255 255 255 }
+				
+				b_rohtas = {
+				}
+				b_rohtasgarh = {
+				}
+				b_rohtasan = {
+				}
+				b_betla = {
+				}
+				b_palamau = {
+				}
+				b_karangi = { # Fictional - For Prosperity
+				}
+				b_karumbakham = { # Fictional - For Prosperity
+				}
+			}
+			c_rajrappa = {
+				color={ 28 138 31 }
+				color2={ 255 255 255 }
+				
+				holy_site = jain # Shikharji, Parasnath Hill
+				
+				b_rajrappa = {
+				}
+				b_kenduli = {
+				}
+				b_kajgaon = { # Fictional - For Prosperity
+				}
+				b_dhaurpur = { # Fictional - For Prosperity
+				}
+				b_digapahandi = { # Fictional - For Prosperity
+				}
+				b_mahobkanth = { # Fictional - For Prosperity
+				}
+				b_kanmukal = { # Fictional - For Prosperity
+				}
+			}
+			c_munda = {
+				color={ 38 148 21 }
+				color2={ 255 255 255 }
+				
+				b_chutia = {
+				}
+				b_ratu = {
+				}
+				b_marang_buru = {
+				}
+				b_melmarudun = { # Fictional - For Prosperity
+				}
+				b_nathorl = { # Fictional - For Prosperity
+				}
+				b_patera = { # Fictional - For Prosperity
+				}
+				b_patho = { # Fictional - For Prosperity
+				}
+			}
+			c_damin_i_koh = {
+				color = { 80 200 60 }
+				color2={ 255 255 255 }
+				
+				b_deogarh2 = {
+				}
+				b_shikarji = {
+				}
+				b_bhadalthua = { # Fictional - For Prosperity
+				}
+				b_bhadua = { # Fictional - For Prosperity
+				}
+				b_dhanaura = { # Fictional - For Prosperity
+				}
+				b_dharau = { # Fictional - For Prosperity
+				}
+				b_kannpur = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_magadha = {
+			color={ 15 122 25 }
+			color2={ 255 255 255 }
+			
+			capital = 1154 # Magadha
+			
+			c_magadha = {
+				color={ 35 122 25 }
+				color2={ 255 255 255 }
+				
+				b_pataliputra = {
+				}
+				b_odantapuri  = {
+				}
+				b_maner = {
+				}
+				b_barh = {
+				}
+				b_bihar_sharif = {
+				}
+				b_rajagrha = {
+				}
+				b_triveni = {
+				}
+			}
+			c_sasaram = {
+				color={ 15 122 45 }
+				color2={ 255 255 255 }
+				
+				b_sasaram = {
+				}
+				b_jaund = {
+				}
+				b_mundeshwari = {
+				}
+				b_arrah = {
+				}
+				b_horilnagar = {
+				}
+				b_kapadvanj = { # Fictional - For Prosperity
+				}
+				b_arhu = { # Fictional - For Prosperity
+				}
+			}
+			c_gaya = {
+				color={ 15 112 35 }
+				color2={ 255 255 255 }
+
+				holy_site = buddhist
+				holy_site = taoist
+				
+				b_gaya = {
+				}
+				b_bodh_gaya = {
+				}
+				b_elahabad = {
+				}
+				b_nalanda = {
+				}
+				b_sherghati = {
+				}
+				b_nawada = {
+				}
+				b_bahloipur = { # Fictional - For Prosperity
+				}
+			}
+			c_mudgagiri = {
+				color = { 60 200 80 }
+				color2={ 255 255 255 }
+				
+				b_mudgagiri = {
+				}
+				b_kahalgaon = {
+				}
+				b_campa = {
+				}
+				b_vikramasila = {
+				}
+				b_karnagarh = {
+				}
+				b_jahnugiri = {
+				}
+				b_lakhisarai = {
+				}
+			}
+		}
+	}
+}
+
+e_deccan = {
+	color={ 190 20 50 }
+	color2={ 200 0 0 }
+	
+	capital = 1210 # Manyaketha
+
+	short_name = yes
+	
+	k_maharastra = {
+		color={ 150 0 20 }
+		color2={ 255 255 255 }
+		
+		capital = 1145 # Devagiri
+		
+		d_vidharba = {
+			color={ 155 5 30 }
+			color2={ 255 255 255 }
+			
+			capital = 1285 # Acalapura
+			
+			c_acalapura = {
+				color={ 155 5 50 }
+				color2={ 255 255 255 }
+				
+				b_acalapura = {
+				}
+				b_narnala = {
+				}
+				b_amravati = {
+				}
+				b_kalam = {
+				}
+				b_yavatmal = {
+				}
+				b_bhojapur = {
+				}
+				b_bangomunda = { # Fictional - For Prosperity
+				}
+			}
+			c_ramagiri = {
+				color={ 135 5 30 }
+				color2={ 255 255 255 }
+				
+				b_ramagiri = {
+				}
+				b_pavnar = {
+				}
+				b_nandivardhana = {
+				}
+				b_mansar = {
+				}
+				b_banjapalli = { # Fictional - For Prosperity
+				}
+				b_behtar = { # Fictional - For Prosperity
+				}
+				b_belagula = { # Fictional - For Prosperity
+				}
+			}
+			c_kherla = {
+				color={ 155 25 30 }
+				color2={ 255 255 255 }
+				
+				b_kherla = {
+				}
+				b_pachmarhi = {
+				}
+				b_anjangaon = {
+				}
+				b_gawilghar = {
+				}
+				b_mauli = { # Fictional - For Prosperity
+				}
+				b_pemayangtse = { # Fictional - For Prosperity
+				}
+				b_pithorai = { # Fictional - For Prosperity
+				}
+			}
+			c_canda = {
+				color={ 175 5 30 }
+				color2={ 255 255 255 }
+				
+				b_canda = {
+				}
+				b_ballarpur = {
+				}
+				b_nagbhid = {
+				}
+				b_rajura = {
+				}
+				b_gadchiroli = {
+				}
+				b_khunabat = { # Fictional - For Prosperity
+				}
+				b_mathila = { # Fictional - For Prosperity
+				}
+			}
+			c_vairagara = {
+				color={ 155 5 10 }
+				color2={ 255 255 255 }
+				
+				b_vairagara = {
+				}
+				b_bhandugara = {
+				}
+				b_cikamburika = {
+				}
+				b_gondia = {
+				}
+				b_kas = { # Fictional - For Prosperity
+				}
+				b_kauria = { # Fictional - For Prosperity
+				}
+				b_kelod = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_konkana = {
+			color={ 115 20 40 }
+			color2={ 255 255 255 }
+			
+			capital = 1125 # Thana
+			
+			c_goa = {
+				color={ 115 40 40 }
+				color2={ 255 255 255 }
+				
+				b_gopakapattana = {
+				}
+				b_gheria = {
+				}
+				b_mathagram = {
+				}
+				b_kapardikadvipa = {
+				}
+				b_chandrapur = {
+				}
+				b_chitrakul = {
+				}
+				b_kapurgarh = { # Fictional - For Prosperity
+				}
+			}
+			c_thana = {
+				color={ 100 20 40 }
+				color2={ 255 255 255 }
+				
+				b_thana = {
+				}
+				b_dabhol = {
+				}
+				b_kanhagiri = {
+				}
+				b_chaul = {
+				}
+				b_mahim = {
+				}
+				b_bassein = {
+				}
+				b_janjira = {
+				}
+			}
+			c_honnore = {
+				color={ 115 20 60 }
+				color2={ 255 255 255 }
+				
+				b_honnore = {
+				}
+				b_bhatkal = {
+				}
+				b_gokarna = {
+				}
+				b_barkur = {
+				}
+				b_mookambika = {
+				}
+				b_karwar = {
+				}
+				b_balisna = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_nasikya = {
+			color={ 120 50 90 }
+			color2={ 255 255 255 }
+			
+			capital = 1213 # Kondana
+			
+			c_nasikya = {
+				color={ 140 50 90 }
+				color2={ 255 255 255 }
+				
+				b_nasikya = {
+				}
+				b_seunapura = {
+				}
+				b_patta = {
+				}
+				b_saptashrungi = {
+				}
+				b_ratangad = {
+				}
+				b_igatpuri = {
+				}
+				b_tryambaka = {
+				}
+			}
+			c_nandurbar = {
+				color={ 120 50 110 }
+				color2={ 255 255 255 }
+				
+				b_nandurbar = {
+				}
+				b_bhambhagiri = {
+				}
+				b_chandor = {
+				}
+				b_malegaon = {
+				}
+				b_songarh = {
+				}
+				b_sultanpur = {
+				}
+				b_mayuragiri = {
+				}
+			}
+			c_kondana = {
+				color={ 120 70 90 }
+				color2={ 255 255 255 }
+				
+				b_kondana = {
+				}
+				b_puna = {
+				}
+				b_bhimashankara = {
+				}
+				b_chakan = {
+				}
+				b_junir = {
+				}
+				b_raigad = {
+				}
+				b_purandar = {
+				}
+				b_tikona = {
+				}
+				b_rajmachi = {
+				}
+				b_sudhagad = {
+				}
+			}
+		}
+		d_devagiri = {
+			color={ 220 99 85 }
+			color2={ 255 255 255 }
+			
+			capital = 1145 # Devagiri
+			
+			c_devagiri = {
+				color={ 220 119 85 }
+				color2={ 255 255 255 }
+				
+				holy_site = buddhist
+
+				b_devagiri = {
+				}
+				b_ellora = {
+				}
+				b_khuldabad = {
+				}
+				b_grishneshwar = {
+				}
+				b_sillod = {
+				}
+				b_vaijapur = {
+				}
+				b_bangra = { # Fictional - For Prosperity
+				}
+			}
+			c_pratishthana = {
+				color={ 220 99 115 }
+				color2={ 255 255 255 }
+				
+				b_pratishthana = {
+				}
+				b_harishchandragad = {
+				}
+				b_chambargonda = {
+				}
+				b_patkapur = {
+				}
+				b_bhingar = {
+				}
+				b_ahmednagar = {
+				}
+				b_pochannapet = { # Fictional - For Prosperity
+				}
+			}
+			c_vatsagulma = {
+				color={ 200 99 85 }
+				color2={ 255 255 255 }
+				
+				b_vatsagulma = {
+				}
+				b_jalna = {
+				}
+				b_satgaon = {
+				}
+				b_lonar = {
+				}
+				b_manora = {
+				}
+				b_nandura = {
+				}
+				b_puduchattiram = { # Fictional - For Prosperity
+				}
+			}
+			c_nanded = {
+				color={ 230 99 95 }
+				color2={ 255 255 255 }
+				
+				b_nanded = {
+				}
+				b_aurad = {
+				}
+				b_qandhar = {
+				}
+				b_shelgaon = {
+				}
+				b_pathri = {
+				}
+				b_parbhani = {
+				}
+				b_balol = { # Fictional - For Prosperity
+				}
+			}
+			c_parnakheta = {
+				color={ 220 79 85 }
+				color2={ 255 255 255 }
+				
+				b_parnakheta = {
+				}
+				b_akola = {
+				}
+				b_mahkar = {
+				}
+				b_ambadapura = {
+				}
+				b_karanja = {
+				}
+				b_buldhana = {
+				}
+				b_betora = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_rattapadi = {
+			color={ 255 70 160 }
+			color2={ 255 255 255 }
+			
+			capital = 1206 # Taradavadi
+			
+			c_lattalura = {
+				color={ 235 70 160 }
+				color2={ 255 255 255 }
+				
+				b_lattalura = {
+				}
+				b_bir = {
+				}
+				b_barshi = {
+				}
+				b_udgir = {
+				}
+				b_tagara = {
+				}
+				b_darur = {
+				}
+				b_bangi = { # Fictional - For Prosperity
+				}
+			}
+			c_naldurg = {
+				color={ 255 90 160 }
+				color2={ 255 255 255 }
+				
+				b_naldurg = {
+				}
+				b_sonnalagi = {
+				}
+				b_tuljapur = {
+				}
+				b_paranda = {
+				}
+				b_karmala = {
+				}
+				b_dharaseo = {
+				}
+				b_baniagaon = { # Fictional - For Prosperity
+				}
+			}
+			c_kolhapur = {
+				color={ 255 70 180 }
+				color2={ 255 255 255 }
+				
+				b_kolhapur = {
+				}
+				b_kurundaka = {
+				}
+				b_karahataka = {
+				}
+				b_pranala = {
+				}
+				b_satara = {
+				}
+				b_manapura = {
+				}
+				b_miraj = {
+				}
+			}
+			c_taradavadi = {
+				color={ 255 70 160 }
+				color2={ 255 255 255 }
+				
+				b_taradavadi = {
+				}
+				b_viyapura = {
+				}
+				b_saundatti = {
+				}
+				b_hastikundi = {
+				}
+				b_pandharpur = {
+				}
+				b_sangole = {
+				}
+				b_karambakkudi = { # Fictional - For Prosperity
+				}
+			}
+		}
+	}
+	k_karnata = {
+		color={ 150 20 0 }
+		color2={ 255 255 255 }
+		
+		capital = 1143 # Kalyani
+		
+		d_kalyani = {
+			color={ 110 25 2 }
+			color2={ 255 255 255 }
+			
+			capital = 1143 # Kalyani
+			
+			c_kalyani = {
+				color={ 110 25 22 }
+				color2={ 255 255 255 }
+				
+				b_kalyani = {
+				}
+				b_narayanapur = {
+				}
+				b_umapur = {
+				}
+				b_hanakuni = {
+				}
+				b_ausa = {
+				}
+				b_sarsala = { # Fictional - For Prosperity
+				}
+				b_sarseir = { # Fictional - For Prosperity
+				}
+			}
+			c_bidar = {
+				color={ 110 45 2 }
+				color2={ 255 255 255 }
+				
+				b_bidar = {
+				}
+				b_avarwadi = {
+				}
+				b_kamthana = {
+				}
+				b_bhalki = {
+				}
+				b_jalasangvi = {
+				}
+				b_bhatambra = {
+				}
+				b_tekadee = {
+				}
+			}
+			c_manyakheta = {
+				color={ 130 25 2 }
+				color2={ 255 255 255 }
+				
+				b_manyakheta = {
+				}
+				b_yadavagiri = {
+				}
+				b_sedam = {
+				}
+				b_gulbarga = {
+				}
+				b_kovilkonda = {
+				}
+				b_firuzabad = {
+				}
+				b_saongi = { # Fictional - For Prosperity
+				}
+			}
+			c_sagar = {
+				color={ 90 25 2 }
+				color2={ 255 255 255 }
+				
+				b_sagar = {
+				}
+				b_bagavadi = {
+				}
+				b_pattadakal = {
+				}
+				b_talikota = {
+				}
+				b_sorapur = {
+				}
+				b_bagpura = { # Fictional - For Prosperity
+				}
+				b_bandaguda = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_gangavadi = {
+			color={ 108 23 29 }
+			color2={ 255 255 255 }
+			
+			capital = 1196 # Srirangapatna
+			
+			c_srirangapatna = {
+				color={ 108 23 49 }
+				color2={ 255 255 255 }
+				
+				holy_site = jain
+
+				b_srirangapatna = {
+				}
+				b_shravanabelagola = {
+				}
+				b_periyapatna = {
+				}
+				b_panasoge = {
+				}
+				b_nanjarayapattana = {
+				}
+				b_belapura = {
+				}
+				b_mysore = {
+				}
+			}
+			c_talakad = {
+				color={ 108 43 29 }
+				color2={ 255 255 255 }
+				
+				b_talakad = {
+				}
+				b_veppur = {
+				}
+				b_somanathapura = {
+				}
+				b_ummattur = {
+				}
+				b_sivasamudram = {
+				}
+				b_kotagiri = {
+				}
+				b_narasamangala = {
+				}
+				b_nanjangud = {
+				}
+			}
+			c_manyapura = {
+				color={ 128 23 29 }
+				color2={ 255 255 255 }
+				
+				b_manyapura = {
+				}
+				b_aralaguppe = {
+				}
+				b_turuvekere = {
+				}
+				b_kikkeri = {
+				}
+				b_melukote = {
+				}
+				b_govindanahalli = {
+				}
+				b_basaralu = {
+				}
+			}
+			c_nandagiri = {
+				color={ 88 23 29 }
+				color2={ 255 255 255 }
+				
+				b_nandagiri = {
+				}
+				b_kuvalala = {
+				}
+				b_avani = {
+				}
+				b_kundani = {
+				}
+				b_nangali = {
+				}
+				b_kurudumale = {
+				}
+				b_mulavagil = {
+				}
+			}
+		}
+		d_nulambavadi = {
+			color={ 178 93 29 }
+			color2={ 255 255 255 }
+			
+			capital = 1197 # Dwarasamudra
+			
+			c_uchangidurga = {
+				color={ 178 93 49 }
+				color2={ 255 255 255 }
+				
+				b_uchangidurga = {
+				}
+				b_parivi = {
+				}
+				b_hemavati = {
+				}
+				b_sira = {
+				}
+				b_harihar = {
+				}
+				b_chitradurga = {
+				}
+				b_nidugallu = {
+				}
+			}
+			c_dwarasamudra = {
+				color={ 178 113 29 }
+				color2={ 255 255 255 }
+				
+				b_dwarasamudra = {
+				}
+				b_belur = {
+				}
+				b_sosavur = {
+				}
+				b_hassan = {
+				}
+				b_koravangala = {
+				}
+				b_arasikere = {
+				}
+				b_javagallu = {
+				}
+			}
+			c_alampur = {
+				color={ 158 93 29 }
+				color2={ 255 255 255 }
+				
+				b_alampur = {
+				}
+				b_gooty = {
+				}
+				b_kampili = {
+				}
+				b_hampi = {
+				}
+				b_adavani = {
+				}
+				b_ittagi = {
+				}
+				b_vijayanagara = {
+				}
+			}
+		}
+		d_raichur_doab = {
+			color={ 188 133 35 }
+			color2={ 255 255 255 }
+			
+			capital = 1203 # Idatarainadu
+			
+			c_idatarainadu = {
+				color={ 188 153 35 }
+				color2={ 255 255 255 }
+				
+				b_mudgal = {
+				}
+				b_gabburu = {
+				}
+				b_raichur = {
+				}
+				b_jaladurga = {
+				}
+				b_hemagudda = {
+				}
+				b_kammatadurga = {
+				}
+				b_manvi = {
+				}
+			}
+			c_kudalasangama = {
+				color={ 168 133 35 }
+				color2={ 255 255 255 }
+				
+				b_kudalasangama = {
+				}
+				b_koppam = {
+				}
+				b_musangi = {
+				}
+				b_anegundi = {
+				}
+				b_bagali = {
+				}
+				b_kuknur = {
+				}
+				b_dambal = {
+				}
+			}
+			c_banavasi = {
+				color={ 188 133 55 }
+				color2={ 255 255 255 }
+				
+				b_vaijayanti = {
+				}
+				b_hangal = {
+				}
+				b_balligavi = {
+				}
+				b_vankapura = {
+				}
+				b_lakkundi = {
+				}
+				b_candragutti = {
+				}
+				b_kuruvatti = {
+				}
+				b_ikkeri = {
+				}
+				b_sringeri = {
+				}
+			}
+			c_vatapi = {
+				color={ 188 113 35 }
+				color2={ 255 255 255 }
+				
+				b_vatapi = {
+				}
+				b_venugrama = {
+				}
+				b_parasgad = {
+				}
+				b_aihole = {
+				}
+				b_halasi = {
+				}
+				b_dharwar = {
+				}
+				b_bagalkot = {
+				}
+			}
+		}
+	}
+	k_tamilakam = {
+		color={ 200 25 65 }
+		color2={ 255 255 255 }
+	
+		capital = 1115 # Cholamandalam
+		
+		d_chola_nadu = {
+			color={ 140 65 65 }
+			color2={ 255 255 255 }
+			
+			capital = 1115 # Cholamandalam
+			
+			c_cholamandalam = {
+				color={ 140 45 65 }
+				color2={ 255 255 255 }
+				
+				b_tanjavur = {
+				}
+				b_uraiyur = {
+				}
+				b_nagapattinam = {
+				}
+				b_kannanur = {
+				}
+				b_gangaikondacolapuram = {
+				}
+				b_srirangam = {
+				}
+				b_tiruccirapalli = {
+				}
+				b_kumbhakarna = {
+				}
+			}
+			c_tagadur = {
+				color={ 140 65 45 }
+				color2={ 255 255 255 }
+				
+				b_tagadur = {
+				}
+				b_tiruvannamalai = {
+				}
+				b_satyamangalam = {
+				}
+				b_jinji  = {
+				}
+				b_tirukkovalur = {
+				}
+				b_padaividu = {
+				}
+				b_siyyamangalam = {
+				}
+			}
+		}
+		d_pandya_nadu = {
+			color={ 180 80 130 }
+			color2={ 255 255 255 }
+			
+			capital = 1112 # Madurai
+			
+			c_madurai = {
+				color={ 160 80 130 }
+				color2={ 255 255 255 }
+				
+				b_madurai = {
+				}
+				b_srivilliputtur = {
+				}
+				b_ramesvaram = {
+				}
+				b_kilakarai = {
+				}
+				b_ramnadhapuram = {
+				}
+				b_tiruparankunram = {
+				}
+				b_anaimalai = {
+				}
+			}
+			c_tirunelveli = {
+				color={ 180 60 130 }
+				color2={ 255 255 255 }
+				
+				b_tirunelveli = {
+				}
+				b_kayattar = {
+				}
+				b_korkai = {
+				}
+				b_kayal = {
+				}
+				b_kalugumalai = {
+				}
+				b_tiruvalisvaram = {
+				}
+				b_santera = { # Fictional - For Prosperity
+				}
+			}
+			c_kongu = {
+				color={ 180 80 150 }
+				color2={ 255 255 255 }
+				
+				b_karavur = {
+				}
+				b_erode = {
+				}
+				b_perur = {
+				}
+				b_dharapuri = {
+				}
+				b_hemambika = {
+				}
+				b_sendamangalam = {
+				}
+				b_tiruppur = {
+				}
+				b_namakkal = {
+				}
+				b_sankagiri = {
+				}
+			}
+			c_tenkasi = {
+				color={ 180 100 130 }
+				color2={ 255 255 255 }
+				
+				b_tenkasi = {
+				}
+				b_dindigul = {
+				}
+				b_sankaranayinarkovil = {
+				}
+				b_palayamcottai = {
+				}
+				b_tirumalapuram = {
+				}
+				b_aivarmalai = {
+				}
+				b_bandgaon = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_chera_nadu = {
+			color={ 140 75 75 }
+			color2={ 255 255 255 }
+			
+			capital = 1114 # Mahoyadapuram
+			
+			c_mahoyadapuram = {
+				color={ 160 75 75 }
+				color2={ 255 255 255 }
+				
+				holy_site = nestorian # Burial site of St.Thomas
+				
+				b_mahoyadapuram = {
+				}
+				b_udagai = {
+				}
+				b_kaladi = {
+				}
+				b_kunjakari = {
+				}
+				b_tripunittura = {
+				}
+				b_kaviyur = {
+				}
+				b_kadungallur = {
+				}
+			}
+			c_venadu = {
+				color={ 140 55 75 }
+				color2={ 255 255 255 }
+				
+				b_vizhinjam = {
+				}
+				b_kollam = {
+				}
+				b_kanya_kumari = {
+				}
+				b_anantasayanam = {
+				}
+				b_kandalur = {
+				}
+				b_nagercoil = {
+				}
+				b_asaudah = { # Fictional - For Prosperity
+				}
+			}
+			c_qalqut = {
+				color={ 140 75 95 }
+				color2={ 255 255 255 }
+				
+				tamil = Kallikkottai 
+				
+				b_calicut = {
+					tamil = Kallikkottai 
+				}
+				b_nediyiruppu = {
+				}
+				b_kannur = {
+				}
+				b_urakam = {
+				}
+				b_vatakara = {
+				}
+				b_parappanangadi = {
+				}
+				b_chaliyam = {
+				}
+			}
+			c_kanara = {
+				color={ 150 65 65 }
+				color2={ 255 255 255 }
+				
+				b_udayavara = {
+				}
+				b_udupi = {
+				}
+				b_mangalur = {
+				}
+				b_dharmasthala = {
+				}
+				b_kasargod = {
+				}
+				b_kadarika = {
+				}
+				b_aruvankadu = { # Fictional - For Prosperity
+				}
+			}
+			c_maldives = {
+				color={ 120 75 75 }
+				color2={ 255 255 255 }
+				
+				b_mahal = {
+				}
+				b_fuvahmulah = {
+				}
+				b_isdhoo = {
+				}
+				b_salliballu = {
+				}
+				b_dhanbidhoo = {
+				}
+				b_mundoo = {
+				}
+				b_gan = {
+				}
+			}
+		}
+		d_tondai_nadu = {
+			color={ 200 120 120 }
+			color2={ 255 255 255 }
+			
+			capital = 1119 # Kanchipuram
+			
+			c_kanchipuram = {
+				color={ 180 120 120 }
+				color2={ 255 255 255 }
+				
+				b_kanchipuram = {
+				}
+				b_uttaramerur = {
+				}
+				b_mailapur = {
+				}
+				b_rajagiri = {
+				}
+				b_koodalur = {
+				}
+				b_takkaloma = {
+				}
+				b_alampuravi = {
+				}
+			}
+			c_potapi = {
+				color={ 200 120 140 }
+				color2={ 255 255 255 }
+				
+				b_potapi = {
+				}
+				b_kaveripattinam = {
+				}
+				b_tirupati = {
+				}
+				b_melpadi = {
+				}
+				b_virincipuram = {
+				}
+				b_chaura = { # Fictional - For Prosperity
+				}
+				b_mando = { # Fictional - For Prosperity
+				}
+			}
+		}
+	}
+	k_andhra = {
+		color={ 110 0 20 }
+		color2={ 220 220 20 }
+	
+		capital = 1122 # Udayagiri
+		
+		d_vengi = {
+			color={ 190 40 60 }
+			color2={ 255 255 255 }
+			
+			capital = 1221 # Vijayawada
+			
+			c_vengipura = {
+				color={ 190 60 60 }
+				color2={ 255 255 255 }
+				
+				b_vengipura = {
+				}
+				b_eluru = {
+				}
+				b_dwarakatirumala = {
+				}
+				b_kondapalli = {
+				}
+				b_palakollu = {
+				}
+				b_bandarulanka = {
+				}
+				b_narasapuram = {
+				}
+			}
+			c_vijayawada = {
+				color={ 190 40 40 }
+				color2={ 255 255 255 }
+				
+				b_vijayawada = {
+				}
+				b_kondavidu = {
+				}
+				b_chebrolu = {
+				}
+				b_masula = {
+				}
+				b_guntur = {
+				}
+				b_peddapalli = {
+				}
+				b_monvel = { # Fictional - For Prosperity
+				}
+			}
+			c_pithapuram = {
+				color={ 210 40 60 }
+				color2={ 255 255 255 }
+				
+				b_pithapuram = {
+				}
+				b_mandapeta = {
+				}
+				b_draksharama = {
+				}
+				b_somarama = {
+				}
+				b_samalkota = {
+				}
+				b_kakinada = {
+				}
+				b_wardha = { # Fictional - For Prosperity
+				}
+			}
+			c_rajamahendravaram = {
+				color={ 190 20 55 }
+				color2={ 255 255 255 }
+				
+				b_rajamahendravaram = {
+				}
+				b_kuwakonda = {
+				}
+				b_kirandul = {
+				}
+				b_pattiseema = {
+				}
+				b_getalsud = { # Fictional - For Prosperity
+				}
+				b_hemagiri = { # Fictional - For Prosperity
+				}
+				b_pathyar = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_udayagiri = {
+			color={ 197 20 90 }
+			color2={ 255 255 255 }
+			
+			capital = 1122 # Udayagiri
+			
+			c_udayagiri = {
+				color={ 197 40 90 }
+				color2={ 255 255 255 }
+				
+				b_udayagiri = {
+				}
+				b_srisailam = {
+				}
+				b_vallurapura = {
+				}
+				b_nandyal = {
+				}
+				b_sriparvata = {
+				}
+				b_gandikota = {
+				}
+				b_mahanandi = {
+				}
+				b_kanipakam = {
+				}
+			}
+			c_amaravati = {
+				color={ 197 20 70 }
+				color2={ 255 255 255 }
+				
+				b_amaravati = {
+				}
+				b_vinukonda = {
+				}
+				b_dhanyakataka = {
+				}
+				b_macherla = {
+				}
+				b_gurazala = {
+				}
+				b_kotappakonda = {
+				}
+				b_ahobalam = {
+				}
+			}
+			c_penugonda = {
+				color={ 177 20 90 }
+				color2={ 255 255 255 }
+				
+				b_penugonda = {
+				}
+				b_suragiri = {
+				}
+				b_anantapur = {
+				}
+				b_togarakunta = {
+				}
+				b_gurramkonda = {
+				}
+				b_rayadurgam = {
+				}
+				b_uravakonda = {
+				}
+				b_lepakshi = {
+				}
+			}
+			c_nellore = {
+				color={ 197 20 110 }
+				color2={ 255 255 255 }
+				
+				b_nellore = {
+				}
+				b_kalahasti = {
+				}
+				b_kandukura = {
+				}
+				b_addanki = {
+				}
+				b_tripurantakam = {
+				}
+				b_gundigapuri = {
+				}
+				b_mutapali = {
+				}
+			}
+		}
+	}
+	k_telingana = {
+		color={ 195 50 55 }
+		color2={ 220 220 0 }
+	
+		capital	= 1256 # Orangallu
+		
+		d_warangal = {
+			color={ 185 39 45 }
+			color2={ 255 255 255 }
+			
+			capital = 1256 # Orangallu
+			
+			c_orangallu = {
+				color={ 185 59 45 }
+				color2={ 255 255 255 }
+				
+				b_warangal = {
+				}
+				b_palampet = {
+				}
+				b_kothakonda = {
+				}
+				b_anumakonda = {
+				}
+				b_ghanpur = {
+				}
+				b_molangoor = {
+				}
+				b_bhadrakali = {
+				}
+			}
+			c_kambampet = {
+				color={ 185 39 65 }
+				color2={ 255 255 255 }
+				
+				b_kambampet = {
+				}
+				b_bhadrachalam = {
+				}
+				b_nelakondapalli = {
+				}
+				b_penuballi = {
+				}
+				b_suryapet = {
+				}
+				b_madupalli = {
+				}
+				b_shahpura = {
+				}
+			}
+			c_vemulavada = {
+				color={ 165 39 45 }
+				color2={ 255 255 255 }
+				
+				b_vemulavada = {
+				}
+				b_kaulas = {
+				}
+				b_kaleshwaram = {
+				}
+				b_indur = {
+				}
+				b_potali = {
+				}
+				b_konni = { # Fictional - For Prosperity
+				}
+				b_balijipeta = { # Fictional - For Prosperity
+				}
+			}
+			c_balkonda = {
+				color={ 205 39 45 }
+				color2={ 255 255 255 }
+				
+				b_balkonda = {
+				}
+				b_mahur = {
+				}
+				b_basara = {
+				}
+				b_nirmal = {
+				}
+				b_manikdurg = {
+				}
+				b_dharmapuri = {
+				}
+				b_khairaput = { # Fictional - For Prosperity
+				}
+			}
+		}
+		d_racakonda = {
+			color={ 130 0 20 }
+			color2={ 255 255 255 }
+			
+			capital = 1209 # Racakonda
+			
+			c_racakonda = {
+				color={ 130 20 20 }
+				color2={ 255 255 255 }
+				
+				b_racakonda = {
+				}
+				b_bhuvanagiri = {
+				}
+				b_manchal = {
+				}
+				b_yadagirigutta = {
+				}
+				b_sobhapur = { # Fictional - For Prosperity
+				}
+				b_mara = { # Fictional - For Prosperity
+				}
+				b_manpura = { # Fictional - For Prosperity
+				}
+			}
+			c_nilagiri = {
+				color={ 130 0 40 }
+				color2={ 255 255 255 }
+				
+				b_nilagiri = {
+				}
+				b_avulagadda = {
+				}
+				b_panagallu = {
+				}
+				b_maheshwaram = {
+				}
+				b_devarakonda = {
+				}
+				b_vadapally = {
+				}
+				b_zuchhip = { # Fictional - For Prosperity
+				}
+			}
+			c_pannagallu = {
+				color={ 110 0 20 }
+				color2={ 255 255 255 }
+				
+				b_pannagallu = {
+				}
+				b_nagarkurnool = {
+				}
+				b_charakonda = {
+				}
+				b_mutudugu = {
+				}
+				b_kunda = { # Fictional - For Prosperity
+				}
+				b_malikpur = { # Fictional - For Prosperity
+				}
+				b_bodla = { # Fictional - For Prosperity
+				}
+			}
+			c_medak = {
+				color={ 150 0 20 }
+				color2={ 255 255 255 }
+				
+				b_medak = {
+				}
+				b_domakonda = {
+				}
+				b_kohir = {
+				}
+				b_mardi = {
+				}
+				b_ananthagiri = {
+				}
+				b_baramgala = { # Fictional - For Prosperity
+				}
+				b_chikalthana = { # Fictional - For Prosperity
+				}
+			}
+			c_kollipake = {
+				color={ 130 20 0 }
+				color2={ 255 255 255 }
+				
+				b_kollipake = {
+				}
+				b_karmanghat = {
+				}
+				b_golkonda = {
+				}
+				b_chilkur_balaji = {
+				}
+				b_devaryamjal = {
+				}
+				b_ratia = { # Fictional - For Prosperity
+				}
+				b_pahla = { # Fictional - For Prosperity
+				}
+			}
+		}
+	}
+	k_lanka = {
+		color = { 221 187 80 }
+		color2={ 255 255 255 }
+	
+		capital = 1215 # Dakhina Desa
+		
+		d_lanka = {
+			color = { 231 195 85 }
+			color2={ 255 255 255 }
+			
+			capital = 1215 # Dakhina Desa
+			
+			c_dakhina_desa = {
+				color = { 231 175 85 }
+				color2={ 255 255 255 }
+				
+				b_vapinagara = {
+				}
+				b_samantakuta = {
+				}
+				b_kalyani2 = {
+				}
+				b_mahiyangana = {
+				}
+				b_jambudoni = {
+				}
+				b_hatthigiripura = {
+				}
+				b_kotte = {
+				}
+				b_rayigama = {
+				}
+			}
+			c_rohana = {
+				color = { 231 195 105 }
+				color2={ 255 255 255 }
+				
+				b_rohana = {
+				}
+				b_mahagama = {
+				}
+				b_dighavapi = {
+				}
+				b_mahanagakula = {
+				}
+				b_devanagara = {
+				}
+				b_gampala = {
+				}
+				b_kajaragama = {
+				}
+				b_buduruvagala = {
+				}
+			}
+		}
+		d_sinhala = {
+			color = { 181 155 55 }
+			color2={ 255 255 255 }
+			
+			capital = 1195 # Pihiti
+			
+			c_phiti = { # Pihiti
+				color = { 181 135 55 }
+				color2={ 255 255 255 }
+				
+				b_anuradhapura = {
+				}
+				b_atamasthana = {
+				}
+				b_mahatittha = {
+				}
+				b_punkhagama = {
+				}
+				b_mihintale = {
+				}
+				b_mannara = {
+				}
+				b_subhagiri = {
+				}
+			}
+			c_nagadipa = {
+				color = { 181 155 75 }
+				color2={ 255 255 255 }
+				
+				b_sukaratittha = {
+				}
+				b_yapapatuna = {
+				}
+				b_vallipuram = {
+				}
+				b_nallur = {
+				}
+				b_nainativu = {
+				}
+				b_manertha = { # Fictional - For Prosperity
+				}
+				b_agia = { # Fictional - For Prosperity
+				}
+			}
+			c_kotthasara = {
+				color = { 161 155 55 }
+				color2={ 255 255 255 }
+				
+				b_pulatthinagara = {
+				}
+				b_gokanna = {
+				}
+				b_sigiriya = {
+				}
+				b_vatagiri = {
+				}
+				b_trincomalee = {
+				}
+				b_girikandaka = {
+				}
+				b_madakalapuva = {
+				}
+			}
+		}
+	}
+}
+
+e_tibet = {
+  color={ 250 40 0 }
+  color2= { 255 255 255 }
+
+	capital = 1498 # Lhasa
+	
+	#bodpa = "Bodchenpo"
+	han = "Tubo"
+
+	k_yarlung = {
+		color={ 209 52 80 }
+		color2= { 255 255 255 }
+
+		capital = 1496 # Taktse
+
+		culture = bodpa
+		
+		han = "Tubo"
+
+		d_lhasa = { # A.k.a "Ü-Tsang"
+			color={ 225 75 0 }
+			color2= { 255 255 255 }
+
+			capital = 1498 # Lhasa
+			
+			dignity = 5
+			
+			bodpa = "Lhasa"
+			han = "Lasa"
+
+			c_lhasa = {
+				color={ 170 10 0 }
+				color2= { 255 255 255 }
+					
+				holy_site = bon
+				holy_site = bon_reformed
+				holy_site = taoist 
+				
+				han = "Lasa"
+
+				b_lhasa = {
+					han = "Lasa"
+				}
+				b_marpori = { #castle (built by Songtsen Gampo in 637, foundations for later Palace)
+					han = "Budala"
+				}
+				b_jokhang = { #temple (in Lhasa)
+					han = "Dazhao"
+				}
+				b_ramoche = { #temple (in Lhasa)
+					han = "Xiaozhao"
+				}
+				b_barkhor = {
+					han = "Bakuo"
+				}
+				b_donggar = {
+					han = "Dongga"
+				}
+				b_naiqung = {
+					han = "Naiqiong"
+				}
+			}
+			c_lhunzhub = {
+				color={ 175 15 5 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Lhünzhub"
+				han = "Linzhou"
+					
+				b_lhunzhub = {
+					bodpa = "Lhünzhub"
+					han = "Linzhou"
+				}
+				b_reting = { #temple
+				}
+				b_codoi = {
+					han = "Chundui"
+				}
+				b_karze = {
+					han = "Kazi"
+				}
+				b_ngarnang = {
+					han = "Alang"
+				}
+				b_poindo = {
+					han = "Pangduo"
+				}
+				b_sumcheng = {
+					bodpa = "Sumchêng"
+					han = "Songpan"
+				}
+			}
+			c_kunggar = {
+				color={ 180 20 10 }
+				color2= { 255 255 255 }
+				
+				han = "Gongka"
+					
+				b_kunggar = {
+					han = "Gongka"
+				}
+				b_gyama = {
+					han = "Jiama"
+				}
+				b_drigung = { #temple
+					han = "Zhigong"
+				}
+				b_zaxoi = {
+					han = "Zhaxue"
+				}
+				b_mamba = {
+					han = "Menba"
+				}
+				b_tanggya = {
+					han = "Tangjia"
+				}
+				b_nyimajangra = {
+					han = "Nimajiangre"
+				}
+			}
+		}
+		d_yarlung = {
+			color={ 209 52 40 }
+			color2= { 255 255 255 }
+
+			capital = 1496 # Taktse
+			
+			han = "Yalu"
+			
+			c_taktse = {
+				color={ 191 13 0 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Taktsé"
+				han = "Dazi"
+
+				b_taktse = {
+					bodpa = "Taktsé"
+					han = "Dazi"
+				}
+				b_qonggyai = {
+					bodpa = "Chonggyé"
+					han = "Qiongjie"
+				}
+				b_qoi = {
+					han = "Qugou"
+				}
+				b_comai = {
+					han = "Cuomei"
+				}
+				b_zhegu = {
+				}
+				b_layu = {
+				}
+				b_kazhu = {
+				}
+			}
+			c_lhunze = {
+				color={ 197 17 7 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Lhünzê"
+				han = "Longzi"
+
+				b_lhunze = {
+					bodpa = "Lhünzê"
+					han = "Longzi"
+				}
+				b_yumai = {
+					bodpa = "Yümai"
+				}
+				b_sangngagqoiling = {
+					han = "San'anqulin"
+				}
+				b_cona_b = {
+					han = "Cuona"
+				}
+				b_ritang = {
+				}
+				b_zhunba = {
+				}
+				b_nariyong = {
+					han = "Nariyang"
+				}
+			}
+			c_nedong = {
+				color={ 171 23 0 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Nêdong"
+				han = "Naidong"
+
+				b_yungbulakang = {
+					han = "Yongbulangong"
+				}
+				b_zetang = {
+					bodpa = "Zêtang"
+					han = "Zedang"
+				}
+				b_tradruk = { #temple
+					han = "Changzhu"
+				}
+				b_nedong = {
+					bodpa = "Nêdong"
+					han = "Naidong"
+				}
+				b_phagmodru = {
+					han = "Pamuzhu"
+				}
+				b_sangri = {
+				}
+				b_zengqi = {
+				}
+			}
+		}
+		d_shigatse = {
+			color={ 215 25 70 }
+			color2= { 255 255 255 }
+
+			capital = 1499 # Shigatse
+			
+			bodpa = "Xigazê"
+			han = "Rikaze"
+			
+			c_shigatse = {
+				color={ 195 63 0 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Xigazê"
+				han = "Rikaze"
+
+				b_shigatse = {
+					bodpa = "Xigazê"
+					han = "Rikaze"
+				}
+				b_namling = {
+					han = "Nanmulin"
+				}
+				b_tashilhunpo = { #temple
+					bodpa = "Tashi Lhünpo"
+					han = "Zhashi Lunbu"
+				}
+				b_shalu = { #temple
+					han = "Xialu"
+				}
+				b_samzhubze = {
+					bodpa = "Samzhubzê"
+					han = "Sangzhuzi"
+				}
+				b_yungdrungling = { #temple
+					han = "Yongshunling"
+				}
+				b_gongon_lhakhang = { #temple
+					han = "Longgong Lakang"
+				}
+			}
+			c_lhatse = {
+				color={ 195 73 30 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Lhazê"
+				han = "Lazi"
+
+				b_lhatse = {
+					bodpa = "Lhazê"
+					han = "Lazi"
+				}
+				b_deleg = {
+					bodpa = "Dêlêg"
+					han = "Delei"
+				}
+				b_drampagyang = { #temple
+					han = "Dalanba Geyang"
+				}
+				b_gyangbumoche = { #temple
+					han = "Geyang Bumoqi"
+				}
+				b_kagar = {
+					han = "Kege"
+				}
+				b_quxar = {
+					han = "Quxia"
+				}
+				b_puncogling = {
+					bodpa = "Püncogling"
+					han = "Pengcuolin"
+				}
+			}
+			c_gyantse = {
+				color={ 215 35 0 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Gyangzê"
+				han = "Jiangze"
+
+				b_gyantse = {
+					bodpa = "Gyangzê"
+					han = "Jiangze"
+				}
+				b_palcho = { #temple
+				}
+				b_bainang = {
+					han = "Bailang"
+				}
+				b_kangmar = {
+					han = "Kangma"
+				}
+				b_rinbung = {
+					han = "Renbu"
+				}
+				b_yatung = {
+					han = "Yadong"
+				}
+				b_karmai = {
+					han = "Kamai"
+				}
+			}
+			c_sakya = {
+				color={ 170 140 0 }
+				color2= { 255 255 255 }
+				
+				#bodpa = "Sa'gya"
+				han = "Sajia"
+
+				b_sakya = {
+					bodpa = "Sa'gya"
+					han = "Sajia"
+				}
+				b_pelsakya = { #temple
+					bodpa = "Pel Sa'gya"
+					han = "Sajiasi"
+				}
+				b_geding = {
+					bodpa = "Gêding"
+					han = "Jiding"
+				}
+				b_dinggye = {
+					bodpa = "Dinggyê"
+					han = "Dingjie"
+				}
+				b_zhentang = {
+					bodpa = "Zhêntang"
+					han = "Chentang"
+				}
+				b_gamba = {
+					han = "Gangba"
+				}
+				b_lungrong = {
+					han = "Longzhong"
+				}
+			}
+			c_mangyul = {
+				color={ 150 100 0 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Mangyül"
+				han = "Mangyu"
+				nepali = "Keruna"
+
+				b_dzongka = {
+					han = "Zongga"
+				}
+				b_gyirong = {
+					han = "Jilong"
+					nepali = "Keruna"
+				}
+				b_tingri = { #temple
+					han = "Dingri"
+				}
+				b_shelkar = { #temple
+					han = "Xiegeer"
+				}
+				b_nyalam = {
+					han = "Nielamu"
+					nepali = "Kuti"
+				}
+				b_dram = {
+					han = "Zhangmu"
+					nepali = "Khasa"
+				}
+				b_gyagya = {
+					bodpa = "Gya'gya"
+					han = "Saga"
+				}
+			}
+			c_gyesar = {
+				color={ 180 150 0 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Gyêsar"
+				han = "Jiesa"
+				
+				b_gyesar = {
+					bodpa = "Gyêsar"
+					han = "Jiesa"
+				}
+				b_karongshar = {
+					han = "Garongxia"
+				}
+				b_semola = {
+					han = "Sangmula"
+				}
+				b_khongtog = {
+					han = "Gongduo"
+				}
+				b_jyangling = {
+					han = "Jiangnong"
+				}
+				b_trengsham = {
+					han = "Chengxiang"
+				}
+				b_pashul = {
+					han = "Bashu"
+				}
+			}
+		}
+		d_nagchu = {
+			color={ 206 107 125 }
+			color2= { 255 255 255 }
+
+			capital = 1351 # Nagchu
+			
+			han = "Naqu"
+			
+			culture = sumpa
+
+			c_nagchu = {
+				color={ 165 136 3 }
+				color2= { 255 255 255 }
+				
+				han = "Naqu"
+
+				b_nagchu = {
+					han = "Naqu"
+				}
+				b_lhomar = {
+					han = "Luoma"
+				}
+				b_namra = {
+					han = "Namaqie"
+				}
+				b_golug = {
+					han = "Gulu"
+				}
+				b_khormang = {
+					han = "Kongma"
+				}
+				b_daqen = {
+					bodpa = "Daqên"
+					han = "Daqian"
+				}
+				b_yochak = {
+					bodpa = "Yöchak"
+					han = "Youqia"
+				}
+			}
+			c_xainza = {
+				color={ 140 132 2 }
+				color2= { 255 255 255 }
+				
+				han = "Shenzha"
+
+				b_xainza = {
+					han = "Shenzha"
+				}
+				b_baingoin = {
+					han = "Bange"
+				}
+				b_siling = {
+					bodpa = "Sêling"
+					han = "Selin"
+				}
+				b_maryo = {
+					bodpa = "Mar'yo"
+					han = "Mayue"
+				}
+				b_zhago = {
+					han = "Xiaguo"
+				}
+				b_pukpa = {
+					han = "Pubao"
+				}
+				b_jakhyung = {
+					han = "Jiaqiong"
+				}
+			}
+			c_nyima = {
+				color={ 155 100 0 }
+				color2= { 255 255 255 }
+				
+				han = "Nima"
+
+				b_nyima = {
+					han = "Nima"
+				}
+				b_chugtsodropo = {
+					han = "Chugecuoruobo"
+				}
+				b_khyungdzong = {
+					han = "Qiongzhuang"
+				}
+				b_jiwa = {
+				}
+				b_tanglai = {
+				}
+				b_jialong = {
+				}
+				b_laiduo = {
+				}
+			}
+		}
+		d_sumparu = {
+			color={ 230 40 0 }
+			color2= { 255 255 255 }
+
+			capital = 1558 # Amdo
+			
+			culture = sumpa
+			
+			han = "Supi"
+			mongol = "Hoh Xil"
+
+			c_samtho = {
+				color={ 190 140 0 }
+				color2= { 255 255 255 }
+
+				han = "Sunpo"
+				mongol = "Hoh Xil"
+
+				b_rolagang = {
+					han = "Ruolagang"
+				}
+				b_tsoring = {
+					han = "Cuoren"
+				}
+				b_zholhun = {
+					bodpa = "Zhölhün"
+					han = "Xuehuan"
+				}
+				b_drangtsen = {
+					han = "Changgeng"
+				}
+				b_yungpo = {
+					han = "Yongbu"
+				}
+				b_traoyang = {
+					han = "Chaoyang"
+				}
+				b_yulpun = {
+					bodpa = "Yülpün"
+					han = "Yupan"
+				}
+			}
+			c_qangtang = {
+				color={ 192 132 11 }
+				color2= { 255 255 255 }
+
+				han = "Changtang"
+				
+				b_bairab = {
+					han = "Baire"
+				}
+				b_burog = {
+					han = "Buruo"
+				}
+				b_margai = {
+					han = "Ma'ergai"
+				}
+				b_yurba = {
+					han = "Yuereba"
+				}
+				b_satso = {
+					bodpa = "Satsö"
+					han = "Sacuo"
+				}
+				b_zhoyon = {
+					bodpa = "Zhöyon"
+					han = "Xueyuan"
+				}
+				b_laxong = {
+					han = "Laxiong"
+				}
+			}
+			c_arjin = {
+				color={ 190 140 22 }
+				color2= { 255 255 255 }
+
+				han = "A'erjin"
+				uyghur = "Altyn"
+				mongol = "Altun"
+				
+				b_arjin = {
+					han = "Baire"
+					uyghur = "Altyn"
+					mongol = "Altun"
+				}
+				b_yitun = {
+				}
+				b_kumkol = {
+					han = "Kumukuli"
+					mongol = "Kum Köl"
+				}
+				b_ayakkum = {
+					han = "Ayakekumu"
+				}
+				b_aqqikkol = {
+					han = "Aqikekule"
+				}
+				b_muztagh = {
+					han = "Muzitage"
+				}
+				b_zhotsen = {
+					bodpa = "Zhötsen"
+					han = "Xuejing"
+				}
+			}
+			c_amdo = {
+				color={ 190 120 11 }
+				color2= { 255 255 255 }
+				
+				han = "Anduo"
+
+				b_amdo = {
+					han = "Anduo"
+				}
+				b_cona = { #temple
+					han = "Cuona"
+				}
+				b_zaring = {
+					han = "Zharen"
+				}
+				b_qangma = {
+					han = "Qiangma"
+				}
+				b_sewa = {
+					bodpa = "Sêwa"
+					han = "Sewu"
+				}
+				b_gangnyi = {
+					han = "Gangni"
+				}
+				b_nyainrong = {
+					han = "Nierong"
+				}
+			}
+		}
+		d_bhutan = {
+			color={ 200 60 10 }
+			color2= { 255 255 255 }
+
+			capital = 1482 # Bumthang
+			
+			han = "Budan"
+
+			c_bumthang = {
+				color={ 160 70 20 }
+				color2= { 255 255 255 }
+				
+				han = "Bumutang"
+
+				b_bumthang = {
+					han = "Bumutang"
+				}
+				b_jambay = { #temple
+				}
+				b_kongchogsum = { #temple
+				}
+				b_trongsa = {
+				}
+				b_singye = {
+				}
+				b_trashigang = {
+				}
+				b_zugne = { #temple
+				}
+			}
+			c_paro = {
+				color={ 220 62 12 }
+				color2= { 255 255 255 }
+
+				b_paro = {
+				}
+				b_kyichu = { #temple
+				}
+				b_taktshang = { #temple
+				}
+				b_hungrel = {
+				}
+				b_damthang = {
+				}
+				b_tshalunang = {
+				}
+				b_gasa = {
+				}
+			}
+		}
+	}
+	k_guge = {
+		color={ 137 168 188 }
+		color2= { 255 255 255 }
+
+		capital = 1486 # Tsaparang
+		
+		zhangzhung = "Zhangzhung"
+		han = "Xiangxiong"
+		
+		culture = zhangzhung
+
+		d_purang = {
+			color={ 67 130 219 }
+			color2= { 255 255 255 }
+
+			capital = 1491 # Purang
+			
+			zhangzhung = "Zhangzhung"
+
+			c_tsaparang = {
+				color={ 85 155 200 }
+				color2= { 255 255 255 }
+
+				b_tsaparang = {
+				}
+				b_tholing = {
+					bodpa = "Thöling"
+					han = "Tuolin"
+				}
+				b_tholinggompa = { #temple
+					bodpa = "Thöling Gompa"
+					han = "Tuolinsi"
+				}
+				b_mangga = {
+					han = "Menge"
+				}
+				b_boyi = {
+				}
+				b_mangnang = { #temple
+					han = "Mengong"
+				}
+				b_gartok = {
+					han = "Gaiteke"
+				}
+			}
+			c_kyunglung = {
+				color={ 102 132 206 }
+				color2= { 255 255 255 }
+				
+				han = "Qulong"
+
+				b_kyunglung = {
+					han = "Qulong"
+				}
+				b_gurugem = { #temple
+					han = "Gurujia"
+				}
+				b_monicer = {
+					bodpa = "Moincêr"
+					han = "Menshi"
+				}
+				b_tirthapuri = { #temple
+					han = "Deretabore"
+				}
+				b_dolchu = { #temple
+					bodpa = "Dölchu"
+					han = "Duolaqiu"
+				}
+				b_xalazakung = {
+					han = "Xialazigong"
+				}
+				b_gyanyima = {
+					han = "Ge'annima"
+				}
+			}
+			c_purang = {
+				color={ 96 149 216 }
+				color2= { 255 255 255 }
+				
+				# Mount Kailash
+				holy_site = hindu
+				holy_site = jain
+				holy_site = bon
+				holy_site = bon_reformed
+				
+				han = "Pulan"
+				nepali = "Taklakot"
+				zhangzhung = "Puhrang"
+
+				b_purang = {
+					han = "Pulan"
+					nepali = "Taklakot"
+					zhangzhung = "Puhrang"
+				}
+				b_kailash = { # Holy Site
+					han = "Kailashen"
+					zhangzhung = "Titsé"
+					hindustani = "Kailasa"
+				}
+				b_teglakar = {
+					han = "Degelaka"
+				}
+				b_simbiling= { #temple
+					han = "Xangboling"
+					zhangzhung = "Tsegu"
+				}
+				b_khorzhak = { #temple
+					han = "Kejia"
+					hindustani = "Kojanath"
+				}
+				b_zhangja = {
+					han = "Shengjie"
+				}
+				b_dulung = {
+					han = "Duolong"
+				}
+			}
+			c_gegyai = {
+				color={ 72 168 216 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Gê'gyai"
+				han = "Geji"
+				
+				b_gegyai = {
+					bodpa = "Gê'gyai"
+					han = "Geji"
+				}
+				b_zhungpa = {
+					han = "Xiongba"
+				}
+				b_yakra = {
+					han = "Yare"
+				}
+				b_chuktsang = {
+					han = "Quezang"
+				}
+				b_arkog = {
+					han = "Aguo"
+				}
+				b_kelle = {
+					han = "Kele"
+				}
+				b_sekhadrig = {
+					han = "Sekazhi"
+				}
+			}
+			c_zhongba = {
+				color={ 106 107 165 }
+				color2= { 255 255 255 }
+
+				b_labrang = {
+					han = "Larang"
+				}
+				b_paryang = {
+					han = "Payang"
+				}
+				b_gela_b = {
+					bodpa = "Gêla"
+					han = "Jila"
+				}
+				b_lunggar = {
+					han = "Longgaer"
+				}
+				b_barma = {
+					han = "Pama"
+				}
+				b_ringtor = {
+					han = "Renduo"
+				}
+				b_yagra = {
+					han = "Yare"
+				}
+			}
+		}
+		d_ngari = {
+			color={ 144 152 206 }
+			color2= { 255 255 255 }
+
+			capital = 1487 # Gar
+			
+			han = "Ali"
+
+			c_gar = {
+				color={ 154 152 190 }
+				color2= { 255 255 255 }
+				
+				han = "Ga'er"
+
+				b_gar = {
+					han = "Ga'er"
+				}
+				b_senggezangbo = {
+					bodpa = "Sênggêzangbo"
+					han = "Shiquanhe"
+				}
+				b_kunsa = {
+				}
+				b_rabang = {
+					han = "Rebang"
+				}
+				b_kupa = {
+					han = "Guoba"
+				}
+				b_chakgang = {
+					han = "Jiagang"
+				}
+				b_langchu = {
+					han = "Langjiu"
+				}
+			}
+			c_coqen = {
+				color={ 134 142 206 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Coqên"
+				han = "Cuoqin"
+
+				b_coqen = {
+					bodpa = "Coqên"
+					han = "Cuoqin"
+				}
+				b_zhuglung = {
+					han = "Zhulong"
+				}
+				b_dawaxung = {
+					han = "Daxiong"
+				}
+				b_maindong = {
+					han = "Mandong"
+				}
+				b_gyangrang = {
+					han = "Jiangrang"
+				}
+				b_asog = {
+					han = "Asuo"
+				}
+				b_tarungha = {
+					han = "Teronghai"
+				}
+			}
+			c_tsakha = {
+				color={ 149 159 219 }
+				color2= { 255 255 255 }
+				
+				han = "Caka"
+				
+				b_tsakha = {
+					han = "Caka"
+				}
+				b_sharma = {
+					han = "Xiama"
+				}
+				b_nyer = {
+					bodpa = "Nyêr"
+					han = "Nier"
+				}
+				b_rungra = {
+					han = "Rongre"
+				}
+				b_gacha = {
+				}
+				b_ombulung = {
+					han = "Wumulong"
+				}
+				b_perotse = {
+					han = "Bieruoze"
+				}
+			}
+			c_gerze = {
+				color={ 124 142 216 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Gêrzê"
+				han = "Gaize"
+
+				b_gerze = {
+					bodpa = "Gêrzê"
+					han = "Gaize"
+				}
+				b_gotsang = {
+					han = "Guchang"
+				}
+				b_tongtso = {
+					han = "Dongcuo"
+				}
+				b_langkor = {
+					han = "Laguo"
+				}
+				b_nangangonna = {
+					bodpa = "Nanga Ngönna"
+					han = "Nakawona"
+				}
+				b_jakar_b = {
+					han = "Xiaga"
+				}
+				b_rimar = {
+					han = "Rima"
+				}
+			}
+			c_rutog = {
+				color= { 164 152 206 }
+				color2= { 255 255 255 }
+				
+				han = "Ritu"
+
+				b_rutog = {
+					han = "Ritu"
+				}
+				b_rawang_rutog = { #temple
+					han = "Ranwang Ritu"
+				}
+				b_derok = {
+					han = "Derucun"
+				}
+				b_gobak = {
+					han = "Guobaka"
+				}
+				b_sumshi = {
+					han = "Songxi"
+				}
+				b_tsapuk = {
+					han = "Zhapu"
+				}
+				b_domar = {
+					han = "Duoma"
+				}
+			}
+			c_kunlun = {
+				color={ 134 142 180 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Kulung"
+				mongol = "Khöndlön"
+
+				b_bangdag = {
+					han = "Bangda"
+				}
+				b_ashi = {
+					mongol = "Achik"
+					uyghur = "Achik"
+				}
+				b_ulug = {
+					han = "Wulu"
+				}
+				b_pur = {
+					han = "Pu'er"
+				}
+				b_yulya = {
+					han = "Yueya"
+				}
+				b_dulihri = {
+					han = "Dulishi"
+				}
+				b_seldang = {
+					han = "Qingche"
+				}
+			}
+		}
+		d_ladakh = {
+			color= { 63 113 158 }
+			color2= { 255 255 255 }
+
+			capital = 1468 # Leh
+			
+			bodpa = "Maryul"
+			han = "Ladake"
+
+			c_leh = {
+				color= { 73 113 168 }
+				color2= { 255 255 255 }
+				
+				han = "Lie"
+
+				b_leh = {
+					han = "Lie"
+				}
+				b_keylong = {
+				}
+				b_gya = {
+				}
+				b_shey = { #temple
+				}
+				b_thiksey = {
+				}
+				b_chuchot_yakma = {
+				}
+				b_chumathang = {
+				}
+			}
+			c_diskit = {
+				color= { 43 113 158 }
+				color2= { 255 255 255 }
+				
+				han = "Disikete"
+
+				b_diskit = {
+					han = "Disikete"
+				}
+				b_thirit = {
+				}
+				b_hundar = {
+				}
+				b_thoise = {
+				}
+				b_charassa = {
+				}
+				b_panamik = {
+				}
+				b_unmaru = {
+				}
+			}
+			c_pangong = {
+				color= { 63 113 138 }
+				color2= { 255 255 255 }
+				
+				han = "Bangong"
+
+				b_pangong = {
+					han = "Bangong"
+				}
+				b_khumak = {
+				}
+				b_spanggur = {
+				}
+				b_kizilyeza = {
+				}
+				b_aksayqin = {
+				}
+				b_sumdo = {
+				}
+				b_surigh = {
+				}
+			}
+		}
+	}
+	
+	k_kham = {
+		color={ 150 10 0 }
+		color2= { 255 255 255 }
+
+		capital = 1508 # Qamdo
+		
+		han = "Kang"
+
+		d_dege = {
+			color={ 150 20 11 }
+			color2= { 255 255 255 }
+
+			capital = 1506 # Dege
+			
+			bodpa = "Dêgê"
+
+			c_dege = {
+				color={ 151 11 0 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Dêgê"
+
+				b_dege = {
+					bodpa = "Dêgê"
+				}
+				b_dzongsar = { #temple
+				}
+				b_palpung = { #temple
+				}
+				b_dama = {
+				}
+				b_baiya = {
+				}
+				b_babang = {
+				}
+				b_gongya = {
+				}
+			}
+			c_lhatok = {
+				color={ 140 20 20 }
+				color2= { 255 255 255 }
+				
+				han = "Laduo"
+				
+				b_lhatok = {
+					han = "Laduo"
+				}
+				b_gonjo = {
+					han = "Gonjue"
+				}
+				b_bolo = {
+				}
+				b_zeba = {
+					bodpa = "Zêba"
+				}
+				b_bumgye = {
+					bodpa = "Bumgyê"
+					han = "Benxie"
+				}
+				b_zhagyab = {
+					bodpa = "Zhag'yab"
+					han = "Chaya"
+				}
+				b_korra = {
+				}
+			}
+			c_markam = {
+				color={ 110 20 0 }
+				color2= { 255 255 255 }
+				
+				han = "Mangkang"
+
+				b_markam = {
+					han = "Mangkang"
+				}
+				b_mangling = {
+				}
+				b_cuowa = {
+				}
+				b_qudeng = {
+				}
+				b_zogong = {
+					bodpa = "Drorkong"
+					han = "Zuogong"
+				}
+				b_wangda = {
+				}
+				b_zhonglin = {
+				}
+			}
+		}	
+		d_qamdo = {
+			color={ 160 30 0 }
+			color2= { 255 255 255 }
+
+			capital = 1508 # Qamdo
+			
+			han = "Changdu"
+
+			c_qamdo = {
+				color={ 140 9 29 }
+				color2= { 255 255 255 }
+				
+				han = "Changdu"
+
+				b_qamdo = {
+					han = "Chengguan"
+				}
+				b_riwoche = { #temple
+					bodpa = "Riwoqê"
+					han = "Leiwuqi"
+				}
+				b_karub = {
+					bodpa = "Kharro"
+					han = "Karuo"
+				}
+				b_guro = {
+					han = "Eluo"
+				}
+				b_retong = {
+					han = "Ritong"
+				}
+				b_karma = {
+					han = "Gama"
+				}
+				b_asangka = {
+				}
+			}
+			c_bome = {
+				color={ 160 50 0 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Bomê"
+				han = "Bomi"
+
+				b_bome = {
+					bodpa = "Bomê"
+					han = "Bomi"
+				}
+				b_zhamo = {
+					han = "Zhamu"
+				}
+				b_alamdo = {
+				}
+				b_yupu = {
+				}
+				b_naha = {
+				}
+				b_cizula = {
+				}
+				b_yiong = {
+					bodpa = "Yi'ong"
+					han = "Yihong"
+				}
+			}
+			c_banbar = {
+				color={ 120 0 44 }
+				color2= { 255 255 255 }
+				
+				han = "Bianba"
+
+				b_banbar = {
+					han = "Bianba"
+				}
+				b_coka = {
+					han = "Caoka"
+				}
+				b_domartang = {
+					han = "Duomatang"
+				}
+				b_sadeng = {
+					bodpa = "Sadêng"
+				}
+				b_dengqen = {
+					bodpa = "Dêngqên"
+					han = "Dingqing"
+				}
+				b_shagong = {
+				}
+				b_egage = {
+				}
+			}
+		}
+		d_nyingchi = {
+			color={ 170 10 30 }
+			color2= { 255 255 255 }
+
+			capital = 1500 # Nyingchi
+			
+			han = "Linzhi"
+
+			c_nyingchi = {
+				color={ 120 20 11 }
+				color2= { 255 255 255 }
+				
+				han = "Linzhi"
+
+				b_nyingchi = {
+					han = "Linzhi"
+				}
+				b_drakchi = {
+					han = "Bayi"
+				}
+				b_lamaling = { #temple
+					han = "Sangzhong"
+				}
+				b_buchasergyi_lakang = { #temple
+					han = "Buchu"
+				}
+				b_beba = {
+					han = "Baiba"
+					bodpa = "Bêba"
+				}
+				b_gongbogyamda = {
+					han = "Gongbujiangda"
+					bodpa = "Gongbo'gyamda"
+				}
+				b_pagsum = {
+					han = "Basong"
+				}
+			}
+			c_medog = {
+				color={ 129 50 9 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Mêdog"
+				han = "Motuo"
+
+				b_medog = {
+					bodpa = "Mêdog"
+					han = "Motuo"
+				}
+				b_baibung = {
+					han = "Beibeng"
+				}
+				b_deshing = {
+					han = "Dexing"
+				}
+				b_tamu = {
+					han = "Damu"
+				}
+				b_phomshen = {
+					han = "Paizhen"
+				}
+				b_gedang = {
+				}
+				b_gandain = {
+					han = "Gandeng"
+				}
+			}
+			c_mainling = {
+				color={ 177 57 7 }
+				color2= { 255 255 255 }
+				
+				han = "Milin"
+
+				b_mainling = {
+					han = "Milin"
+				}
+				b_nang = {
+					han = "Lang"
+				}
+				b_lilong = {
+				}
+				b_nanyi = {
+				}
+				b_wolong = {
+				}
+				b_jindong = {
+				}
+				b_dengmu = {
+				}
+			}
+		}
+	}
+	
+	k_nepal = {
+		color= { 175 60 30 }
+		color2= { 255 255 255 }
+	
+		capital = 1478 # Kathmandu
+		
+		culture = nepali
+		
+		han = "Nibo'er"
+
+		d_kathmandu = {
+			color= { 175 60 30 }
+			color2= { 255 255 255 }
+
+			capital = 1478 # Kathmandu
+			
+			han = "Jiademandu"
+
+			c_kathmandu = {
+				color= { 175 60 30 }
+				color2= { 255 255 255 }
+				
+				han = "Jiademandu"
+
+				b_kathmandu = {
+					han = "Jiademandu"
+				}
+				b_bhaktapur = {
+				}
+				b_lalitpur = {
+				}
+				b_patan_yala = {
+				}
+				b_kirtipur = {
+				}
+				b_pashupatinath = { #temple (hindu)
+				}
+				b_nagarkot = {
+				}
+			}
+			c_janakpur = {
+				color= { 180 40 20 }
+				color2= { 255 255 255 }
+				
+				han = "Jianakebu'er"
+
+				b_janakpur = {
+					han = "Jianakebu'er"
+				}
+				b_kamalamai = { #temple
+				}
+				b_birgunj = {
+				}
+				b_bharatpur = {
+				}
+				b_devghat = { #temple and hindu holy site
+				}
+				b_hetauda = {
+				}
+				b_kalaiya = {
+				}
+			}
+			c_limbuwan = {
+				color= { 190 60 20 }
+				color2= { 255 255 255 }
+
+				b_taplejung = {
+				}
+				b_tambar = {
+				}
+				b_gograha = {
+				}
+				b_dhankuta = {
+				}
+				b_myanglung = {
+				}
+				b_ilam_limbuwan = {
+				}
+				b_morong = {
+				}
+			}
+		}
+		d_gorkha = {
+			color={ 195 100 20 }
+			color2= { 255 255 255 }
+
+			capital = 1475 # Pokhara
+			
+			bodpa = "Yartse"
+			han = "Kuoerka"
+
+			c_pokhara = {
+				color={ 195 100 20 }
+				color2= { 255 255 255 }
+				
+				han = "Bokala"
+
+				b_pokhara = {
+					han = "Bokala"
+				}
+				b_marpha = {
+				}
+				b_muktinath = { #temple
+				}
+				b_prithbinarayan = {
+				}
+				b_butwal = {
+				}
+				b_chame = {
+				}
+				b_besisahar = {
+				}
+			}
+			c_jumla = {
+				color={ 195 120 0 }
+				color2= { 255 255 255 }
+
+				b_jumla = {
+				}
+				b_simikot = {
+				}
+				b_chainpur = {
+				}
+				b_dunai = {
+				}
+				b_manma = {
+				}
+				b_gamgadhi = {
+				}
+				b_martadi = {
+				}
+			}
+			c_doti = {
+				color={ 175 110 20 }
+				color2= { 255 255 255 }
+
+				b_dullu = {
+				}
+				b_dailekh = {
+				}
+				b_gularia = {
+				}
+				b_mahendranagar = {
+				}
+				b_dadeldhura = {
+				}
+				b_dhamboji = {
+				}
+				b_khalanga = {
+				}
+			}
+			c_lumbini = {
+				color={ 175 140 20 }
+				color2= { 255 255 255 }
+				
+				holy_site = buddhist
+				
+				han = "Lanpini"
+
+				b_lumbini = { #temple and birthplace of the Buddha
+					han = "Lanpini"
+				}
+				b_bhairahawa = {
+				}
+				b_sandhikharka = {
+				}
+				b_taulihawa = { #temple and childhood home of the buddha
+				}
+				b_nigrodharama = { #temple
+				}
+				b_tulsipur = {
+				}
+				b_musikot = {
+				}
+			}
+			c_mustang = {
+				color={ 130 160 20 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Manthang"
+				han = "Yangtang"
+
+				b_lo = {
+					han = "Luo"
+				}
+				b_chhonhup = {
+				}
+				b_tetang = {
+				}
+				b_kagbeni = {
+				}
+				b_chhusang = {
+				}
+				b_chhoser = {
+				}
+				b_drak_gyawu = {
+				}
+			}
+		}
+	}
+	k_kashmir = {
+
+		color={ 204 180 30 }
+		color2= { 255 255 255 }
+
+		capital = 1161 # Kasmira
+
+		d_kashmir = {
+
+			color={ 204 180 30 }
+			color2= { 255 255 255 }
+
+			capital = 1161 # Kasmira
+
+			c_kasmira = {
+				color={ 245 160 31 }
+				color2={ 255 255 255 }
+				
+				b_srinagara = {
+				}
+				b_shankaracharya = {
+				}
+				b_parihasapura = {
+				}
+				b_padmapura = {
+				}
+				b_loharakota = {
+				}
+				b_amaresvara = {
+				}
+				b_baghsar = {
+				}
+			}
+			
+			c_skardu = {
+				color={ 170 160 20 }
+				color2= { 255 255 255 }
+
+				b_skardu = {
+				}
+				b_huldi = {
+				}
+				b_madhupur_skardu = {
+				}
+				b_kharkoo = {
+				}
+				b_khaplu = {
+				}
+				b_hilmat = {
+				}
+				b_janwai = {
+				}
+			}
+			c_gilgit = {
+				color={ 204 170 30 }
+				color2= { 255 255 255 }
+				
+				holy_site = bon
+				holy_site = bon_reformed
+
+				b_gilgit = {
+				}
+				b_danyor = {
+				}
+				b_chitral = {
+				}
+				b_minawar = {
+				}
+				b_pahot = {
+				}
+				b_chatorkhand = {
+				}
+				b_barjangle = {
+				}
+			}
+		}
+		
+		d_pamir = {
+			color={ 174 120 0 }
+			color2= { 255 255 255 }
+
+			capital = 1511 # Pamir
+			
+			c_pamir = {
+				color={ 174 120 0 }
+				color2= { 255 255 255 }
+				
+				b_daroot_korgon = {
+				}
+				b_kala_panja = {
+				}
+				b_vanj = {
+				}
+				b_zamr_i_atish_parast = {
+				}
+				b_khorugh = {
+				}
+				b_darmadar = {
+				}
+				b_traguladar = { #Fictional, for prosperity
+				}
+			}
+
+			c_tashkurgan = {
+				sogdian = "Sarikol"
+
+				color={ 224 150 50 }
+				color2= { 255 255 255 }
+
+				b_tashkurgan = {
+					sogdian = "Sarikol"
+				}
+				b_jianggala = {
+				}
+				b_hangdi = {
+				}
+				b_kaladong = {
+				}
+				b_zankan = {
+				}
+				b_qiate = {
+				}
+				b_bulongke = {
+				}
+			}
+		}
+		d_uttaranchal = {
+			color= { 200 180 50 }
+			color2= { 255 255 255 }
+
+			capital = 1470 # Garhwal
+
+			c_kangra = {
+				color= { 150 140 30 }
+				color2= { 255 255 255 }
+
+				b_kangra = {
+				}
+				b_shimla = {
+				}
+				b_nurpur = {
+				}
+				b_chamba = {
+				}
+				b_bharmour = {
+				}
+				b_kahlur = {
+				}
+				b_kullu = {
+				}
+			}
+			c_garhwal = {
+
+				color= { 200 180 50 }
+				color2= { 255 255 255 }
+
+				b_devalghar = {
+				}
+				b_badrinath = { # Temple & Hindu Holy Site
+				}
+				b_srinagar = {
+				}
+				b_tehri = {
+				}
+				b_uttarkashi = {
+				}
+				b_sudhnagar = {
+				}
+				b_haridwar = {
+				}
+				# Joshimath / Jyotirmath
+			}
+			c_kurmanchal = {
+
+				color= { 220 200 70 }
+				color2= { 255 255 255 }
+
+				b_kartikeyapura = {
+				}
+				b_katarmal = {
+				}
+				b_askot_kurmanchal = {
+				}
+				b_govishana = {
+				}
+				b_ranikhet = {
+				}
+				b_didihat = {
+				}
+				b_champawat = {
+				}
+			}
+		}
+	}
+	k_xixia = {
+		color={ 8 119 114 }
+		color2={ 255 255 255 }
+		
+		capital = 1513 # Jiuquan (in lieu of Xingqing/Yinchuan)
+		
+		culture = tangut
+		
+		khitan = "Tuyuhun"
+		bodpa = "Amdo"
+		han = "Qinghai"
+		#tangut = "Minyak"
+		mongol = "Tangghut"
+		
+		d_jiuquan = {
+			color={ 31 186 165 }
+			
+			capital = 1513 # Jiuquan
+			
+			uyghur = "Yugur"
+			
+			c_jiuquan = {
+				color={ 8 119 114 }
+				
+				holy_site = taoist
+				
+				b_jiuquan = {
+				}
+				b_suzhou = {
+				}
+				b_kongtong = {
+				}
+				b_fulu = {
+				}
+				b_xianshi = {
+				}
+				b_longdi = { # Fictional, for prosperity
+				}
+				b_guantou = { # Fictional, for prosperity
+				}
+			}
+			c_dunhuang = {
+				color={ 8 129 114 }
+
+				uyghur = "Dukhan"
+				
+				b_dunhuang = {
+					uyghur = "Dukhan"
+				}
+				b_fangpan = {
+				}
+				b_mogao = {
+				}
+				b_yueyaquan = {
+				}
+				b_yumenquan = {
+				}
+				b_hongliuwan = {
+				}
+				b_xuanquanzhi = {
+				}
+			}
+			c_anxi = {
+				color={ 28 119 114 }
+				
+				b_anxi = {
+				}
+				b_guazhou = {
+				}
+				b_xincheng = {
+				}
+				b_yuanquan = {
+				}
+				b_yulin = {
+				}
+				b_suoyang = {
+				}
+				b_renhou = { # Fictional, for prosperity
+				}
+			}
+			c_yungguan = {
+				color={ 8 119 134 }
+
+				b_yungguan = {
+				}
+				b_shouchang = {
+				}
+				b_ziting = {
+				}
+				b_tuotou = { # Fictional, for prosperity
+				}
+				b_guihuayuan = { # Fictional, for prosperity
+				}
+				b_nieercun = { # Fictional, for prosperity
+				}
+				b_pochao = { # Fictional, for prosperity
+				}
+			}
+			c_yumen = {
+				color={ 18 129 124 }
+
+				b_yumen = {
+				}
+				b_xiaxihao = {
+				}
+				b_huangzhawan = {
+				}
+				b_chuanbei = {
+				}
+				b_baoen = { #temple
+				}
+				b_dongshuwo = { #temple
+				}
+				b_shagang = {
+				}
+			}
+		}
+		d_qinghai = {
+			color={ 38 109 104 }
+			color2= { 255 255 255 }
+
+			capital = 1502 # Fuqi
+			
+			culture = tangut
+			
+			tangut = "Minyak"
+			khitan = "Tuyuhun"
+			mongol = "Kokonur"
+
+			c_fuqi = {
+				color={ 48 109 104 }
+				color2= { 255 255 255 }
+
+				b_fuqi = {
+				}
+				b_shinaihai = {
+				}
+				b_naerji = {
+				}
+				b_shatuo = { #temple
+				}
+				b_qieji = {
+				}
+				b_caierqiong = {
+				}
+				b_tiebujia = {
+				}
+			}
+			c_delingha = {
+				color={ 38 109 114 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Dêrlênka"
+				mongol = "Delhi"
+				khitan = "Delhi"
+
+				b_delingha = {
+					bodpa = "Dêrlênka"
+					mongol = "Delhi"
+					khitan = "Delhi"
+				}
+				b_xuji = {
+				}
+				b_haixi = {
+				}
+				b_hedong = {
+				}
+				b_hexi = {
+				}
+				b_keluke = {
+				}
+				b_gahai = {
+				}
+			}
+			c_dulan = {
+				color={ 38 119 104 }
+				color2= { 255 255 255 }
+
+				b_dulan = {
+				}
+				b_reshui = { #temple
+				}
+				b_xiariha = {
+				}
+				b_zongjia = {
+				}
+				b_xiangride = {
+				}
+				b_gouli = {
+				}
+				b_xiangjia = {
+				}
+			}
+		}
+			
+		d_nagormo = {
+			color={ 18 139 134 }
+			color2= { 255 255 255 }
+
+			capital = 1501 # Nagormo
+			
+			mongol = "Golmud"
+			khitan = "Golmud"
+			uyghur = "Golmud"
+			han = "Ge'ermu"
+			
+			c_nagormo = {
+				color={ 28 139 134 }
+				color2= { 255 255 255 }
+				
+				mongol = "Golmud"
+				khitan = "Golmud"
+				uyghur = "Golmud"
+				han = "Ge'ermu"
+
+				b_golmud = {
+					han = "Ge'ermu"
+					bodpa = "Nagormo"
+				}
+				b_qarham = {
+				}
+				b_qingshui = {
+				}
+				b_xinle = {
+				}
+				b_dagele = {
+				}
+				b_baoku = {
+				}
+				b_dabuxun = {
+				}
+			}
+			c_qaidam = {
+				color={ 18 149 134 }
+				color2= { 255 255 255 }
+				
+				han = "Chaidan"
+				bodpa = "Cheba'i"
+				mongol = "Tsaydmyn"
+				
+				b_qaidam = {
+					han = "Chaidan"
+					bodpa = "Cheba'i"
+					mongol = "Tsaydmyn"
+				}
+				b_xitishan = {
+				}
+				b_yinmaxia = {
+				}
+				b_ligouchu = {
+				}
+				b_xiaochaidamu = {
+				}
+				b_daqaidam = {
+					han = "Da Chaidan"
+					bodpa = "'Dam Cheba'i"
+					mongol = "Da Tsaydmyn"
+				}
+				b_aolaohe = {
+				}
+			}
+			c_lenghu = {
+				color={ 18 139 144 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Lenghu'u"
+				mongol = "Lyenkhyn"
+				
+				b_lenghu = {
+					bodpa = "Lenghu'u"
+					mongol = "Lyenkhyn"
+				}
+				b_tuanjie = { # Fictional, for prosperity
+				}
+				b_xinghu = { # Fictional, for prosperity
+				}
+				b_yucai = { # Fictional, for prosperity
+				}
+				b_yanhua = { # Fictional, for prosperity
+				}
+				b_junheju = { # Fictional, for prosperity
+				}
+				b_ledu = { # Fictional, for prosperity
+				}
+			}
+			c_tanggula = {
+				color={ 18 159 154 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Dangla"
+				
+				b_dangla = {
+					han = "Tanggula"
+				}
+				b_tongtian = {
+				}
+				b_yanshiping = {
+				}
+				b_maqu = {
+				}
+				b_marong = {
+				}
+				b_wenquan = {
+				}
+				b_sewu = {
+				}
+			}
+		}
+		d_nangqen = {
+			color={ 44 152 132 }
+			color2= { 255 255 255 }
+
+			capital = 1503 # Nangqen
+			
+			bodpa = "Nangqên"
+			han = "Nangqian"
+			
+			c_nangqen = {
+			
+				color={ 54 152 132 }
+				color2= { 255 255 255 }
+				
+				bodpa = "Nangqên"
+				han = "Nangqian"
+				
+				b_xangda = {
+					han = "Xiangda"
+				}
+				b_tana_b = {
+				}
+				b_niangla = {
+				}
+				b_dongba = {
+				}
+				b_juela = {
+				}
+				b_maozhuang = {
+				}
+				b_gayong = {
+				}
+			}
+			c_zadoi = {
+
+				color={ 44 162 132 }
+				color2= { 255 255 255 }
+				
+				han = "Zaduo"
+				
+				b_zadoi = {
+					han = "Zaduo"
+				}
+				b_qapugtang = {
+					han = "Shahuteng"
+				}
+				b_chadan = {
+				}
+				b_moyun = {
+				}
+				b_angsai = {
+				}
+				b_aduo = {
+				}
+				b_zhaqing = {
+				}
+			}
+			c_lingtsang = {
+				color={ 44 152 142 }
+				color2= { 255 255 255 }
+				
+				han = "Liangsong"
+
+				b_denkok = {
+				}
+				b_serxu = {
+					bodpa = "Sêrxü"
+					han = "Shiqu"
+				}
+				b_gemeng = {
+				}
+				b_derong = {
+				}
+				b_arizha = {
+				}
+				b_maga = {
+				}
+				b_wenbo = {
+				}
+			}
+		}
+	}
+}
+
+# Chinese Mercenaries
+d_han_massive = { # Massive Merc
+	color={ 60 165 80 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = chinesegfx
+
+	capital = 1408 # Anxi
+	hire_range = 1300
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = han_massive_composition
+}
+
+d_han_large = { # Large Merc
+	color={ 235 235 235 }
+	color2={ 255 255 255 }
+	
+	graphical_culture = chinesegfx
+
+	capital = 1408 # Anxi
+	hire_range = 1300
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = han_large_composition
+}
+
+d_han_mid = { # Mid Merc
+	color = { 150 80 40 }
+	color2 = { 255 255 255 }
+
+	graphical_culture = chinesegfx
+
+	capital = 1408 # Anxi
+	hire_range = 1300
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = han_mid_composition
+}
+
+d_han_mid_low = { # Mid-Low Merc
+	color = { 30 150 50 }
+	color2 = { 255 255 255 }
+
+	graphical_culture = chinesegfx
+
+	capital = 1408 # Anxi
+	hire_range = 1300
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = han_mid_low_composition
+}
+
+d_outlaws_of_the_marsh = { # Big merc
+	color = { 66 66 66 }
+	color2 = { 255 255 255 }
+
+	graphical_culture = chinesegfx
+
+	capital = 1408 # Anxi
+	hire_range = 1300
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = outlaws_of_the_marsh
+}
+
+d_han_low = { # Small Merc
+	color = { 30 170 50 }
+	color2 = { 255 255 255 }
+
+	graphical_culture = chinesegfx
+
+	capital = 1408 # Anxi
+	hire_range = 1300
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = han_low_composition
+}
+
+d_han_tiny_1 = { # Tiny Merc
+	color = { 38 120 51 }
+	color2 = { 255 255 255 }
+
+	graphical_culture = chinesegfx
+
+	capital = 1408 # Anxi
+	hire_range = 1300
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = han_tiny_composition_1
+}
+
+d_han_tiny_2 = { # Tiny Merc
+	color = { 32 175 57 }
+	color2 = { 255 255 255 }
+
+	graphical_culture = chinesegfx
+
+	capital = 1408 # Anxi
+	hire_range = 1300
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = han_tiny_composition_2
+}
+
+d_jurchen_band = { # Mid-Low Merc
+	color = { 32 120 50 }
+	color2 = { 255 255 255 }
+
+	graphical_culture = chinesegfx
+
+	capital = 1408 # Anxi
+	hire_range = 1300
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = jurchen
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = jurchen_band_composition
+}
+
+d_tangut_low = { # Small Merc
+	color = { 30 170 50 }
+	color2 = { 255 255 255 }
+
+	capital = 1503 # Jyekundo
+	hire_range = 800
+	
+	# Parent Religion 
+	religion = buddhist
+	
+	# Parent Culture
+	culture = tangut
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = tangut_low_composition
+}
+
+d_bodpa_low = { # Small Merc
+	color = { 30 170 50 }
+	color2 = { 255 255 255 }
+
+	capital = 1491 # Purang
+	hire_range = 800
+	
+	# Parent Religion 
+	religion = bon
+	
+	# Parent Culture
+	culture = bodpa
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = bodpa_low_composition
+}
+
+d_treasure_fleet = {
+	color={ 222 80 20 }
+	color2={ 255 255 255 }
+
+	capital = 1318 # Samatata
+	hire_range = 1200
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+
+	mercenary_type = treasure_fleet_composition
+}
+
+d_han_junks = {
+	color={ 222 80 20 }
+	color2={ 255 255 255 }
+	
+	short_name = yes
+
+	capital = 1318 # Samatata
+	hire_range = 1000
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = han
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+
+	mercenary_type = naval_merc_composition
+}
+
+d_jurchen_corsairs = {
+	color={ 222 180 20 }
+	color2={ 255 255 255 }
+	
+	short_name = yes
+
+	capital = 1318 # Samatata
+	hire_range = 1000
+	
+	# Parent Religion 
+	religion = taoist
+	
+	# Parent Culture
+	culture = jurchen
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+
+	mercenary_type = naval_merc_composition
+}
+
+# INDIAN MERCS
+
+d_tamil_band = {
+	color = { 110 60 30 }
+	color2 = { 255 255 255 }
+
+	capital = 1120 # Tagadur
+	
+	# Parent Religion 
+	religion = hindu
+	
+	culture = tamil
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = tamil_band_composition
+}
+
+d_marathi_company = {
+	color = { 150 80 40 }
+	color2 = { 255 255 255 }
+
+	capital = 1254 # Vairagara
+	
+	# Parent Religion
+	religion = hindu
+	
+	culture = marathi
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = marathi_company_composition
+}
+
+d_marathi_band = {
+	color = { 180 80 40 }
+	color2 = { 255 255 255 }
+
+	capital = 1254 # Vairagara
+	
+	# Parent Religion
+	religion = hindu
+	
+	culture = marathi
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = marathi_band_composition
+}
+
+d_bengal_company = {
+	color = { 30 150 50 }
+	color2 = { 255 255 255 }
+
+	capital = 1236 # Candradvipa
+	
+	# Parent Religion
+	religion = hindu
+	
+	culture = bengali
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = bengal_company_composition
+}
+
+d_bengal_band = {
+	color = { 30 170 50 }
+	color2 = { 255 255 255 }
+
+	capital = 1236 # Candradvipa
+	
+	# Parent Religion
+	religion = hindu
+	
+	culture = bengali
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = bengal_band_composition
+}
+
+d_rajput_company = {
+	color = { 180 65 0 }
+	color2 = { 255 255 255 }
+
+	capital = 1130 # Mandavyapura
+	
+	# Parent Religion
+	religion = hindu
+	
+	culture = rajput
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = rajput_company_composition
+}
+
+d_rajput_band = {
+	color = { 170 50 0 }
+	color2 = { 255 255 255 }
+
+	capital = 1130 # Mandavyapura
+	
+	# Parent Religion
+	religion = hindu
+	
+	culture = rajput
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = rajput_band_composition
+}
+
+# Silk Road Mercs
+d_persian_caravan_guards = {
+	color = { 67 155 135 }
+	color2 = { 255 255 255 }
+
+	capital = 630 # Merv
+	
+	religion = shiite
+	culture = persian
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = persian_caravan_guards_composition
+}
+
+d_silk_road_sentinels = {
+	color = { 167 125 135 }
+	color2 = { 255 255 255 }
+
+	capital = 1180 # Udabhanda
+	
+	religion = buddhist
+	culture = panjabi
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = silk_road_sentinels_composition
+}
+
+d_turkic_guard = {
+	color = { 167 125 135 }
+	color2 = { 255 255 255 }
+
+	capital = 900 # Syr Darya
+	
+	religion = khurmazta
+	culture = turkish
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.00
+	
+	mercenary_type = turkic_guards_composition
+}
+
+e_china_west_governor = { #placeholder for the Chinese Empire Western Governor
+	color={ 245 240 10 }
+	color2={ 220 220 0 }
+	
+	capital = 1448 # Dunhuang
+	
+	assimilate = no # Duchies cannot de jure drift IN or OUT of this title
+	
+	title_female = "WESTERN_GOVERNOR_FEMALE"
+	title = "WESTERN_GOVERNOR_MALE"
+	foa = "WESTERN_GOVERNOR_TITLE_FOA"
+	short_name = yes
+	#location_ruler_title = yes
+	
+	# Always exists
+	landless = yes
+	
+	# Cannot be vassalized
+	independent = yes
+
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+	
+	can_be_claimed = no
+	can_be_usurped = no
+	
+	extra_ai_eval_troops = 7500
+}
+k_sakya_trizin = {
+	color = { 95 190 50 }
+}
+
+d_manichean = {
+	color={ 180 137 97 }
+	color2={ 220 220 0 }
+	
+	capital = 903 # Samarkand
+	
+	title = "YAMAG"
+	foa = "POPE_FOA" # needs new graphics
+	
+	short_name = yes
+
+	# Always exists
+	landless = yes
+	
+	# Controls a religion
+	controls_religion = manichean
+	
+	religion = manichean
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	dynasty_title_names = no 	# Will not be named "Seljuk", etc.
+}
+	
+d_army_light = {
+	color={ 181 204 20 } 
+	
+	graphical_culture = bektashigfx # needs altered
+	
+	capital = 903 # Samarkand
+
+	title = "GRANDMASTER"
+	foa = "GRANDMASTER_FOA" # needs graphics
+	
+	# Always exists
+	landless = yes
+	
+	holy_order = yes
+	
+	# Parent Religion 
+	religion = manichean
+	
+	culture = persian
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Extra income due to donations, etc
+	monthly_income = 2 # (Must be an integer between 1 and 512)
+	
+	strength_growth_per_century = 0.10
+
+	mercenary_type = bektashi_composition
+}
+
+# African Mercenaries
+d_african_massive = { # Massive Merc
+	color={ 60 165 80 }
+	color2={ 255 255 255 }
+
+	graphical_culture = westafricanholygfx
+	
+	capital = 925 # Mali
+	hire_range = 900
+	
+	# Parent Religion 
+	religion = west_african_pagan
+	
+	# Parent Culture
+	culture = manden
+	
+	mercenary = yes
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = african_massive_composition
+}
+
+d_african_large = { # Large Merc
+	color={ 235 235 235 }
+	color2={ 255 255 255 }
+	
+	capital = 1739 # Djimi
+	hire_range = 900
+	
+	# Parent Religion 
+	religion = west_african_pagan
+	
+	# Parent Culture
+	culture = soninke
+	
+	mercenary = yes
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+		
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+
+	mercenary_type = african_large_composition
+}
+
+d_african_mid = { # Mid Merc
+	color = { 150 80 40 }
+	color2 = { 255 255 255 }
+
+	graphical_culture = africangfx
+
+	capital = 1335 # Kosti
+	hire_range = 900
+	
+	# Parent Religion 
+	religion = west_african_pagan
+	
+	# Parent Culture
+	culture = nubian
+	
+	mercenary = yes
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = african_mid_composition
+}
+
+d_african_mid_low_1 = { # Mid-Low Merc
+	color = { 30 150 50 }
+	color2 = { 255 255 255 }
+
+	capital = 913 # Ghana
+	hire_range = 900
+	
+	# Parent Religion 
+	religion = west_african_pagan
+	
+	# Parent Culture
+	culture = soninke
+	
+	mercenary = yes
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = african_mid_low_1_composition
+}
+
+d_african_mid_low_2 = { # Big merc
+	color = { 66 66 66 }
+	color2 = { 255 255 255 }
+
+	capital = 925 # Mali
+	hire_range = 900
+	
+	# Parent Religion 
+	religion = west_african_pagan
+	
+	# Parent Culture
+	culture = hausa
+	
+	mercenary = yes
+
+	title = "CAPTAIN"
+	foa = "CAPTAIN_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = african_mid_low_2_composition
+}
+
+d_african_low = { # Small Merc
+	color = { 30 170 50 }
+	color2 = { 255 255 255 }
+
+	capital = 914 # Gao
+	hire_range = 900
+	
+	# Parent Religion 
+	religion = west_african_pagan
+	
+	# Parent Culture
+	culture = songhay
+	
+	mercenary = yes
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = african_low_composition
+}
+
+d_african_tiny = { # Tiny Merc
+	color = { 38 120 51 }
+	color2 = { 255 255 255 }
+
+	capital = 1738 # Air
+	hire_range = 900
+	
+	# Parent Religion 
+	religion = west_african_pagan
+	
+	# Parent Culture
+	culture = maghreb_arabic
+	
+	mercenary = yes
+
+	title = "WARCHIEF"
+	foa = "WARCHIEF_FOA"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	# Cannot be vassalized
+	independent = yes
+	
+	strength_growth_per_century = 1.0
+	
+	mercenary_type = african_tiny_composition_1
+}
+
+d_scholae_palatinae = {
+	color={ 178 34 34 }
+	color2={ 255 215 0 }
+	
+	graphical_culture = orthodoxholygfx
+
+	capital = 496 # Byzantion
+	
+	# Parent Religion 
+	religion = orthodox
+	
+	culture = greek
+	
+	mercenary = yes
+
+	title = "domestic"
+	foa = "domestic_FOA"
+	title_female = "domestic_female"
+
+	# Always exists
+	landless = yes
+	
+	# Cannot be held as a secondary title
+	primary = yes
+	
+	replace_captain_on_death = yes
+	
+	strength_growth_per_century = 0.10
+	
+	mercenary_type = Scholae_Palatinae_composition
+}
+
+
+# OBSOLETE TITLES IN THE MIDDLE EAST SINCE 2.8
+d_hamadan = {
+	color={ 184 225 112 }
+	color2={ 255 255 255 }
+}
+
+d_esfahan = {
+	color={ 142 176 84 }
+	color2={ 255 255 255 }	
+}
+d_kermanshah = { # Luristan
+	color={ 55 144 95 }
+	color2={ 255 255 255 }	
+}
+d_tigris = {
+	color={ 113 150 32 }
+	color2={ 255 255 255 }
+}
+d_burtas = {
+	color = { 173 121 176 }
+	color2 = { 0 128 128 }
+	
+	capital = 592 # Burtasy
+	
+	culture = alan
+	
+	allow = {
+		always = no
+	}
+}
+
+# OBSOLETE TITLES HRE
+d_luxembourg = {
+	color={ 110 110 155 }
+	color2={ 255 255 255 }
+}
+
+e_russian_empire = {	
+	color={ 220 60 70 }
+	color2={ 255 255 255 }
+	
+	capital = 582 # Vladimir
+	
+	culture = russian
+	
+	allow = {
+		always = no # Only created through special event
+	}
+}
+
+k_liao = {
+	color = { 33 202 156 }
+	color2= { 255 255 255 }
+
+	culture = khitan
+}
+d_guiyi = { # 
+	color={ 202 26 26 }
+	color2={ 255 255 255 }
+	
+	capital = 1448 # Dunhuang
+	
+	dignity = 200
+	
+	allow = {
+		always = no
+	}
+}

--- a/Data/ck2_landed_titles.txt
+++ b/Data/ck2_landed_titles.txt
@@ -960,7 +960,7 @@ d_teutonic_order = {
 	
 	graphical_culture = holygfx
 	
-	capital = 258 # L√ºneburg
+	capital = 258 # L¸neburg
 
 	title = "HOCHMEISTER"
 	foa = "HOCHMEISTER_FOA"
@@ -3103,7 +3103,7 @@ d_finnish_band = {
 	color = { 131 35 35 }
 	color2 = { 255 255 255 }
 
-	capital = 383 # H√§me
+	capital = 383 # H‰me
 	
 	# Hire Trigger
 	allow = {
@@ -3653,7 +3653,7 @@ d_hanseatic_navy = { # Now "Baltic Cogs"
 	
 	short_name = yes
 
-	capital = 262 # L√ºbeck
+	capital = 262 # L¸beck
 	
 	# Hire Trigger
 	allow = {
@@ -3859,7 +3859,7 @@ e_hre = {                      # Created by special decision only
 	color={ 250 250 250 }
 	color2={ 0 0 0 }
 	
-	capital = 90 # J√ºlich / Aachen
+	capital = 90 # J¸lich / Aachen
 
 	short_name = yes
 	
@@ -3895,7 +3895,7 @@ e_hre = {                      # Created by special decision only
 		color={ 100 108 100 }
 		color2={ 255 255 255 }
 		
-		capital = 254 # W√ºrzburg
+		capital = 254 # W¸rzburg
 
 		title_prefix = "GRAND_DUCHY_PREFIX"
 		title = "GRAND_DUCHY_RULER"
@@ -3940,7 +3940,7 @@ e_germany = {
 	color={ 190 200 190 }
 	color2={ 220 220 20 }
 	
-	capital = 254 # W√ºrburg
+	capital = 254 # W¸rburg
 	
 	culture = german
 	
@@ -4005,7 +4005,7 @@ e_germany = {
 		color={ 210 210 210 }
 		color2={ 255 255 255 }
 
-		capital = 262 # L√ºbeck
+		capital = 262 # L¸beck
 	
 		dignity = 200 # Never want the Hanseatic League to change primary title
 	
@@ -4930,18 +4930,18 @@ e_germany = {
 			
 			capital = 119 #Cologne
 			
-			norse = K√∂ln
-			swedish = K√∂ln
-			danish = K√∂ln
-			norwegian = K√∂ln
-			german = K√∂ln
-			lombard = K√∂ln
-			old_frankish = K√∂ln
-			suebi = K√∂ln
+			norse = Kˆln
+			swedish = Kˆln
+			danish = Kˆln
+			norwegian = Kˆln
+			german = Kˆln
+			lombard = Kˆln
+			old_frankish = Kˆln
+			suebi = Kˆln
 			dutch = Keulen
 			frisian = Keulen
-			saxon = K√∂ln
-			old_saxon = K√∂ln
+			saxon = Kˆln
+			old_saxon = Kˆln
 			
 			c_koln = {
 				color={ 141 141 141 }
@@ -4949,32 +4949,32 @@ e_germany = {
 
 				holy_site = catholic
 				
-				norse = K√∂ln
-				swedish = K√∂ln
-				danish = K√∂ln
-				norwegian = K√∂ln
-				german = K√∂ln
-				lombard = K√∂ln
-				old_frankish = K√∂ln
-				suebi = K√∂ln
+				norse = Kˆln
+				swedish = Kˆln
+				danish = Kˆln
+				norwegian = Kˆln
+				german = Kˆln
+				lombard = Kˆln
+				old_frankish = Kˆln
+				suebi = Kˆln
 				dutch = Keulen
 				frisian = Keulen
-				saxon = K√∂ln
-				old_saxon = K√∂ln
+				saxon = Kˆln
+				old_saxon = Kˆln
 				
 				b_koln = {
-					norse = K√∂ln
-					swedish = K√∂ln
-					danish = K√∂ln
-					norwegian = K√∂ln
-					german = K√∂ln
-					lombard = K√∂ln
-					old_frankish = K√∂ln
-					suebi = K√∂ln
+					norse = Kˆln
+					swedish = Kˆln
+					danish = Kˆln
+					norwegian = Kˆln
+					german = Kˆln
+					lombard = Kˆln
+					old_frankish = Kˆln
+					suebi = Kˆln
 					dutch = Keulen
 					frisian = Keulen
-					saxon = K√∂ln
-					old_saxon = K√∂ln
+					saxon = Kˆln
+					old_saxon = Kˆln
 				}
 				b_mark = {
 				}
@@ -5214,7 +5214,7 @@ e_germany = {
 			color={ 191 182 182 }
 			color2={ 255 255 255 }
 			
-			capital = 449 #√ñsterreich
+			capital = 449 #÷sterreich
 
 			roman = "Noricum"
 		
@@ -5273,7 +5273,7 @@ e_germany = {
 				dutch = Wenen
 				frisian = Wenen
 				carantanian = "Dunaj"
-				bohemian = "V√≠den"
+				bohemian = "VÌden"
 				croatian = "Bec"
 			
 				b_wien = {
@@ -5290,7 +5290,7 @@ e_germany = {
 					saxon = Wien
 					old_saxon = Wien
 					carantanian = "Dunaj"
-					bohemian = "V√≠den"
+					bohemian = "VÌden"
 					croatian = "Bec"
 				}
 				b_wagram = {
@@ -5680,7 +5680,7 @@ e_germany = {
 			
 			capital = 456 # Villach
 
-			german = "K√§rnten"
+			german = "K‰rnten"
 			carantanian = "Carantania"
 
 			c_karnten = {
@@ -5728,7 +5728,7 @@ e_germany = {
 		
 		culture = german
 		
-		capital = 254 # W√ºrburg
+		capital = 254 # W¸rburg
 		
 		catholic = 5000 # Crusade target weight
 		
@@ -5833,7 +5833,7 @@ e_germany = {
 			color={ 100 108 100 }
 			color2={ 255 255 255 }
 			
-			capital = 254 # W√ºrzburg
+			capital = 254 # W¸rzburg
 		
 			c_leiningen = {
 				color={ 126 126 126 }
@@ -6026,7 +6026,7 @@ e_germany = {
 				color2={ 255 255 255 }
 				
 				b_zurich = {
-					german = "Z√ºrich"
+					german = "Z¸rich"
 					frankish = "Turic"
 					italian = "Turigo"
 				}
@@ -6099,7 +6099,7 @@ e_germany = {
 				}
 			}
 
-			german = "Churr√§tien"
+			german = "Churr‰tien"
 
 			c_chur = {
 				color={ 87 87 87 }
@@ -6152,7 +6152,7 @@ e_germany = {
 				}
 				b_disentis = {
 					italian = "Mosteriou"
-					frankish = "Monst√©ry"
+					frankish = "MonstÈry"
 				}
 				b_kussnacht = {
 					frankish = "Cossigny"
@@ -6337,7 +6337,7 @@ e_germany = {
 		color={ 105 135 105 }
 		color2={ 255 255 255 }
 
-		capital = 254 # W√ºrzburg
+		capital = 254 # W¸rzburg
 	}
 
 	k_thuringia_otto = {
@@ -6939,7 +6939,7 @@ e_byzantium = {
 					turkish = "Ayvansaray"
 				}
 				b_hieron = {
-					turkish = "Kadik√∂y"
+					turkish = "Kadikˆy"
 				}
 				b_deuteron = {
 					turkish = "Topkapi"
@@ -7657,7 +7657,7 @@ e_byzantium = {
 					turkish = "Fiaki"
 				}
 				b_cerigo = {
-					turkish = "√áuha"
+					turkish = "«uha"
 				}
 				b_atros = {
 				}
@@ -7738,11 +7738,11 @@ e_byzantium = {
 				turkish = "Bursa"
 				
 				b_prusa = {
-					turkish = "H√ºdavendigar"
+					turkish = "H¸davendigar"
 				}
 				b_darieium = {
 					greek = "Dorieion"
-					turkish = "S√∂g√ºt"
+					turkish = "Sˆg¸t"
 				}
 				b_apamea = {
 					greek = "Trigleia"
@@ -7765,13 +7765,13 @@ e_byzantium = {
 				color={ 176 25 124 }
 				color2={ 255 255 20 }
 				
-				turkish = "K√ºtahya"
+				turkish = "K¸tahya"
 				
 				b_dorylaion = {
 					turkish = "Eskisehir"
 				}
 				b_kotiaion = {
-					turkish = "K√ºtahya"
+					turkish = "K¸tahya"
 				}
 				b_orkistos = {
 				}
@@ -8306,7 +8306,7 @@ e_byzantium = {
 				color2={ 255 255 255 }
 				
 				greek = "Doliche"
-				turkish = "G√¢vur"
+				turkish = "G‚vur"
 	
 				b_teluch = {
 					greek = "Doliche"
@@ -11373,7 +11373,7 @@ e_italy = {
 				color2={ 255 255 255 }
 
 				german = "Livinen"
-				frankish = "L√©ventine"
+				frankish = "LÈventine"
 
 				b_castelgrande = {}
 				b_bellinzona = {
@@ -11744,7 +11744,7 @@ e_italy = {
 		orthodox = 50
 		muslim = 10
 		
-		#catalan = "Sardenya i C√≤rsega"
+		#catalan = "Sardenya i CÚrsega"
 		#greek = "Sardhnia kai thn Korsikn"
 		#italian = "Sardegna e Corsica"
 		
@@ -11762,7 +11762,7 @@ e_italy = {
 				color={ 170 182 225 }
 				color2={ 255 255 255 }
 				
-				italian = "Arbor√©a"
+				italian = "ArborÈa"
 				
 				b_oristano = {
 					catalan = "Oristany"
@@ -11809,7 +11809,7 @@ e_italy = {
 				b_capoterra = {
 				}
 				b_iglesias = {
-					catalan = "Esgl√©sies"
+					catalan = "EsglÈsies"
 				}
 			}
 			c_ogliastra = {
@@ -11843,7 +11843,7 @@ e_italy = {
 				b_ardara = {
 				}
 				b_sassari = {
-					catalan = "S√†sser"
+					catalan = "S‡sser"
 				}
 				b_portotorres = {
 				}
@@ -11875,10 +11875,10 @@ e_italy = {
 				}
 				b_lungone = {
 					greek = "Tibula"
-					italian = "Lung√≤ni"
+					italian = "LungÚni"
 				}
 				b_galtelli = {
-					italian = "Galtell√¨"
+					italian = "GaltellÏ"
 				}
 				b_dorgali = {
 				}
@@ -11898,7 +11898,7 @@ e_italy = {
 			
 			capital = 324 # Corsica
 			
-			catalan = "C√≤rsega"
+			catalan = "CÚrsega"
 			frankish = "Corse"
 			greek = "Korsikn"
 		
@@ -11906,7 +11906,7 @@ e_italy = {
 				color={ 226 248 251 }
 				color2={ 255 255 255 }
 				
-				catalan = "C√≤rsega"
+				catalan = "CÚrsega"
 				frankish = "Corse"
 				greek = "Korsikn"
 				italian = "Cismonte"
@@ -11917,7 +11917,7 @@ e_italy = {
 				b_corte = {
 				}
 				b_aleria = {
-					catalan = "Al√©ria"
+					catalan = "AlÈria"
 				}
 				b_alando = {
 				}
@@ -11943,7 +11943,7 @@ e_italy = {
 				b_filitosa = {
 				}
 				b_sartene = {
-					catalan = "Sart√®ne"
+					catalan = "SartËne"
 					italian = "Sartena"
 				}
 				b_bastelicaccia = {
@@ -11991,7 +11991,7 @@ e_scandinavia = {
 		baltic_pagan_reformed = 50 # Crusade target weight
 		finnish_pagan_reformed = 50
 		
-		norse = Svi√æjod
+		norse = Svi˛jod
 		#swedish = "Svea Rike"
 	
 		d_gotland = {
@@ -12055,7 +12055,7 @@ e_scandinavia = {
 			
 			capital = 290 # Uppland
 			
-			norse = Svi√æjod
+			norse = Svi˛jod
 			
 			pagan_coa = {
 				template = 0
@@ -12082,8 +12082,8 @@ e_scandinavia = {
 				b_uppsala = {
 				}
 				b_osteras = {
-					norwegian = "√òster√•s"
-					danish = "√òster√•s"
+					norwegian = "ÿsterÂs"
+					danish = "ÿsterÂs"
 				}
 				b_hatuna = {
 				}
@@ -12091,12 +12091,12 @@ e_scandinavia = {
 					used_for_dynasty_names = no
 				}
 				b_enkoping = {
-					norwegian = "Enk√∏ping"
-					danish = "Enk√∏bing"
+					norwegian = "Enk¯ping"
+					danish = "Enk¯bing"
 				}
 				b_alsno = {
-					norwegian = "Alsn√∏"
-					danish = "Alsn√∏"
+					norwegian = "Alsn¯"
+					danish = "Alsn¯"
 				}
 				b_vaksala = {
 				}
@@ -12115,8 +12115,8 @@ e_scandinavia = {
 				b_hille = {
 				}
 				b_farnebo = {
-					norwegian = "F√¶rnebo"
-					danish = "F√¶rnebo"
+					norwegian = "FÊrnebo"
+					danish = "FÊrnebo"
 				}
 				b_hedesunda = {
 				}
@@ -12144,12 +12144,12 @@ e_scandinavia = {
 				b_godby = {
 				}
 				b_finstrom = {
-					norwegian = "Finstr√∏m"
-					danish = "Finstr√∏m"
+					norwegian = "Finstr¯m"
+					danish = "Finstr¯m"
 				}
 				b_eckero = {
-					norwegian = "Ecker√∏"
-					danish = "Ecker√∏"
+					norwegian = "Ecker¯"
+					danish = "Ecker¯"
 				}
 				b_kumlinge = {
 				}
@@ -12158,32 +12158,32 @@ e_scandinavia = {
 				color={ 50 35 225 }
 				color2={ 255 255 255 }
 				
-				norwegian = "S√∏dermanland"
-				danish = "S√∏dermanland"
+				norwegian = "S¯dermanland"
+				danish = "S¯dermanland"
 				norse = "Sudermanland"
-				swedish = "S√∂dermanland"
+				swedish = "Sˆdermanland"
 				
 				b_nykoping = {
-					norwegian = "Nyk√∏ping"
-					danish = "Nyk√∏bing"
+					norwegian = "Nyk¯ping"
+					danish = "Nyk¯bing"
 				}
 				b_telge = {
 				}
 				b_gripsholm = {
 				}
 				b_strangnas = {
-					norwegian = "Str√¶ngnes"
-					danish = "Str√¶ngn√¶s"
+					norwegian = "StrÊngnes"
+					danish = "StrÊngnÊs"
 				}
 				b_torshalla = {
-					norwegian = "Torsh√¶lla"
-					danish = "Torsh√¶lla"
+					norwegian = "TorshÊlla"
+					danish = "TorshÊlla"
 				}
 				b_eskilstuna = {
 				}
 				b_vaderbrunn = {
-					norwegian = "V√¶derbrunn"
-					danish = "V√¶derbrunn"
+					norwegian = "VÊderbrunn"
+					danish = "VÊderbrunn"
 				}
 				b_hundhamra = {
 				}
@@ -12195,39 +12195,39 @@ e_scandinavia = {
 			
 			capital = 1701 # Vista
 			
-			norwegian = "√òsterg√∏tland"
-			danish = "√òsterg√∏tland"
+			norwegian = "ÿsterg¯tland"
+			danish = "ÿsterg¯tland"
 			norse = "Austergautland"
-			swedish = "√ñsterg√∂tland"
+			swedish = "÷stergˆtland"
 			
 			c_ostergotland = {
 				color={ 50 50 149 }
 				color2={ 255 255 255 }
 				
-				norwegian = "√òsterg√∏tland"
-				danish = "√òsterg√∏tland"
+				norwegian = "ÿsterg¯tland"
+				danish = "ÿsterg¯tland"
 				norse = "Austergautland"
-				swedish = "√ñsterg√∂tland"
+				swedish = "÷stergˆtland"
 				
 				b_uttersberg = {
 				}
 				b_skanninge = {
-					norwegian = "Sk√¶nninge"
-					danish = "Sk√¶nninge"
+					norwegian = "SkÊnninge"
+					danish = "SkÊnninge"
 				}
 				b_vadstena = {
 				}
 				b_linkoping = {
-					norwegian = "Link√∏ping"
-					danish = "Link√∏bing"
+					norwegian = "Link¯ping"
+					danish = "Link¯bing"
 				}
 				b_norrkoping = {
-					norwegian = "Norrk√∏ping"
-					danish = "Norrk√∏bing"
+					norwegian = "Norrk¯ping"
+					danish = "Norrk¯bing"
 				}
 				b_soderkoping = {
-					norwegian = "S√∏derk√∏ping"
-					danish = "S√∏derk√∏bing"
+					norwegian = "S¯derk¯ping"
+					danish = "S¯derk¯bing"
 				}
 				b_ringstaholm = {
 				}
@@ -12242,13 +12242,13 @@ e_scandinavia = {
 				
 				b_nasborg = {
 					norwegian = "Nesborg"
-					danish = "N√¶sborg"
+					danish = "NÊsborg"
 				}
 				b_alvastra = {
 				}
 				b_jonkoping = {
-					norwegian = "J√∏nk√∏ping"
-					danish = "J√∏nk√∏bing"
+					norwegian = "J¯nk¯ping"
+					danish = "J¯nk¯bing"
 				}
 				b_rumlaborg = {
 				}
@@ -12296,11 +12296,11 @@ e_scandinavia = {
 		d_vastergotland = {
 			color={ 46 30 205 }
 			color2={ 255 255 255 }
-			capital = 297 # V√§sterg√∂tland
+			capital = 297 # V‰stergˆtland
 			
-			swedish = "V√§sterg√∂tland"
-			norwegian = "Vesterg√∏tland"
-			danish = "Vesterg√∏tland"
+			swedish = "V‰stergˆtland"
+			norwegian = "Vesterg¯tland"
+			danish = "Vesterg¯tland"
 			norse = "Vestergautland"
 			
 			pagan_coa = {
@@ -12320,24 +12320,24 @@ e_scandinavia = {
 				color={ 60 55 255 }
 				color2={ 255 255 255 }
 				
-				swedish = "V√§sterg√∂tland"
-				norwegian = "Vesterg√∏tland"
-				danish = "Vesterg√∏tland"
+				swedish = "V‰stergˆtland"
+				norwegian = "Vesterg¯tland"
+				danish = "Vesterg¯tland"
 				norse = "Vestergautland"
 
 				holy_site = pagan
 				
 				b_lodose = {
-					norwegian = "L√∏d√∏se"
-					danish = "L√∏d√∏se"
+					norwegian = "L¯d¯se"
+					danish = "L¯d¯se"
 				}
 				b_falkoping = {
-					norwegian = "Falk√∏ping"
-					danish = "Falk√∏bing"
+					norwegian = "Falk¯ping"
+					danish = "Falk¯bing"
 				}
 				b_lacko = {
-					norwegian = "L√¶ck√∏"
-					danish = "L√¶ck√∏"
+					norwegian = "LÊck¯"
+					danish = "LÊck¯"
 				}
 				b_skalunda = {
 				}
@@ -12357,12 +12357,12 @@ e_scandinavia = {
 				norse = Nerike
 				
 				b_goksholm = {
-					norwegian = "G√∏ksholm"
-					danish = "G√∏ksholm"
+					norwegian = "G¯ksholm"
+					danish = "G¯ksholm"
 				}
 				b_orebro = {
-					norwegian = "√òrebro"
-					danish = "√òrebro"
+					norwegian = "ÿrebro"
+					danish = "ÿrebro"
 				}
 				b_mosas = {
 				}
@@ -12419,8 +12419,8 @@ e_scandinavia = {
 				b_skara = {
 				}
 				b_galakvist = {
-					norwegian = "G√¶lakvist"
-					danish = "G√¶lakvist"
+					norwegian = "GÊlakvist"
+					danish = "GÊlakvist"
 				}	
 				b_ymseborg = {
 				}
@@ -12438,7 +12438,7 @@ e_scandinavia = {
 			color={ 50 50 160 }
 			color2={ 255 255 255 }
 			
-			capital = 285 # H√§lsingland
+			capital = 285 # H‰lsingland
 
 			c_angermanland = {
 				color={ 24 0 255 }
@@ -12447,28 +12447,28 @@ e_scandinavia = {
 				norse = Angermanland
 				
 				b_bjartra = {
-					norwegian = "Bjertr√•"
-					danish = "Bj√¶rtr√•"
+					norwegian = "BjertrÂ"
+					danish = "BjÊrtrÂ"
 				}
 				b_ulvo = {
-					norwegian = "Ulv√∏"
-					danish = "Ulv√∏"
+					norwegian = "Ulv¯"
+					danish = "Ulv¯"
 				}
 				b_natra = {
 				}
 				b_skulnas = {
 					norwegian = "Skulnes"
-					danish = "Skuln√¶s"
+					danish = "SkulnÊs"
 				}
 				b_solleftea = {
 				}
 				b_harnosand = {
-					norwegian = "H√¶rn√∏sand"
-					danish = "H√¶rn√∏sand"
+					norwegian = "HÊrn¯sand"
+					danish = "HÊrn¯sand"
 				}
 				b_ornskoldsvik = {
-					norwegian = "√òrnsk√∏ldsvik"
-					danish = "√òrnsk√∏ldsvik"
+					norwegian = "ÿrnsk¯ldsvik"
+					danish = "ÿrnsk¯ldsvik"
 				}
 				b_biedsta = {
 				}
@@ -12480,14 +12480,14 @@ e_scandinavia = {
 				b_selanger = {
 				}
 				b_alno = {
-					norwegian = "Aln√∏"
-					danish = "Aln√∏"
+					norwegian = "Aln¯"
+					danish = "Aln¯"
 				}
 				b_njurunda = {
 				}
 				b_skon = {
-					norwegian = "Sk√∏n"
-					danish = "Sk√∏n"
+					norwegian = "Sk¯n"
+					danish = "Sk¯n"
 				}
 				b_liden = {
 				}
@@ -12511,8 +12511,8 @@ e_scandinavia = {
 				b_hog = {
 				}
 				b_jattendal = {
-					norwegian = "J√¶ttendal"
-					danish = "J√¶ttendal"
+					norwegian = "JÊttendal"
+					danish = "JÊttendal"
 				}
 				b_forsa = {
 				}
@@ -12529,16 +12529,16 @@ e_scandinavia = {
 		d_bergslagen = { 
 			color={ 60 60 200 }
 			color2={ 255 255 255 }
-			capital = 289 # V√§stmanland
+			capital = 289 # V‰stmanland
 			
 			c_dalarna = {
 				color={ 20 20 230 }
 				color2={ 255 255 255 }
 				
-				norwegian = "Jernb√¶raland"
-				danish = "Jernb√¶raland"
+				norwegian = "JernbÊraland"
+				danish = "JernbÊraland"
 				english = Dalecarlia
-				norse = J√°rnberaland
+				norse = J·rnberaland
 				
 				b_borganas = {
 				}
@@ -12561,10 +12561,10 @@ e_scandinavia = {
 				color={ 35 35 210 }
 				color2={ 255 255 255 }
 				
-				swedish = "V√§rmland"
-				german = "V√§rmland"
+				swedish = "V‰rmland"
+				german = "V‰rmland"
 				norwegian = "Vermland"
-				danish = "V√¶rmland"
+				danish = "VÊrmland"
 				norse = "Vermaland"
 				
 				b_saxholm = {
@@ -12593,18 +12593,18 @@ e_scandinavia = {
 				norse = "Vestmannaland"
 				
 				b_vasteras = {
-					norwegian = "Vester√•s"
-					danish = "Vester√•s"
+					norwegian = "VesterÂs"
+					danish = "VesterÂs"
 				}
 				b_arboga = {
 				}
 				b_kopingshus = {
-					norwegian = "K√∏pingshus"
-					danish = "K√∏bingshus"
+					norwegian = "K¯pingshus"
+					danish = "K¯bingshus"
 				}
 				b_koping = {
-					norwegian = "K√∏ping"
-					danish = "K√∏bing"
+					norwegian = "K¯ping"
+					danish = "K¯bing"
 				}
 				b_norberg = {
 				}
@@ -12619,16 +12619,16 @@ e_scandinavia = {
 		d_smaland = {
 			color={ 60 40 255 }
 			color2={ 255 255 255 }
-			capital = 931 # M√∂re
+			capital = 931 # Mˆre
 			
-			norse = "Sm√°land"
+			norse = "Sm·land"
 			
 			c_more = {
 				color={ 105 55 215 }
 				color2={ 255 255 255 }
 				
-				danish = M√∏re
-				norwegian = M√∏re
+				danish = M¯re
+				norwegian = M¯re
 				
 				b_kalmar = {
 				}
@@ -12651,8 +12651,8 @@ e_scandinavia = {
 				color2={ 255 255 255 }
 				
 				b_tornsfall = {
-					norwegian = "T√∏rnsfall"
-					danish = "T√∏rnsfall"
+					norwegian = "T¯rnsfall"
+					danish = "T¯rnsfall"
 				}
 				b_vastervik = {
 					norwegian = "Vestervik"
@@ -12694,8 +12694,8 @@ e_scandinavia = {
 				b_vimmerby = {
 				}			
 				b_doderhult = {
-					norwegian = "D√∏derhult"
-					danish = "D√∏derhult"
+					norwegian = "D¯derhult"
+					danish = "D¯derhult"
 				}
 				b_hulingsryd = { # Now Hultsfred
 				}	
@@ -12711,8 +12711,8 @@ e_scandinavia = {
 				color={ 75 60 255 }
 				color2={ 255 255 255 }
 				
-				norwegian = "√òland"
-				danish = "√òland"
+				norwegian = "ÿland"
+				danish = "ÿland"
 				
 				b_borgholm = {
 				}
@@ -12729,12 +12729,12 @@ e_scandinavia = {
 				b_gardby = {
 				}
 				b_gronhogen = {
-					norwegian = "Gr√∏nh√∏gen"
-					danish = "Gr√∏nh√∏gen"
+					norwegian = "Gr¯nh¯gen"
+					danish = "Gr¯nh¯gen"
 				}
 				b_kopingsvik = {
-					danish = "K√∏bingsvik"
-					norwegian = "K√∏pingsvik"
+					danish = "K¯bingsvik"
+					norwegian = "K¯pingsvik"
 				}
 			}
 		}
@@ -12742,9 +12742,9 @@ e_scandinavia = {
 			color={ 30 70 225 }
 			color2={ 255 255 255 }
 			
-			capital = 291 # V√§rend
+			capital = 291 # V‰rend
 			
-			swedish = "Tioh√§rad"
+			swedish = "Tioh‰rad"
 			
 			pagan_coa = {
 				template = 0
@@ -12759,15 +12759,15 @@ e_scandinavia = {
 				religion = "norse_pagan"
 			}
 			
-			c_smaland = { # Now called V√§rend
+			c_smaland = { # Now called V‰rend
 				color={ 95 30 215 }
 				color2={ 255 255 255 }
 				
 				b_kronoberg = {
 				}
 				b_vaxjo = {
-					danish = Vexj√∏
-					norwegian = Vexj√∏
+					danish = Vexj¯
+					norwegian = Vexj¯
 				}
 				b_aringsas = {
 				}
@@ -12846,21 +12846,21 @@ e_scandinavia = {
 			color={ 210 2 2 }
 			color2={ 255 255 255 }
 		
-			capital = 303 # Sk√•ne
+			capital = 303 # SkÂne
 			
-			swedish = Sk√•ne
-			norse = Sk√•ne
-			danish = Sk√•ne
-			norwegian = Sk√•ne
+			swedish = SkÂne
+			norse = SkÂne
+			danish = SkÂne
+			norwegian = SkÂne
 			
 			c_skane = {
 				color={ 215 5 5 }
 				color2={ 255 255 255 }
 				
-				swedish = Sk√•ne
-				norse = Sk√•ne
-				danish = Sk√•ne
-				norwegian = Sk√•ne
+				swedish = SkÂne
+				norse = SkÂne
+				danish = SkÂne
+				norwegian = SkÂne
 			
 				b_lund = {
 				}
@@ -12871,14 +12871,14 @@ e_scandinavia = {
 				b_herrevad = {
 				}
 				b_lillohus = {
-					danish = "Lill√∏hus"
-					norwegian = "Lill√∏hus"
+					danish = "Lill¯hus"
+					norwegian = "Lill¯hus"
 				}
 				b_helsingborg = {
 				}
 				b_malmo = {
-					danish = "Malm√∏"
-					norwegian = "Malm√∏"
+					danish = "Malm¯"
+					norwegian = "Malm¯"
 				}
 				b_ystad = {
 				}
@@ -12900,7 +12900,7 @@ e_scandinavia = {
 				b_kungsbacka = {
 				}
 				b_aranaes = {
-					danish = "Aran√¶s"
+					danish = "AranÊs"
 					norwegian = "Aranes"
 				}
 				b_baastad = {
@@ -12921,8 +12921,8 @@ e_scandinavia = {
 				b_hammershus = {
 				}
 				b_nexo = {
-					swedish = "Nex√∂"
-					norse = "Nex√∂"
+					swedish = "Nexˆ"
+					norse = "Nexˆ"
 				}
 				b_aakirkeby = {
 				}
@@ -12938,16 +12938,16 @@ e_scandinavia = {
 				color2={ 255 255 255 }
 			
 				b_solvesborg_slott = {
-					danish = "S√∏lvesborg Slott"
-					norwegian = "S√∏lvesborg Slott"
+					danish = "S¯lvesborg Slott"
+					norwegian = "S¯lvesborg Slott"
 				}
 				b_solvesborg = {
-					danish = "S√∏lvesborg"
-					norwegian = "S√∏lvesborg"
+					danish = "S¯lvesborg"
+					norwegian = "S¯lvesborg"
 				}
 				b_avaskar = {
-					danish = "Avask√¶r"
-					norwegian = "Avask√¶r"
+					danish = "AvaskÊr"
+					norwegian = "AvaskÊr"
 				}
 				b_elleholm = {
 				}
@@ -12968,9 +12968,9 @@ e_scandinavia = {
 			
 			dignity = 8
 			
-			swedish = Sj√§lland
+			swedish = Sj‰lland
 			english = Zealand
-			norse = Sj√¶lland
+			norse = SjÊlland
 			
 			pagan_coa = {
 				template = 0
@@ -12989,28 +12989,28 @@ e_scandinavia = {
 				color={ 216 50 50 }
 				color2={ 255 255 255 }
 				
-				swedish = Sj√§lland
-				norse = Sj√¶lland
+				swedish = Sj‰lland
+				norse = SjÊlland
 				english = Zealand
 
 				holy_site = norse_pagan
 				holy_site = norse_pagan_reformed
 				
 				b_kobenhavn = {
-					swedish = K√∂penhamn
+					swedish = Kˆpenhamn
 					norse = Hafn
 				}
 				b_roskilde = {
 				}
 				b_helsingor = {
-					swedish = Helsing√∂r
-					norse = Helsing√∂r
+					swedish = Helsingˆr
+					norse = Helsingˆr
 				}
 				b_kalundborg = {
 				}
 				b_naestved = {
-					swedish = N√§stved
-					norse = N√¶stved
+					swedish = N‰stved
+					norse = NÊstved
 				}
 				b_slagelse = {
 				}
@@ -13019,7 +13019,7 @@ e_scandinavia = {
 				b_ringsted = {
 				}
 				b_lejre = {
-					norse = Hlei√∞ra
+					norse = Hleira
 				}
 			}
 			c_lolland = {
@@ -13060,7 +13060,7 @@ e_scandinavia = {
 			color={ 224 74 74 }
 			color2={ 255 255 255 }
 			
-			capital = 1684 # √Öbosyssel
+			capital = 1684 # ≈bosyssel
 						
 			pagan_coa = {
 				template = 0
@@ -13097,8 +13097,8 @@ e_scandinavia = {
 				b_skive = {
 				}
 				b_ringkobing = {
-					swedish = "Ringk√∂ping"
-					norse = Ringk√∂ping
+					swedish = "Ringkˆping"
+					norse = Ringkˆping
 				}				
 				b_skjern = {}
 				b_lemvig = {}
@@ -13109,17 +13109,17 @@ e_scandinavia = {
 				color={ 255 45 45 }
 				color2={ 255 255 255 }
 
-				swedish = "√Örhus"
-				norse = "√Örus"
+				swedish = "≈rhus"
+				norse = "≈rus"
 
 				b_aarhus = {
-					swedish = "√Örhus"
-					norse = "√Örus"
+					swedish = "≈rhus"
+					norse = "≈rus"
 				}
 				b_jelling = {}
 				b_randers = {}
 				b_horsens = {
-					norse = "Horsn√¶s"
+					norse = "HorsnÊs"
 				}
 				b_lisbjerg = {}
 				b_vejle = {}
@@ -13161,13 +13161,13 @@ e_scandinavia = {
 				b_slesvig = {
 				}
 				b_sonderborg = {
-					swedish = "S√∂nderborg"
+					swedish = "Sˆnderborg"
 					german = "Sonderburg"
 				}
 				b_tonder = {
 				}
 				b_aabenraa = {
-					swedish = "√Öbenr√•"
+					swedish = "≈benrÂ"
 					german = "Apenrade"
 				}
 				b_haderslev = {
@@ -13176,7 +13176,7 @@ e_scandinavia = {
 				b_kolding = {
 				}
 				b_hedeby = {
-					norse = Hei√∞abyr
+					norse = Heiabyr
 				}
 			}
 
@@ -13262,7 +13262,7 @@ e_scandinavia = {
 				color={ 190 230 250 }
 				color2={ 220 220 220 }
 				
-				swedish = "V√§stisland"
+				swedish = "V‰stisland"
 				
 				b_hvamm = {
 				}
@@ -13284,7 +13284,7 @@ e_scandinavia = {
 				color={ 185 195 255 }
 				color2={ 220 220 220 }
 				
-				swedish = "√ñstisland"
+				swedish = "÷stisland"
 				
 				b_valpjotstadur = {
 				}
@@ -13335,7 +13335,7 @@ e_scandinavia = {
 					irish = "Papar"
 				}
 				b_alftanes = {
-					swedish = "Alftan√§s"
+					swedish = "Alftan‰s"
 				}
 				b_skalholt = {
 				}
@@ -13355,7 +13355,7 @@ e_scandinavia = {
 			
 			capital = 36 # Orkney
 			
-			norse = "Nor√∞reyjar"
+			norse = "Norreyjar"
 			pictish = "Insee Galeth"
 			welsh = "Ynysoedd Gogledd"
 			irish = "Innse Tuath"
@@ -13377,7 +13377,7 @@ e_scandinavia = {
 				color={ 116 145 239 }
 				color2={ 255 255 255 }
 				
-				swedish = "F√§r√∂arna"
+				swedish = "F‰rˆarna"
 				pictish = "Caliu"
 				welsh = "Ynysoedd Ceiliau"
 				irish = "Innse Caora"
@@ -13410,7 +13410,7 @@ e_scandinavia = {
 				b_sandur = {
 					pictish = "Insee Tret"
 					welsh = "Ynys Traeth"
-					irish = "Eilean Tr√†igh"
+					irish = "Eilean Tr‡igh"
 				}
 				b_klaksvik = {
 					pictish = "Insee Uun"
@@ -13438,12 +13438,12 @@ e_scandinavia = {
 				b_scalloway = {
 					pictish = "Bachuuon Maurt"
 					welsh = "Bachwyon Mawrty"
-					irish = "Batin M√¥rtaigh"
+					irish = "Batin MÙrtaigh"
 				}
 				b_muness = {
 					pictish = "Muunis"
 					welsh = "Mwynis"
-					irish = "M√πnis"
+					irish = "M˘nis"
 				}
 				b_tingwall = {
 					pictish = "Camanfalioth"
@@ -13457,12 +13457,12 @@ e_scandinavia = {
 					norse = "Konungsborg"
 					pictish = "Caer Rui"
 					welsh = "Caer Rhi"
-					irish = "R√¨ghd√πn"
+					irish = "RÏghd˘n"
 				}
 				b_sumburgh = {
 					pictish = "Taranupin"
 					welsh = "Taranupenn"
-					irish = "T√†irneanachceann"
+					irish = "T‡irneanachceann"
 				}
 				b_northmavine = {
 					pictish = "Goglethculder"
@@ -13472,7 +13472,7 @@ e_scandinavia = {
 				b_sound = {
 					pictish = "Cliaubae"
 					welsh = "Cleiaubae"
-					irish = "Cr√®adhbati"
+					irish = "CrËadhbati"
 				}
 				b_yell = {
 					pictish = "Insee Uuan"
@@ -13484,15 +13484,15 @@ e_scandinavia = {
 				color={ 106 140 235 }
 				color2={ 255 255 255 }
 				
-				swedish = "Orkn√∂"
-				danish = "Orkn√∏"
-				norse = "Orkn√∂"
+				swedish = "Orknˆ"
+				danish = "Orkn¯"
+				norse = "Orknˆ"
 				pictish = "Insee Orc"
 				welsh = "Ynysoedd Orc"
 				irish = "Innse Orc"
 				
 				b_kirkwall = {
-					norwegian = "Kirkuv√•g"
+					norwegian = "KirkuvÂg"
 					danish = "Kyrkovik"
 					swedish = "Kyrkovik"
 					norse = "Kyrkovik"
@@ -13501,13 +13501,13 @@ e_scandinavia = {
 					irish = "Baile na h-Eaglais"
 				}
 				b_birsay = {
-					norwegian = "Birgish√¶rad"
-					danish = "Birgish√¶rad"
-					swedish = "Birgish√§rad"
-					norse = "Birgish√¶rad"
+					norwegian = "BirgishÊrad"
+					danish = "BirgishÊrad"
+					swedish = "Birgish‰rad"
+					norse = "BirgishÊrad"
 					pictish = "Brideclauet"
 					welsh = "Ffraidclywed"
-					irish = "Br√¨ghdechuala"
+					irish = "BrÏghdechuala"
 				}
 				b_orphir = {
 					pictish = "Aerfur"
@@ -13532,7 +13532,7 @@ e_scandinavia = {
 				b_sanday = {
 					pictish = "Insee Tiuod"
 					welsh = "Ynys Tywod"
-					irish = "Innis Tr√†igh"
+					irish = "Innis Tr‡igh"
 				}
 				b_ronaldsay = {
 					pictish = "Insee Ninian"
@@ -13547,7 +13547,7 @@ e_scandinavia = {
 
 			capital = 268
 
-			norse = "Eg√∞afylki"
+			norse = "Egafylki"
 
 			c_agder = {
 				color={ 40 85 255 }
@@ -13599,7 +13599,7 @@ e_scandinavia = {
 				color={ 45 160 255 }
 				color2={ 255 255 255 }
 				
-				norse = "√ûelamark"
+				norse = "ﬁelamark"
 				
 				b_skien = {
 				}
@@ -13674,7 +13674,7 @@ e_scandinavia = {
 				norse = "Firdafylki"
 
 				b_forde = {
-					norse = "Fil√∞ir"
+					norse = "Filir"
 				}
 				b_kinn = {
 				}
@@ -13693,7 +13693,7 @@ e_scandinavia = {
 				color = { 20 80 120 }
 				color2 = { 255 255 255 }
 
-				norse = "Sunnm√¶re"
+				norse = "SunnmÊre"
 
 				b_borgund = {
 				}
@@ -13897,16 +13897,16 @@ e_scandinavia = {
 				b_bagahus = {
 				}
 				b_kungahalla = {
-					norwegian = "Kungah√¶lla"
-					danish = "Kungah√¶lla"
+					norwegian = "KungahÊlla"
+					danish = "KungahÊlla"
 				}
 				b_svarteborg = {
 				}
 				b_svenneby = {
 				}
 				b_ockero = {
-					norwegian = "√òcker√∏"
-					danish = "√òcker√∏"
+					norwegian = "ÿcker¯"
+					danish = "ÿcker¯"
 				}
 				b_hede = {
 				}
@@ -14038,7 +14038,7 @@ e_scandinavia = {
 				color={ 40 76 225 }
 				color2={ 255 255 255 }
 				
-				swedish = "H√§rjedalen"
+				swedish = "H‰rjedalen"
 				norse = "Herjadal"
 				
 				b_sveg = {
@@ -14298,10 +14298,10 @@ e_scandinavia = {
 				danish = "Nyland"
 			
 				b_porvoo = {
-					swedish = "Borg√•"
-					norse = "Borg√•"
-					norwegian = "Borg√•"
-					danish = "Borg√•"
+					swedish = "BorgÂ"
+					norse = "BorgÂ"
+					norwegian = "BorgÂ"
+					danish = "BorgÂ"
 				}
 				b_loviisa = {
 					swedish = "Lovisa"
@@ -14324,10 +14324,10 @@ e_scandinavia = {
 				b_svartholm = {
 				}
 				b_hanko = {
-					swedish = "Hang√∂"
-					norse = "Hang√∂"
-					norwegian = "Hang√∏"
-					danish = "Hang√∏"
+					swedish = "Hangˆ"
+					norse = "Hangˆ"
+					norwegian = "Hang¯"
+					danish = "Hang¯"
 				}
 				b_kotka = {
 				}
@@ -14342,22 +14342,22 @@ e_scandinavia = {
 				danish = "Finland"
 			
 				b_turku  = {		#Moved as first holding with HF
-					swedish = "√Öbo"
-					norse = "√Öbo"
-					norwegian = "√Öbo"
-					danish = "√Öbo"
+					swedish = "≈bo"
+					norse = "≈bo"
+					norwegian = "≈bo"
+					danish = "≈bo"
 				}
 				b_kuusisto  = {
-					swedish = "Kust√∂"
-					norse = "Kust√∂"
-					norwegian = "Kust√∏"
-					danish = "Kust√∏"
+					swedish = "Kustˆ"
+					norse = "Kustˆ"
+					norwegian = "Kust¯"
+					danish = "Kust¯"
 				}
 				b_naantali = {
-					swedish = "N√•dendal"
-					norse = "N√•dendal"
-					norwegian = "N√•dendal"
-					danish = "N√•dendal"
+					swedish = "NÂdendal"
+					norse = "NÂdendal"
+					norwegian = "NÂdendal"
+					danish = "NÂdendal"
 				}
 				b_rikala  = {
 				}
@@ -14382,9 +14382,9 @@ e_scandinavia = {
 				norwegian = "Tavastehus"
 				danish = "Tavastehus"
 				norse = "Tavastehus"
-				finnish = H√§me
-				lappish = H√§me
-				ugricbaltic = H√§me
+				finnish = H‰me
+				lappish = H‰me
+				ugricbaltic = H‰me
 			
 				b_hameenlinna = {
 					swedish = "Tavastehus"
@@ -14440,16 +14440,16 @@ e_scandinavia = {
 				color={ 188 73 78 }
 				color2={ 255 255 255 }
 				
-					swedish = "Sjunde√•"
-					norse = "Sjunde√•"
-					norwegian = "Sjunde√•"
-					danish = "Sjunde√•"
+					swedish = "SjundeÂ"
+					norse = "SjundeÂ"
+					norwegian = "SjundeÂ"
+					danish = "SjundeÂ"
 			
 				b_siuntio = {
-					swedish = "Sjunde√•"
-					norse = "Sjunde√•"
-					norwegian = "Sjunde√•"
-					danish = "Sjunde√•"
+					swedish = "SjundeÂ"
+					norse = "SjundeÂ"
+					norwegian = "SjundeÂ"
+					danish = "SjundeÂ"
 				}
 				b_lohja = {
 					swedish = "Lojo"
@@ -14492,9 +14492,9 @@ e_scandinavia = {
 			
 			capital = 385 # Osterbotten
 			
-			swedish = "√ñsterbotten"
-			norwegian = "√òsterbotten"
-			danish = "√òsterbotten"
+			swedish = "÷sterbotten"
+			norwegian = "ÿsterbotten"
+			danish = "ÿsterbotten"
 			norse = "Austerbotn"
 			finnish = Pohjanmaa
 			lappish = Pohjanmaa
@@ -14504,9 +14504,9 @@ e_scandinavia = {
 				color={ 152 66 66 }
 				color2={ 255 255 255 }
 				
-				swedish = "√ñsterbotten"
-				norwegian = "√òsterbotten"
-				danish = "√òsterbotten"
+				swedish = "÷sterbotten"
+				norwegian = "ÿsterbotten"
+				danish = "ÿsterbotten"
 				norse = "Austerbotn"
 				finnish = Pohjanmaa
 				lappish = Pohjanmaa
@@ -14531,10 +14531,10 @@ e_scandinavia = {
 				b_kalajoki = {
 				}
 				b_kaskinen = {
-					swedish = "Kask√∂"
-					norse = "Kask√∂"
-					norwegian = "Kask√∂"
-					danish = "Kask√∂"
+					swedish = "Kaskˆ"
+					norse = "Kaskˆ"
+					norwegian = "Kaskˆ"
+					danish = "Kaskˆ"
 				}
 				b_veteli = {
 				}
@@ -14544,16 +14544,16 @@ e_scandinavia = {
 				color={ 152 76 76 }
 				color2={ 255 255 255 }
 			
-					swedish = "Ule√•borg"
-					norse = "Ule√•borg"
-					norwegian = "Ule√•borg"
-					danish = "Ule√•borg"
+					swedish = "UleÂborg"
+					norse = "UleÂborg"
+					norwegian = "UleÂborg"
+					danish = "UleÂborg"
 				
 				b_oulu = {		#NOT NEW
-					swedish = "Ule√•borg"
-					norse = "Ule√•borg"
-					norwegian = "Ule√•borg"
-					danish = "Ule√•borg"
+					swedish = "UleÂborg"
+					norse = "UleÂborg"
+					norwegian = "UleÂborg"
+					danish = "UleÂborg"
 				}
 				b_kokkola = {
 					swedish = "Karleby"
@@ -14748,7 +14748,7 @@ e_scandinavia = {
 		color = { 255 125 69 }
 		color2={ 255 255 255 }
 		
-		capital = 279 # S√°pmi
+		capital = 279 # S·pmi
 		
 		culture = lappish
 		
@@ -14758,12 +14758,12 @@ e_scandinavia = {
 		catholic = 25
 		norse_pagan_reformed = 50 # Crusade target weight
 		
-		norse = Nor√∞rr√≠ki
+		norse = NorrrÌki
 		swedish = Nordarike
 		norwegian = Nordarike
 		danish = Nordarike
 		finnish = Lappi
-		lappish = S√°pmi
+		lappish = S·pmi
 		
 		# Creation/usurpation trigger
 		allow = {
@@ -14779,21 +14779,21 @@ e_scandinavia = {
 			color={ 231 64 32 }
 			color2={ 255 255 255 }
 			
-			capital = 280 # V√§sterbotten
+			capital = 280 # V‰sterbotten
 			
 			norse = Norrland
 			norwegian = Norrland
 			swedish = Norrland
 			danish = Norrland
 			finnish=Lappi
-			lappish=S√°pmi
+			lappish=S·pmi
 
 			c_lappland = {
 				color={ 255 70 70 }
 				color2={ 255 255 255 }
 				
 				finnish=Lappi
-				lappish=S√°pmi
+				lappish=S·pmi
 				
 				b_lycksele = {
 				}
@@ -14818,12 +14818,12 @@ e_scandinavia = {
 				color={ 240 95 95 }
 				color2={ 255 255 255 }
 				
-				swedish = "V√§sterbotten"
+				swedish = "V‰sterbotten"
 				norwegian = "Vesterbotten"
 				danish = "Vesterbotten"
 				norse = "Vesterbotn"
-				finnish=L√§nsipohja
-				lappish=L√§nsipohja
+				finnish=L‰nsipohja
+				lappish=L‰nsipohja
 				
 				b_umea = {
 					finnish=Uumaja
@@ -14834,8 +14834,8 @@ e_scandinavia = {
 				b_skelleftea = {
 				}
 				b_lovanger = {
-					norwegian = "L√∏v√•nger"
-					danish = "L√∏v√•nger"
+					norwegian = "L¯vÂnger"
+					danish = "L¯vÂnger"
 				}
 				b_pitea = {
 				}
@@ -14854,13 +14854,13 @@ e_scandinavia = {
 			
 			capital = 391 # Nordland
 			
-			lappish=Finnm√°rku
+			lappish=Finnm·rku
 			
 			c_finnmark = {
 				color={ 190 45 45 }
 				color2={ 255 255 255 }
 				
-				lappish=Finnm√°rku
+				lappish=Finnm·rku
 				
 				b_varghoeya = {
 				}
@@ -15096,8 +15096,8 @@ e_scandinavia = {
 				color={ 170 50 50 }
 				color2={ 255 255 255 }
 				
-				swedish = L√§√§ne
-				danish = L√§√§ne
+				swedish = L‰‰ne
+				danish = L‰‰ne
 				
 				b_livs = {		#placeholder
 				}
@@ -15107,7 +15107,7 @@ e_scandinavia = {
 					german = Leal
 				}
 				b_parnu = {
-					ugricbaltic = P√§rnu
+					ugricbaltic = P‰rnu
 					german = Pernau
 					polish = Parnawa
 					lithuanian = Pernu
@@ -15128,11 +15128,11 @@ e_scandinavia = {
 				color={ 101 48 48 }
 				color2={ 255 255 255 }
 				
-				swedish = "√ñsel"
-				norse = "√ñsel"
-				danish = "√òsel"
-				norwegian = "√òsel"
-				german = "√ñsel"
+				swedish = "÷sel"
+				norse = "÷sel"
+				danish = "ÿsel"
+				norwegian = "ÿsel"
+				german = "÷sel"
 
 				holy_site = finnish_pagan
 				holy_site = finnish_pagan_reformed
@@ -15145,11 +15145,11 @@ e_scandinavia = {
 					german = "Arensburg"
 				}
 				b_hiiumaa = {
-					swedish = "Dag√∂"
-					norse = "Dag√∂"
-					danish = "Dag√∏"
-					norwegian = "Dag√∏"
-					german = "Dag√∂"
+					swedish = "Dagˆ"
+					norse = "Dagˆ"
+					danish = "Dag¯"
+					norwegian = "Dag¯"
+					german = "Dagˆ"
 				}
 				b_muhu = {
 					swedish = "Moon"
@@ -15205,13 +15205,13 @@ e_scandinavia = {
 					norse = "Yxkull"
 					danish = "Yxkull"
 					norwegian = "Yxkull"
-					german = "√úxk√ºll"
-					ugricbaltic = Ik≈°kila
-					polish = Ik≈°kile
-					lithuanian = Ik≈°kile
+					german = "‹xk¸ll"
+					ugricbaltic = Ikökila
+					polish = Ikökile
+					lithuanian = Ikökile
 				}
 				b_wenden = {
-					ugricbaltic = V√µnnu
+					ugricbaltic = Vınnu
 					polish = Kies
 					lithuanian = Cesys
 				}
@@ -15228,8 +15228,8 @@ e_scandinavia = {
 					norwegian = "Lemsal"
 					ugricbaltic = Lemsalu
 					german = Lemsal
-					polish = Limba≈æi
-					lithuanian = Limba≈æiai
+					polish = Limbaûi
+					lithuanian = Limbaûiai
 				}
 				b_seswegen = {
 					ugricbaltic = Cesvaine
@@ -15274,8 +15274,8 @@ e_scandinavia = {
 				color={ 98 40 40 }
 				color2={ 255 255 255 }
 				
-				swedish = "J√§rvamaa"
-				danish = "J√§rvamaa"
+				swedish = "J‰rvamaa"
+				danish = "J‰rvamaa"
 				
 				b_viljandi = {
 				}
@@ -16091,10 +16091,10 @@ e_wendish_empire = {
 				color={ 142 142 142 }
 				color2={ 255 255 255 }
 				
-				danish = "Lyb√¶k"
-				swedish = "Lyb√§ck"
-				norwegian = "Lyb√¶k"
-				norse = "Lyb√¶ck"
+				danish = "LybÊk"
+				swedish = "Lyb‰ck"
+				norwegian = "LybÊk"
+				norse = "LybÊck"
 				pommeranian = "Liubice"
 				polish = "Liubice"
 				bohemian = "Liubice"
@@ -16102,10 +16102,10 @@ e_wendish_empire = {
 				old_saxon = "Liubice"
 				
 				b_lubeck = {
-					danish = "Lyb√¶k"
-					swedish = "Lyb√§ck"
-					norwegian = "Lyb√¶k"
-					norse = "Lyb√¶ck"
+					danish = "LybÊk"
+					swedish = "Lyb‰ck"
+					norwegian = "LybÊk"
+					norse = "LybÊck"
 					pommeranian = "Liubice"
 					polish = "Liubice"
 					bohemian = "Liubice"
@@ -16145,10 +16145,10 @@ e_wendish_empire = {
 				color={ 204 204 204 }
 				color2={ 255 255 255 }
 
-				pommeranian = Rastok√∫
+				pommeranian = Rastok˙
 				
 				b_rostock = {
-					pommeranian = Rastok√∫
+					pommeranian = Rastok˙
 				}
 				b_penzlin = {	
 					pommeranian = Pentzelin	
@@ -16190,7 +16190,7 @@ e_wendish_empire = {
 				b_treptow = {
 				}
 				b_friedland = {
-					pommeranian = Mir√≥w
+					pommeranian = MirÛw
 				}
 				b_templin = {
 				}
@@ -16240,7 +16240,7 @@ e_wendish_empire = {
 					pommeranian = Wologoszcz
 				}
 				b_usedom = {
-					pommeranian = Uznj√∂m
+					pommeranian = Uznjˆm
 				}
 				b_anklam = {	
 					pommeranian = Taglim			
@@ -16960,14 +16960,14 @@ e_wendish_empire = {
 					lithuanian = Krustpils
 				}
 				b_daugavpils = {
-					german = "D√ºnaburg"
+					german = "D¸naburg"
 					swedish = "Dynaborg"
 					norse = "Dynaborg"
 					danish = "Dynaborg"
 					norwegian = "Dynaborg"
-					finnish = "V√§in√§nlinna"
+					finnish = "V‰in‰nlinna"
 					russian = "Dvinsk"
-					ugricbaltic = V√§inalinn
+					ugricbaltic = V‰inalinn
 					polish = Dyneburg
 					lithuanian = Daugpilis
 				}
@@ -17240,7 +17240,7 @@ e_wendish_empire = {
                		color={ 197 112 13 }
                		color2={ 255 255 255 }
 					
-               		bohemian = "Ji≈æn√≠ Cechy"
+               		bohemian = "JiûnÌ Cechy"
                		pommeranian = "Jizni Cechy"
                		polish = "Jizni Cechy"
                		croatian = "Jizni Cechy"
@@ -17251,16 +17251,16 @@ e_wendish_empire = {
                 	ilmenian = "Jizni Cechy"
                 	severian = "Jizni Cechy"
                 	volhynian = "Jizni Cechy"
-                	german = "Sudb√∂hmen"
-                	norse = "Sudb√∂hmen"
-                	swedish = "Sudb√∂hmen"
-                	danish = "Sudb√∂hmen"
-                	norwegian = "Sudb√∂hmen"
-                	old_frankish = "Sudb√∂hmen"
-                	old_saxon = "Sudb√∂hmen"
-                	saxon = "Sudb√∂hmen"
-                	suebi = "Sudb√∂hmen"
-					slovieni = "Ji≈æn√≠ Cechy"
+                	german = "Sudbˆhmen"
+                	norse = "Sudbˆhmen"
+                	swedish = "Sudbˆhmen"
+                	danish = "Sudbˆhmen"
+                	norwegian = "Sudbˆhmen"
+                	old_frankish = "Sudbˆhmen"
+                	old_saxon = "Sudbˆhmen"
+                	saxon = "Sudbˆhmen"
+                	suebi = "Sudbˆhmen"
+					slovieni = "JiûnÌ Cechy"
                 
                 	b_prachen = {
                 	}
@@ -17269,12 +17269,12 @@ e_wendish_empire = {
                 	b_chynov = {
                 	}
                 	b_hohenfurth = {
-						bohemian = "Vy≈°≈°√≠ Brod"
-						slovieni = "Vy≈°≈°√≠ Brod"
+						bohemian = "VyööÌ Brod"
+						slovieni = "VyööÌ Brod"
                 	}
                 	b_rosenberg = {
-						bohemian = "Ro≈æmberk"
-						slovieni = "Ro≈æmberk"
+						bohemian = "Roûmberk"
+						slovieni = "Roûmberk"
                 	}
                 	b_budejovice = {
 						german = "Budweis"
@@ -17285,8 +17285,8 @@ e_wendish_empire = {
 						german = "Krumau"
                 	}
                 	b_goldenkron = {
-						bohemian = "Zlat√° Koruna"
-						slovieni = "Zlat√° Koruna"
+						bohemian = "Zlat· Koruna"
+						slovieni = "Zlat· Koruna"
                 	}
                 	b_resenberg = {}
             		}
@@ -17351,7 +17351,7 @@ e_wendish_empire = {
 						saxon = Kuttenberg
 						old_saxon = Kuttenberg
 						bohemian = "Kutna Hora"
-						slovieni = "Kutn√° Hora"
+						slovieni = "Kutn· Hora"
                 	}
                 	b_vysehrad = {
                 	}
@@ -17397,10 +17397,10 @@ e_wendish_empire = {
                 	color={ 200 104 38 }
             		color2={ 255 255 255 }
 				
-					german = "Gr√§tz"
+					german = "Gr‰tz"
                 
                 	b_hradeckralove = {
-						german = "Gr√§tz"
+						german = "Gr‰tz"
                 	}
 					b_kladsko = {
 						german = "Glatz"
@@ -17511,11 +17511,11 @@ e_wendish_empire = {
                 color={ 163 107 41 }
                	color2={ 255 255 255 }
                 
-				german = "Olm√ºtz"
+				german = "Olm¸tz"
 				polish = Olomuniec
 				
                 b_olomouc = {
-					german = "Olm√ºtz"
+					german = "Olm¸tz"
 					polish = Olomuniec
                 }
                 b_velehrad = {
@@ -17537,13 +17537,13 @@ e_wendish_empire = {
                	color={ 166 110 44 }
             	color2={ 255 255 255 }
                	
-				german = "Br√ºnn"
+				german = "Br¸nn"
 				
                 b_veligrad = {
 					slovieni = Velehrad
                 }
                 b_brno = {
-					german = "Br√ºnn"
+					german = "Br¸nn"
 				}
                 b_mikulcice = {
                 }
@@ -17960,10 +17960,10 @@ e_russia = {
 			}
 		}
 		
-		norse = K√∂nugar√∞r
-		swedish = K√∂nug√•rd
-		norwegian = K√∏nug√•rd
-		danish = K√∏nug√•rd
+		norse = Kˆnugarr
+		swedish = KˆnugÂrd
+		norwegian = K¯nugÂrd
+		danish = K¯nugÂrd
 		
 		d_kiev = {
 			color={ 129 187 125 }
@@ -17972,10 +17972,10 @@ e_russia = {
 			dignity = 10 # Counted as having 10 more counties than it does
 			capital = 547 # Kiev
 			
-			norse = K√∂nugar√∞r
-			swedish = K√∂nug√•rd
-			norwegian = K√∏nug√•rd
-			danish = K√∏nug√•rd
+			norse = Kˆnugarr
+			swedish = KˆnugÂrd
+			norwegian = K¯nugÂrd
+			danish = K¯nugÂrd
 					
 			pagan_coa = {
 				template = 0
@@ -18007,19 +18007,19 @@ e_russia = {
 				color={ 106 106 26 }
 				color2={ 255 255 255 }
 				
-				norse = K√∂nugar√∞r
-				swedish = K√∂nug√•rd
-				norwegian = K√∏nug√•rd
-				danish = K√∏nug√•rd
+				norse = Kˆnugarr
+				swedish = KˆnugÂrd
+				norwegian = K¯nugÂrd
+				danish = K¯nugÂrd
 
 				holy_site = slavic_pagan
 				holy_site = slavic_pagan_reformed
 				
 				b_kiev = {
-					norse = K√∂nugar√∞r
-					swedish = K√∂nug√•rd
-					norwegian = K√∏nug√•rd
-					danish = K√∏nug√•rd
+					norse = Kˆnugarr
+					swedish = KˆnugÂrd
+					norwegian = K¯nugÂrd
+					danish = K¯nugÂrd
 				}
 				b_zhytomyr = {
 				}
@@ -19013,7 +19013,7 @@ e_russia = {
 		baltic_pagan_reformed = 100 # Crusade target weight
 		
 		#mordvin = Mordvinia
-		norse = Gar√∞ariki
+		norse = Garariki
 		
 		culture = russian
 		
@@ -19138,10 +19138,10 @@ e_russia = {
 			
 			capital = 414 # Novgorod
 			
-			swedish = "Holmg√•rd"
-			norse = "Holmgar√∞r"
-			danish = "Holmg√•rd"
-			norwegian = "Holmg√•rd"
+			swedish = "HolmgÂrd"
+			norse = "Holmgarr"
+			danish = "HolmgÂrd"
+			norwegian = "HolmgÂrd"
 			ilmenian = "Ilmenia"
 			severian = "Ilmenia"
 			mordvin = "Ilmenia"
@@ -19191,10 +19191,10 @@ e_russia = {
 				color={ 149 166 106 }
 				color2={ 255 255 255 }
 				
-				swedish = "Holmg√•rd"
-				norse = "Holmgar√∞r"
-				danish = "Holmg√•rd"
-				norwegian = "Holmg√•rd"
+				swedish = "HolmgÂrd"
+				norse = "Holmgarr"
+				danish = "HolmgÂrd"
+				norwegian = "HolmgÂrd"
 						
 				holy_site = slavic_pagan
 				holy_site = slavic_pagan_reformed
@@ -19202,10 +19202,10 @@ e_russia = {
 				holy_site = finnish_pagan_reformed								
 
 				b_novgorod = {
-					swedish = "Holmg√•rd"
-					norse = "Holmgar√∞r"
-					danish = "Holmg√•rd"
-					norwegian = "Holmg√•rd"
+					swedish = "HolmgÂrd"
+					norse = "Holmgarr"
+					danish = "HolmgÂrd"
+					norwegian = "HolmgÂrd"
 				}
 				b_soltsy = {
 				}
@@ -19340,11 +19340,11 @@ e_russia = {
 					finnish = "Nevanlinna"
 				}
 				b_noteborg = {
-					swedish = "N√∂teborg"
-					norse = "N√∂teborg"
-					norwegian = "N√∏teborg"
-					danish = "N√∏teborg"
-					german = "Schl√ºsselburg"
+					swedish = "Nˆteborg"
+					norse = "Nˆteborg"
+					norwegian = "N¯teborg"
+					danish = "N¯teborg"
+					german = "Schl¸sselburg"
 					russian = "Oreshek"
 				}
 				b_kingisepp = {
@@ -21326,7 +21326,7 @@ e_tartaria = {
 		d_otuken = {
 			color = { 110 150 220 }
 			
-			capital = 1461 # √ñt√ºken
+			capital = 1461 # ÷t¸ken
 			
 			c_otuken = {
 				color = { 130 136 220 }
@@ -21782,8 +21782,8 @@ e_tartaria = {
 				color={ 120 120 250 }
 
 				b_barkul = {
-					turkish = "Bark√∂l"
-					uyghur = "Bark√∂l"
+					turkish = "Barkˆl"
+					uyghur = "Barkˆl"
 				}
 				b_khoid = {
 				}
@@ -23694,13 +23694,13 @@ e_idel_ural = {
 				color={ 103 118 58 }
 				color2={ 255 255 255 }
 				
-				finnish = "√Ñ√§ninen"
-				lappish = "√Ñ√§ninen"
-				ugricbaltic = "√Ñ√§ninen"
-				komi = "√Ñ√§ninen"
-				samoyed = "√Ñ√§ninen"
-				mordvin = "√Ñ√§ninen"
-				meshchera = "√Ñ√§ninen"
+				finnish = "ƒ‰ninen"
+				lappish = "ƒ‰ninen"
+				ugricbaltic = "ƒ‰ninen"
+				komi = "ƒ‰ninen"
+				samoyed = "ƒ‰ninen"
+				mordvin = "ƒ‰ninen"
+				meshchera = "ƒ‰ninen"
 				
 				b_solovetsky = {
 				}
@@ -24414,7 +24414,7 @@ e_turkestan = {
 			
 			capital = 1450 # Kumul
 			
-			tocharian = "Kror√§n"
+			tocharian = "Kror‰n"
 			han = "Xizhou"
 			
 			c_kumul = {
@@ -24429,7 +24429,7 @@ e_turkestan = {
 					han = "Yizhou"
 				}
 				b_yiwu = {
-					uyghur = "Arat√ºr√ºk"
+					uyghur = "Arat¸r¸k"
 				}
 				b_dahe = {
 				}
@@ -24470,7 +24470,7 @@ e_turkestan = {
 			c_loulan = {
 				color={ 190 180 25 }
 				
-				tocharian = "Kror√§n"
+				tocharian = "Kror‰n"
 				uyghur = "Qroran"
 				
 				b_loulan = {
@@ -24794,13 +24794,13 @@ e_turkestan = {
 			c_luntai = {
 				color={ 199 177 0 }
 				
-				uyghur = "√úr√ºmqi"
-				mongol = "√úr√ºmqi"
+				uyghur = "‹r¸mqi"
+				mongol = "‹r¸mqi"
 				tocharian = "Urabo"
 				
 				b_luntai = {
-					uyghur = "√úr√ºmqi"
-					mongol = "√úr√ºmqi"
+					uyghur = "‹r¸mqi"
+					mongol = "‹r¸mqi"
 					tocharian = "Urabo"
 				}
 				b_fukang = {
@@ -27786,14 +27786,14 @@ e_carpathia = {
 				croatian = Pecuh
 				serbian = Pecuj
 				bosnian = Pecuh
-				german = F√ºnfkirchen
-				bohemian = Petikostel√≠
+				german = F¸nfkirchen
+				bohemian = PetikostelÌ
 				carantanian = Patkostolie
 				slovieni = Patkostolie
 				
 				b_pecs = { 
 					slovieni = Patkostolie
-					bohemian = Petikostel√≠
+					bohemian = PetikostelÌ
 					german = Funfkirchen
 					croatian = Pecuh
 				}
@@ -27803,16 +27803,16 @@ e_carpathia = {
 					german = Kollotschau
 				}
 				b_mohacs = { 
-					slovieni = Moh√°c
-					bohemian = Moh√°c
+					slovieni = Moh·c
+					bohemian = Moh·c
 					german = Mohatsch
-					croatian = Moh√°c
+					croatian = Moh·c
 				}
 				b_sasd = { 
-					slovieni = ≈†a≈°d
-					bohemian = ≈†a≈°d
+					slovieni = äaöd
+					bohemian = äaöd
 					german = Schaschd
-					croatian = ≈†ardin
+					croatian = äardin
 				}
 				b_pecsvarad = { 
 					slovieni = Pecvar
@@ -27821,14 +27821,14 @@ e_carpathia = {
 					croatian = Pecvar
 				}
 				b_siklos = { 
-					slovieni = ≈†iklo≈°
-					bohemian = ≈†iklo≈°
-					croatian = ≈†iklo≈°
+					slovieni = äikloö
+					bohemian = äikloö
+					croatian = äikloö
 					german = Sieglos
 				}
 				b_szentlorinc = { 
-					slovieni = "Svat√Ω Vavrinec"
-					bohemian = "Svat√Ω Vavrinec"
+					slovieni = "Svat˝ Vavrinec"
+					bohemian = "Svat˝ Vavrinec"
 					croatian = Selurinac
 					german = "Sankt Laurenz"
 				}
@@ -27842,17 +27842,17 @@ e_carpathia = {
 				color={ 189 74 74 }
 				color2={ 255 255 255 }
 				
-				croatian = ≈†omod
+				croatian = äomod
 				german = Schomodei
-				bohemian = ≈†omod
-				slovieni = ≈†omod
+				bohemian = äomod
+				slovieni = äomod
 				hungarian = Somogy
 				
 				b_szekezfehervar = { 
-					croatian = ≈†omod
+					croatian = äomod
 					german = Schomodei
-					bohemian = ≈†omod
-					slovieni = ≈†omod
+					bohemian = äomod
+					slovieni = äomod
 					hungarian = Somogy
 				}
 				b_csurgo = { 
@@ -27860,8 +27860,8 @@ e_carpathia = {
 					bohemian = Curgov
 				}
 				b_kaposvar = { 
-					slovieni = Kapo≈°v√°r
-					bohemian = Kapo≈°v√°r
+					slovieni = Kapoöv·r
+					bohemian = Kapoöv·r
 					german= Kopisch
 				}
 				b_szigetvar = { 
@@ -27895,8 +27895,8 @@ e_carpathia = {
 				croatian = Zelezna
 				bosnian = Zelezna
 				carantanian = Zelezna
-				bohemian = ≈Ωelezna
-				slovieni = ≈Ωelezna
+				bohemian = éelezna
+				slovieni = éelezna
 				hungarian = Vas
 				
 				b_szombathely = { 
@@ -27904,16 +27904,16 @@ e_carpathia = {
 					german = Steinamanger
 				}
 				b_szentgotthard = { 
-					slovieni = "Svat√Ω Gothard"
-					bohemian = "Svat√Ω Gothard"
-					carantanian = Mono≈°ter
+					slovieni = "Svat˝ Gothard"
+					bohemian = "Svat˝ Gothard"
+					carantanian = Monoöter
 					german = "Sankt Gotthard"
 				}
 				b_vasvar = { 
-					slovieni = "≈Ωelezn√Ω hrad"
-					bohemian = "≈Ωelezn√Ω hrad"
+					slovieni = "éelezn˝ hrad"
+					bohemian = "éelezn˝ hrad"
 					german = Eisenburg
-					carantanian = ≈Ωeleznograd
+					carantanian = éeleznograd
 				}
 				b_sarvar = {
 					german = Kotenburg
@@ -27927,11 +27927,11 @@ e_carpathia = {
 				b_koszeg = { 
 					slovieni = Kysek
 					bohemian = Kysek
-					german = G√ºns
+					german = G¸ns
 					croatian = Kiseg
 				}
 				b_nemetujvar = { 
-					german = G√ºssing
+					german = G¸ssing
 					croatian = Novigrad
 				}
 			}
@@ -27943,8 +27943,8 @@ e_carpathia = {
 				croatian = "Stolni Belegrad"
 				bosnian = "Stolni Belegrad"
 				carantanian = "Stolni Belegrad"
-				bohemian = "Stolicn√Ω Belehrad"
-				slovieni = "Stolicn√Ω Belehrad"
+				bohemian = "Stolicn˝ Belehrad"
+				slovieni = "Stolicn˝ Belehrad"
 
 				b_sarbogard = {
 					german = Bochart
@@ -27990,19 +27990,19 @@ e_carpathia = {
 				color={ 211 63 63 }
 				color2={ 255 255 255 }
 				
-				german = √ñdenburg
-				slovieni = ≈†opron
-				bohemian = ≈†opron
+				german = ÷denburg
+				slovieni = äopron
+				bohemian = äopron
 
 				b_sopron = { 
-					slovieni = ≈†opron
-					bohemian = ≈†opron
-					german = √ñdenburg
+					slovieni = äopron
+					bohemian = äopron
+					german = ÷denburg
 				}
 				b_gyor = {
-					slovieni = R√°b
+					slovieni = R·b
 					german = Raab
-					bohemian = R√°b
+					bohemian = R·b
 				}
 				b_csorna = {
 					german = Gschirnau
@@ -28014,19 +28014,19 @@ e_carpathia = {
 					german = Schapring
 				}
 				b_kapuvar = {
-					slovieni = Kapuv√°r
-					bohemian = Kapuv√°r
+					slovieni = Kapuv·r
+					bohemian = Kapuv·r
 					german = Kobrunn
 				}
 				b_kismarton = {
-					slovieni = ≈Ωelezno
-					bohemian = ≈Ωelezno
+					slovieni = éelezno
+					bohemian = éelezno
 					german = Eisenstadt
-					croatian = ≈Ωeljezno
+					croatian = éeljezno
 				}
 				b_nagymarton = {
 					german = Mattersburg
-					croatian = Mater≈°tof
+					croatian = Materötof
 				}
 			}
 			c_esztergom = {
@@ -28053,9 +28053,9 @@ e_carpathia = {
 					polish = Ostrzyhom
 				}
 				b_komarom = { 
-					slovieni = Kom√°rno
-					bohemian = Kom√°rno
-					hungarian = Kom√°rom
+					slovieni = Kom·rno
+					bohemian = Kom·rno
+					hungarian = Kom·rom
 					german = Komorn
 				}
 				b_kakath = { 
@@ -28072,8 +28072,8 @@ e_carpathia = {
 					bohemian = "Zemianska Olca"
 				}
 				b_ogylla = { 
-					slovieni = "Star√° Dala"
-					bohemian = "Star√° Dala"
+					slovieni = "Star· Dala"
+					bohemian = "Star· Dala"
 					german = Altdala
 					hungarian = Ogyalla
 				}
@@ -28084,14 +28084,14 @@ e_carpathia = {
 
 				german = Pressburg
 				hungarian = Pozsony
-				bohemian = Pre≈°purk
-				slovieni = Pre≈°porok
+				bohemian = Preöpurk
+				slovieni = Preöporok
 				
 				b_pressburg = { 
 					german = Pressburg
 					hungarian = Pozsony
-					bohemian = Pre≈°purk
-					slovieni = Pre≈°porok
+					bohemian = Preöpurk
+					slovieni = Preöporok
 				}
 				b_nagyszombat = { 
 					slovieni = Trnava
@@ -28099,9 +28099,9 @@ e_carpathia = {
 					german = Tyrnau
 				}
 				b_bazin = { 
-					slovieni = Dev√≠n
+					slovieni = DevÌn
 					bohemian = Devin
-					hungarian = D√©v√©ny
+					hungarian = DÈvÈny
 					german = Theben
 				}
 				b_modor = { 
@@ -28110,13 +28110,13 @@ e_carpathia = {
 					german = Modern
 				}
 				b_szentgyorgy = { 
-					slovieni = "Svat√Ω Jur"
-					bohemian = "Svat√Ω Jur"
+					slovieni = "Svat˝ Jur"
+					bohemian = "Svat˝ Jur"
 					german = "Sankt Georgen"
 				}
 				b_dunaszerdahely = { 
-					slovieni = "Dunajsk√° Streda"
-					bohemian = "Dunajsk√° Streda"
+					slovieni = "Dunajsk· Streda"
+					bohemian = "Dunajsk· Streda"
 					german = Niedermarkt
 				}
 				b_galanta = { 
@@ -28125,8 +28125,8 @@ e_carpathia = {
 					german = Gallandau
 				}
 				b_somorja = { 
-					slovieni = ≈†amor√≠n
-					bohemian = ≈†amor√≠n
+					slovieni = äamorÌn
+					bohemian = äamorÌn
 					german = Sommerein
 				}
 			}
@@ -28166,13 +28166,13 @@ e_carpathia = {
 					german = Topoltschan
 				}
 				b_stbenedek = { 
-					slovieni = "Hronsk√Ω Benadik"
-					bohemian = "Hronsk√Ω Benadik"
+					slovieni = "Hronsk˝ Benadik"
+					bohemian = "Hronsk˝ Benadik"
 					german = "Sankt Benedikt"
 				}
 				b_nagysurany = { 
-					slovieni = "Velk√© ≈†urany"
-					bohemian = "Velk√© ≈†urany"
+					slovieni = "VelkÈ äurany"
+					bohemian = "VelkÈ äurany"
 					german = Schuran
 				}
 				b_galgoc = { 
@@ -28181,13 +28181,13 @@ e_carpathia = {
 					german = Freistadt
 				}
 				b_zabokreky = { 
-					slovieni = ≈Ωabokreky
-					bohemian = ≈Ωabokreky
-					hungarian = Zs√°mbokr√©t
+					slovieni = éabokreky
+					bohemian = éabokreky
+					hungarian = Zs·mbokrÈt
 				}
 				b_postyen = { 
-					slovieni = Pie≈°tany
-					bohemian = Pie≈°tany
+					slovieni = Pieötany
+					bohemian = Pieötany
 					german = Pistyan
 				}
 				b_preuigan = { 
@@ -28201,21 +28201,21 @@ e_carpathia = {
 				color2={ 255 255 255 }
 
 				german = Trentschin
-				bohemian = Trenc√≠n
-				slovieni = Trenc√≠n
+				bohemian = TrencÌn
+				slovieni = TrencÌn
 				hungarian = Trencsen
 				polish = Trenczyn
 				
 				b_trencsen = { 
 					german = Trentschin
-					bohemian = Trenc√≠n
-					slovieni = Trenc√≠n
+					bohemian = TrencÌn
+					slovieni = TrencÌn
 					hungarian = Trencsen
 					polish = Trenczyn
 				}
 				b_zilina = { 
-					slovieni = ≈Ωilina
-					bohemian = ≈Ωilina
+					slovieni = éilina
+					bohemian = éilina
 					german = Sillein
 					hungarian = Zsolna
 				}
@@ -28225,10 +28225,10 @@ e_carpathia = {
 					german = Turz
 				}
 				b_ban = { 
-					slovieni = Vy≈°ehrad
-					bohemian = Vy≈°ehrad
+					slovieni = Vyöehrad
+					bohemian = Vyöehrad
 					german = Plintenburg
-					hungarian = Visegr√°d
+					hungarian = Visegr·d
 				}
 				b_illava = { 
 					slovieni = Ilava
@@ -28236,10 +28236,10 @@ e_carpathia = {
 					german = Illau
 				}
 				b_povazskabystrica = { 
-					slovieni = "Pova≈æsk√° Bystrica"
-					bohemian = "Pova≈æsk√° Bystrica"
+					slovieni = "Povaûsk· Bystrica"
+					bohemian = "Povaûsk· Bystrica"
 					german = Waagbistritz
-					hungarian = V√°gbeszterce
+					hungarian = V·gbeszterce
 				}
 				b_congsberg = { 
 					slovieni = Beckov
@@ -28260,14 +28260,14 @@ e_carpathia = {
 				german = Gemer
 				bohemian = Gemer
 				slovieni = Gemer
-				hungarian = G√∂m√∂r
+				hungarian = Gˆmˆr
 				polish = Gemer
 				
 				b_gomor = { 
 					german = Gemer
 					bohemian = Gemer
 					slovieni = Gemer
-					hungarian = G√∂m√∂r
+					hungarian = Gˆmˆr
 					polish = Gemer
 				}
 				b_losonc = { 
@@ -28276,34 +28276,34 @@ e_carpathia = {
 					german = Lizenz
 				}
 				b_dobsina = { 
-					slovieni = Dob≈°in√°
-					bohemian = Dob≈°in√°
+					slovieni = Doböin·
+					bohemian = Doböin·
 					german = Dobschau
 				}
 				b_rozsnyo = { 
-					slovieni = Ro≈ænava
-					bohemian = Ro≈ænava
+					slovieni = Roûnava
+					bohemian = Roûnava
 					german = Rosenau
 				}
 				b_balassagyarmat = { 
-					slovieni = "Bal√°≈æske Darmoty"
-					bohemian = "Bal√°≈æske Darmoty"
+					slovieni = "Bal·ûske Darmoty"
+					bohemian = "Bal·ûske Darmoty"
 					german = Jahrmarkt
 				}
 				b_jolsva = { 
-					slovieni = Jel≈°ava
-					bohemian = Jel≈°ava
+					slovieni = Jelöava
+					bohemian = Jelöava
 					german = Eltsch
 				}
 				b_nagyroce = { 
-					slovieni = "Velk√° Rev√∫ca"
-					bohemian = "Velk√° Rev√∫ca"
+					slovieni = "Velk· Rev˙ca"
+					bohemian = "Velk· Rev˙ca"
 					german = Grossrauschenbach
 				}
 				b_nyustya = { 
 					slovieni = Zvolen
 					bohemian = Zvolen
-					hungarian = Z√≥lyom
+					hungarian = ZÛlyom
 					german =  Altsohl
 				}
 			}
@@ -28325,47 +28325,47 @@ e_carpathia = {
 					polish = Orawa
 				}
 				b_nameszto = { 
-					slovieni = N√°mestovo
-					bohemian = N√°mestovo
+					slovieni = N·mestovo
+					bohemian = N·mestovo
 					polish = Namiestowo
-					hungarian = N√°meszto
+					hungarian = N·meszto
 				}
 				b_liptovskymikulas = { 
-					slovieni = "Liptovsk√Ω Mikul√°≈°"
-					bohemian = "Liptovsk√Ω Mikul√°≈°"
+					slovieni = "Liptovsk˝ Mikul·ö"
+					bohemian = "Liptovsk˝ Mikul·ö"
 					polish = "Liptowski Mikulasz"
 					german = "Liptau Nikolaus"
 					hungarian = Liptoszentmiklos
 				}
 				b_zolyom = { 
-					slovieni = "Doln√Ω Kub√≠n"
-					bohemian = "Doln√Ω Kub√≠n"
-					hungarian = Als√≥kubin
+					slovieni = "Doln˝ KubÌn"
+					bohemian = "Doln˝ KubÌn"
+					hungarian = AlsÛkubin
 					german = Unterkubin
 				}
 				b_trsztena = { 
-					slovieni = Trsten√°
-					bohemian = Trsten√°
+					slovieni = Trsten·
+					bohemian = Trsten·
 					polish = Trzciana
 					hungarian = Trsztena
 					german = Bingenstadt
 				}
 				b_turdossin = { 
-					slovieni = Tvrdo≈°√≠n
-					bohemian = Tvrdo≈°√≠n
+					slovieni = TvrdoöÌn
+					bohemian = TvrdoöÌn
 					hungarian = Turdossin
 					german = Turdoschin
 					polish = Twardoszyn
 				}
 				b_nemetlipcse = { 
-					slovieni = "Nemeck√° Lupca"
-					bohemian = "Nemeck√° Lupca"
+					slovieni = "Nemeck· Lupca"
+					bohemian = "Nemeck· Lupca"
 					german = Deutschliptsch
-					hungarian = N√©metlipcse
+					hungarian = NÈmetlipcse
 				}
 				b_rozsahegy = { 
-					slovieni = Ru≈æomberok
-					bohemian = Ru≈æomberok
+					slovieni = Ruûomberok
+					bohemian = Ruûomberok
 					german = Rosenberg
 					hungarian = Rozsahegy
 					polish = Ruzomberk
@@ -28378,36 +28378,36 @@ e_carpathia = {
 			
 			capital = 538 # Abauj
 			
-			croatian = U≈ægorod
+			croatian = Uûgorod
 			german = Ungwar
-			bohemian = U≈æhorod
-			slovieni = U≈æhorod
-			hungarian = Ungv√°r
+			bohemian = Uûhorod
+			slovieni = Uûhorod
+			hungarian = Ungv·r
 			polish = Uzhorod
 			
-			c_saris = { # "Spi≈°" in-game
+			c_saris = { # "Spiö" in-game
 				color={ 158 17 17 }
 				color2={ 255 255 255 }
 				
 				german = Zips
-				bohemian = Spi≈°
-				slovieni = Spi≈°
+				bohemian = Spiö
+				slovieni = Spiö
 				hungarian = Szepes
 				polish = Spisz
 				
 				b_saris = { 
 					german = Zips
-					bohemian = Spi≈°
-					slovieni = Spi≈°
+					bohemian = Spiö
+					slovieni = Spiö
 					hungarian = Szepes
 					polish = Spisz
 				}
 				b_bartfa = { 
 					slovieni = Bardejov
 					bohemian = Bardejov
-					polish = Bardej√≥w
+					polish = BardejÛw
 					german = Bartfeld
-					hungarian = B√°rtfa
+					hungarian = B·rtfa
 				}
 				b_kisszeben = { 
 					slovieni = Sabinov
@@ -28416,32 +28416,32 @@ e_carpathia = {
 					hungarian = Kisszeben
 				}
 				b_eperjes = { 
-					slovieni = Pre≈°ov
-					bohemian = Pre≈°ov
+					slovieni = Preöov
+					bohemian = Preöov
 					german = Eperies
 					hungarian = Eperjes
-					polish = Presz√≥w
+					polish = PreszÛw
 				}
 				b_scyuidnyk = { 
-					slovieni = Svidn√≠k
-					bohemian = Svidn√≠k
+					slovieni = SvidnÌk
+					bohemian = SvidnÌk
 					german = Oberswidnik
-					hungarian = Felsov√≠zkoz
+					hungarian = FelsovÌzkoz
 				}
 				b_giralth = { 
 					slovieni = Giraltovce
 					bohemian = Giraltovce
-					hungarian = Gir√°lt
+					hungarian = Gir·lt
 				}
 				b_hethars = { 
 					slovieni = Lipany
 					bohemian = Lipany
-					hungarian = H√©th√°rs
+					hungarian = HÈth·rs
 					german = Siebenlinden
 				}
 				b_lemesany = { 
-					slovieni = Leme≈°any
-					bohemian = Leme≈°any
+					slovieni = Lemeöany
+					bohemian = Lemeöany
 					hungarian = Lemes
 				}
 			}
@@ -28461,18 +28461,18 @@ e_carpathia = {
 					hungarian = Bereg
 				}
 				b_perecseny = { 
-					slovieni = Perec√≠n
+					slovieni = PerecÌn
 				}
 				b_munkacs = { 
 					slovieni = Mukacevo
 					german = Munkatsch
 				}
 				b_ungvar = { 
-					slovieni = U≈æhorod
+					slovieni = Uûhorod
 					german = Ungwar
 				}
 				b_ilosva = { 
-					slovieni = Ir≈°ava
+					slovieni = Iröava
 				}
 				b_szolyva = { 
 					slovieni = Svalava
@@ -28481,7 +28481,7 @@ e_carpathia = {
 					slovieni = Sobrance
 				}
 				b_kapos = { 
-					slovieni = Kapo≈°
+					slovieni = Kapoö
 				}
 			}
 			c_abauj = {
@@ -28500,16 +28500,16 @@ e_carpathia = {
 					hungarian = Abauj
 				}
 				b_satoraljaujhely = { 
-					slovieni = "Nov√© Mesto pod ≈†iatrom"
-					bohemian = "Nov√© Mesto pod ≈†iatrom"
+					slovieni = "NovÈ Mesto pod äiatrom"
+					bohemian = "NovÈ Mesto pod äiatrom"
 				}
 				b_kassa = { 
-					slovieni = Ko≈°ice
-					bohemian = Ko≈°ice
+					slovieni = Koöice
+					bohemian = Koöice
 					polish = Koszyce
 					hungarian = Kassa
 					german = Kaschau
-					croatian = Ka≈°ava
+					croatian = Kaöava
 				}
 				b_szikszo = { 
 					slovieni = Siksov
@@ -28528,8 +28528,8 @@ e_carpathia = {
 					german = Sepschi
 				}
 				b_sarospatak = { 
-					slovieni = Trebi≈°ov
-					bohemian = Trebi≈°ov
+					slovieni = Trebiöov
+					bohemian = Trebiöov
 					german = Trebischau
 					hungarian = Toketerebes
 				}
@@ -28543,16 +28543,16 @@ e_carpathia = {
 				color2={ 255 255 255 }
 				
 				german = Maramuresch
-				bohemian = Marmaro≈°
-				slovieni = Marmaro≈°
-				hungarian = M√°ramaros
+				bohemian = Marmaroö
+				slovieni = Marmaroö
+				hungarian = M·ramaros
 				
 				b_maramarossziget = { 
-					slovieni = "Marmaro≈°sk√° Sihot"
+					slovieni = "Marmaroösk· Sihot"
 					german = Marmaroschsiget
 				}
 				b_nagybanya = { 
-					slovieni = "Velk√° Bana"
+					slovieni = "Velk· Bana"
 					german = Neustadt
 				}
 				b_nagykaroly = { 
@@ -28579,9 +28579,9 @@ e_carpathia = {
 			capital = 522 # Pest
 			
 			polish = Peszt
-			slovieni = Pe≈°t
-			bohemian = Pe≈°t
-			serbian = Pe≈°ta
+			slovieni = Peöt
+			bohemian = Peöt
+			serbian = Peöta
 			german = Pest
 			
 			c_heves = {
@@ -28589,25 +28589,25 @@ e_carpathia = {
 				color2={ 255 255 255 }
 				
 				german = Hewesch
-				slovieni = Heve≈°
-				bohemian = Heve≈°
+				slovieni = Heveö
+				bohemian = Heveö
 				hungarian = Heves
 
 				b_heves = { 
 					german = Hewesch
-					slovieni = Heve≈°
-					bohemian = Heve≈°
+					slovieni = Heveö
+					bohemian = Heveö
 					hungarian = Heves
 				}
 				b_eger = { 
-					slovieni = J√°ger
+					slovieni = J·ger
 					german = Erlau
 				}
 				b_gyongyos = {
 					german = Gengess
 				}
 				b_miskolc = { 
-					slovieni = Mi≈°kovec
+					slovieni = Miökovec
 					german = Mischkolz
 				}
 				b_petervasara = {
@@ -28624,17 +28624,17 @@ e_carpathia = {
 				color2={ 255 255 255 }
 				
 				german = Pest
-				slovieni = Pe≈°t
-				bohemian = Pe≈°t
+				slovieni = Peöt
+				bohemian = Peöt
 				hungarian = Pest
-				serbian = Pe≈°ta
+				serbian = Peöta
 
 				b_pest = {
 					german = Pest
-					slovieni = Pe≈°t
-					bohemian = Pe≈°t
+					slovieni = Peöt
+					bohemian = Peöt
 					hungarian = Pest
-					serbian = Pe≈°ta
+					serbian = Peöta
 				}
 				b_vac = {
 				}
@@ -28656,9 +28656,9 @@ e_carpathia = {
 				color2={ 255 255 255 }
 				
 				german = Tschanad
-				slovieni = Can√°d
-				bohemian = Can√°d
-				hungarian = Csan√°d
+				slovieni = Can·d
+				bohemian = Can·d
+				hungarian = Csan·d
 
 				b_csanad = {
 				}
@@ -28691,7 +28691,7 @@ e_carpathia = {
 				german = Szeklerland
 				bohemian = Sikulsko
 				slovieni = Sikulsko
-				hungarian = Sz√©kelyfold
+				hungarian = SzÈkelyfold
 				
 				b_csik = {
 				}
@@ -28772,8 +28772,8 @@ e_carpathia = {
 			german = Temesch
 			romanian = Timis
 			serbian = Tamis
-			slovieni = Tami≈°
-			bohemian = Tami≈°
+			slovieni = Tamiö
+			bohemian = Tamiö
 			
 			c_temes = {
 				color={ 153 127 64 }
@@ -28803,7 +28803,7 @@ e_carpathia = {
 				color={ 156 130 67 }
 				color2={ 255 255 255 }
 
-				hungarian = B√°cs
+				hungarian = B·cs
 				german = Batsch
 				bohemian = Bac
 				slovieni = Bac
@@ -30344,8 +30344,8 @@ e_france = {
 		
 		breton = Breizh
 		norse = Bertangaland
-		welsh = Arym√¥r
-		irish = Bhriot√°in
+		welsh = ArymÙr
+		irish = Bhriot·in
 		frankish = Bretagne
 		roman = Armorica
 		
@@ -30419,14 +30419,14 @@ e_france = {
 					breton = "Sant-Mikael"
 				}
 				b_st_malo = {
-					breton = "Sant-Malo√π"
+					breton = "Sant-Malo˘"
 				}
 				b_dol = {
 				}
 				b_dinan = {
 				}
 				b_st_meen = {
-					breton = "Sant-M√©en"
+					breton = "Sant-MÈen"
 				}
 				b_porhoet = {
 				}
@@ -30535,7 +30535,7 @@ e_france = {
 				color={ 140 30 13 }
 				color2={ 255 255 255 }
 
-				breton = Bro√´rec
+				breton = BroÎrec
 				welsh = Guened
 				
 				b_vannes = {
@@ -30592,7 +30592,7 @@ e_france = {
 				b_monkontour = {
 				}
 				b_peran = {
-					breton = "Sant-P√™ran"
+					breton = "Sant-PÍran"
 				}
 				b_loudeac = {
 				}
@@ -30618,7 +30618,7 @@ e_france = {
 				b_plougonven = {
 				}
 				b_plourivo = {
-					breton = "Plourivo√π"
+					breton = "Plourivo˘"
 				}
 				b_lannion = {
 				}
@@ -30774,7 +30774,7 @@ e_france = {
 				b_monthey = {
 				}
 				b_aigle = {
-					german = "√Ñlen"
+					german = "ƒlen"
 				}
 				b_martigny = {
 				}
@@ -30794,7 +30794,7 @@ e_france = {
 				italian = "Ginevresi"
 				
 				b_geneve = {
-					frankish = "Gen√®ve"
+					frankish = "GenËve"
 					german = "Genf"
 					italian = "Ginvera"
 				}
@@ -31136,10 +31136,10 @@ e_france = {
 					german = "Delsberg"
 				}
 				b_moutier = {
-					german = "M√ºnster-im-Grosstal"
+					german = "M¸nster-im-Grosstal"
 				}
 				b_basel = {
-					frankish = "B√¢le"
+					frankish = "B‚le"
 				}
 				b_solothurn = {
 					frankish = "Soleure"
@@ -31159,7 +31159,7 @@ e_france = {
 					german = "Ifferten"
 				}
 				b_romainmotier = {
-					german = "Welschm√ºnster"
+					german = "Welschm¸nster"
 				}
 				b_gruyere = {
 					german = "Greyers"
@@ -31373,11 +31373,11 @@ e_spain = {
 				color = { 234 236 29 }
 				color2={ 255 255 255 }
 
-				visigothic = "M√©rida"
-				basque = "M√©rida"
-				castillan = "M√©rida"
-				catalan = "M√©rida"
-				portuguese = "M√©rida"
+				visigothic = "MÈrida"
+				basque = "MÈrida"
+				castillan = "MÈrida"
+				catalan = "MÈrida"
+				portuguese = "MÈrida"
 				
 				b_jerezdeloscaballeros = {
 				}
@@ -32504,7 +32504,7 @@ e_spain = {
 	
 	k_spanish_galicia = {
 		color={ 255 224 94 }
-		capital = 156 # Coru√±a
+		capital = 156 # CoruÒa
 		
 		culture = portuguese
 		
@@ -33499,7 +33499,7 @@ e_arabia = {
 				b_sharjah = {
 				}
 			}
-			c_hajar = { # Suhar/Suh√°r
+			c_hajar = { # Suhar/Suh·r
 				color={ 98 201 7 }
 				color2={ 255 255 255 }
 				
@@ -38601,7 +38601,7 @@ e_britannia = {
 				}
 				b_london = {
 					used_for_dynasty_names = no
-					norse=Lund√∫nir
+					norse=Lund˙nir
 				}
 				b_st_pauls = {
 				}
@@ -39116,7 +39116,7 @@ e_britannia = {
 				color2={ 255 255 255 }
 				
 				b_aberffraw = {
-					norwegian = Ongulls√∏y
+					norwegian = Ongulls¯y
 					english = Anglesey
 					saxon = Anglesey
 				}
@@ -39286,7 +39286,7 @@ e_britannia = {
 				}
 				b_st_davids = {
 					welsh = Tyddewi
-					norwegian = "Rams√∏y"
+					norwegian = "Rams¯y"
 				}
 				b_penycwm = {
 				}
@@ -39509,10 +39509,10 @@ e_britannia = {
 				irish = "Ellan Mhannin"
 				
 				b_peel = {
-					norwegian = "P√•l√∏"
-					danish = "P√•l√∏"
-					swedish = "P√•l√∏"
-					norse = "P√•l√∏"
+					norwegian = "PÂl¯"
+					danish = "PÂl¯"
+					swedish = "PÂl¯"
+					norse = "PÂl¯"
 					pictish = "Pirtinsee"
 					welsh = "Porth Ynys"
 					irish = "Purt ny h-Inshey"
@@ -39535,25 +39535,25 @@ e_britannia = {
 				b_kirk_michael = {
 					pictish = "Icluasc Mihagal"
 					welsh = "Eglwys Mihangel"
-					irish = "Cill Miche√°l"
+					irish = "Cill Miche·l"
 				}
 				b_sulby = {
 					pictish = "Drauuglan"
 					welsh = "Drywglyn"
-					irish = "Dru√≠gleann"
-					norwegian = "S√µlabyr"
-					danish = "S√µlabyr"
-					swedish = "S√µlabyr"
+					irish = "DruÌgleann"
+					norwegian = "Sılabyr"
+					danish = "Sılabyr"
+					swedish = "Sılabyr"
 				}
 				b_inis_patraic = {
 					pictish = "Inees Pedric"
 					welsh = "Ynys Padric"
-					irish = "Inis P√°traic"
+					irish = "Inis P·traic"
 				}
 				b_laxey = {
 					pictish = "Ahonugad"
 					welsh = "Afoneogiaid"
-					irish = "Uisge Brad√°n"
+					irish = "Uisge Brad·n"
 				}
 			}
 		}
@@ -39579,22 +39579,22 @@ e_britannia = {
 				b_dumfries = {
 					pictish = "Dunrad"
 					welsh = "Dinrhyd"
-					irish = "D√πn Phris"
+					irish = "D˘n Phris"
 				}
 				b_dunragit = {
 					pictish = "Dunreget"
 					welsh = "Din Rheged"
-					irish = "D√πn Reicheit"
+					irish = "D˘n Reicheit"
 				}
 				b_whithorn = {
 					pictish = "Taiuuan"
 					welsh = "Tygwyn"
-					irish = "Taigh Mh√†rtainn"
+					irish = "Taigh Mh‡rtainn"
 				}
 				b_dunrod = {
 					pictish = "Dun Brin"
 					welsh = "Din Brenin"
-					irish = "D√πn Droighnein"
+					irish = "D˘n Droighnein"
 				}
 				b_kirkcudbright = {
 					pictish = "Cuthberbatu"
@@ -39609,12 +39609,12 @@ e_britannia = {
 				b_wigtown = {
 					pictish = "Betrah"
 					welsh = "Faetref"
-					irish = "Baile na h-√ôige"
+					irish = "Baile na h-Ÿige"
 				}
 				b_threave = {
 					pictish = "Insee Datrah"
 					welsh = "Ynys Dytref"
-					irish = "Eilean na h-Uisge Dh√®"
+					irish = "Eilean na h-Uisge DhË"
 				}
 			}
 			c_carrick = {
@@ -39628,12 +39628,12 @@ e_britannia = {
 				b_turnberry = {
 					pictish = "Dun Ueron"
 					welsh = "Din Aeron"
-					irish = "D√πn √Äir"
+					irish = "D˘n ¿ir"
 				}
 				b_dunure = {
 					pictish = "Dunauen"
 					welsh = "Din Ywen"
-					irish = "D√πn I√πbhair"
+					irish = "D˘n I˘bhair"
 				}
 				b_maybole = {
 					pictish = "Maescanatan"
@@ -39649,12 +39649,12 @@ e_britannia = {
 					scottish = "Balloch"
 					pictish = "Landun"
 					welsh = "Llyndin"
-					irish = "Loch Dh√πin"
+					irish = "Loch Dh˘in"
 				}
 				b_ballantrae = {
 					pictish = "Tretrah"
 					welsh = "Traethtref"
-					irish = "Baile na Tr√†gha"
+					irish = "Baile na Tr‡gha"
 				}
 				b_culzean = {
 					pictish = "Pinaglan"
@@ -39664,7 +39664,7 @@ e_britannia = {
 				b_greenan = {
 					pictish = "Abereron"
 					welsh = "Aberaeron"
-					irish = "Inbhir √Äir"
+					irish = "Inbhir ¿ir"
 				}
 			}
 			c_clydesdale = {
@@ -39678,7 +39678,7 @@ e_britannia = {
 				b_renfrew = {
 					pictish = "Bregurun"
 					welsh = "Brigffroen"
-					irish = "Rinn Fri√π"
+					irish = "Rinn Fri˘"
 				}
 				b_st_kentigern = {
 					pictish = "Cantearn"
@@ -39698,12 +39698,12 @@ e_britannia = {
 				b_cadzow = {
 					pictish = "Uuohan"
 					welsh = "Guofan"
-					irish = "B√†ile Ghobhainn"
+					irish = "B‡ile Ghobhainn"
 				}
 				b_bothwell = {
 					pictish = "Mamuanon"
 					welsh = "Mamffynnon"
-					irish = "Tobar na M√†thar"
+					irish = "Tobar na M‡thar"
 				}
 				b_lesmahagow = {
 					pictish = "Lanmahau"
@@ -39713,7 +39713,7 @@ e_britannia = {
 				b_dumbarton = {
 					pictish = "Alcluit"
 					welsh = "Alt Clut"
-					irish = "D√πn Breatainn"
+					irish = "D˘n Breatainn"
 				}
 			}
 		}
@@ -39722,13 +39722,13 @@ e_britannia = {
 			color2 = { 255 255 255 }
 			capital = 35 # Inse Gall
 			
-			norwegian = "S√∏reyar"
-			danish = "S√∏reyar"
-			swedish = "S√∂r√∂arna"
-			norse = "Su√∞reyjar"
+			norwegian = "S¯reyar"
+			danish = "S¯reyar"
+			swedish = "Sˆrˆarna"
+			norse = "Sureyjar"
 			pictish = "Insee Hilth"
 			welsh = "Ynysoedd Heledd"
-			irish = "D√°l Riata"
+			irish = "D·l Riata"
 			
 			pagan_coa = {
 				template = 0
@@ -39747,10 +39747,10 @@ e_britannia = {
 				color={ 20 60 243 }
 				color2={ 255 255 255 }
 				
-				norwegian = "S√∏reyar"
-				danish = "S√∏reyar"
-				swedish = "S√∂r√∂arna"
-				norse = "Su√∞reyjar"
+				norwegian = "S¯reyar"
+				danish = "S¯reyar"
+				swedish = "Sˆrˆarna"
+				norse = "Sureyjar"
 				pictish = "Carnonac"
 				welsh = "Ynysoedd Heledd"
 				irish = "Innse Gall"
@@ -39762,13 +39762,13 @@ e_britannia = {
 					irish = "Cill Targhlain"
 				}
 				b_stornoway = {
-					norwegian = "Stornav√•g"
+					norwegian = "StornavÂg"
 					danish = "Stornavik"
 					swedish = "Stornavik"
 					norse = "Stornavik"
 					pictish = "Laueube"
 					welsh = "Llywiobae"
-					irish = "Ste√≤rnabhagh"
+					irish = "SteÚrnabhagh"
 				}
 				b_uig = {
 					norwegian = "Vik"
@@ -39777,12 +39777,12 @@ e_britannia = {
 					norse = "Vik"
 					pictish = "Betret"
 					welsh = "Baetraeth"
-					irish = "C√†rnais √ôige"
+					irish = "C‡rnais Ÿige"
 				}
 				b_dunvegan = {
 					pictish = "Dun Bachain"
 					welsh = "Din Bychan"
-					irish = "D√πn Bheagain"
+					irish = "D˘n Bheagain"
 				}
 				b_kiltaraglen = {
 				}
@@ -39801,7 +39801,7 @@ e_britannia = {
 				b_iona = {
 					pictish = "Auenle"
 					welsh = "Ywenlle"
-					irish = "√å Chaluim Chille"
+					irish = "Ã Chaluim Chille"
 				}
 				b_finlaggan = {
 					pictish = "Inseepirt"
@@ -39811,12 +39811,12 @@ e_britannia = {
 				b_laggan = {
 					pictish = "Nuuathuchel"
 					welsh = "Neuadduchel"
-					irish = "√Äird Talla"
+					irish = "¿ird Talla"
 				}
 				b_dunyveg = {
 					pictish = "Dun Galiuu"
-					welsh = "Din Gal√Øau"
-					irish = "D√πn Naomhaig"
+					welsh = "Din GalÔau"
+					irish = "D˘n Naomhaig"
 				}
 				b_tobermory = {
 				}
@@ -39831,17 +39831,17 @@ e_britannia = {
 				
 				pictish = "Ebithan"
 				welsh = "Epiddant"
-				irish = "Airer Go√≠del"
+				irish = "Airer GoÌdel"
 				
 				b_st_moluag = {
 					pictish = "Malluoc"
 					welsh = "Malluoc Sant"
-					irish = "Naomh Molu√≥c"
+					irish = "Naomh MoluÛc"
 				}
 				b_dunollie = {
 					pictish = "Dun Ugastel"
 					welsh = "Din Ogystal"
-					irish = " D√πn Ollaigh"
+					irish = " D˘n Ollaigh"
 				}
 				b_loch_awe = {
 					pictish = "Lanahon"
@@ -39851,12 +39851,12 @@ e_britannia = {
 				b_sween = {
 					pictish = "Caer Sauunae"
 					welsh = "Caer Sywny"
-					irish = "D√πn Suibhne"
+					irish = "D˘n Suibhne"
 				}
 				b_dunstaffnage = {
 					pictish = "Dun Stapan"
 					welsh = "Din Staffpentir"
-					irish = "D√πn Stafhainis"
+					irish = "D˘n Stafhainis"
 				}
 				b_ardchattan = {
 					pictish = "Uchdarcathan"
@@ -39897,7 +39897,7 @@ e_britannia = {
 				b_edinburgh = {
 					pictish = "Dun Eidan"
 					welsh = "Din Eidyn"
-					irish = "D√πn Eideann"
+					irish = "D˘n Eideann"
 				}
 				b_stirling = {
 					pictish = "Iutheu"
@@ -39907,7 +39907,7 @@ e_britannia = {
 				b_abercorn = {
 					pictish = "Abercarn"
 					welsh = "Abercarnedd"
-					irish = "Obar Ch√πirnidh"
+					irish = "Obar Ch˘irnidh"
 				}
 				b_linlithgow = {
 					pictish = "Glanaluu"
@@ -39922,17 +39922,17 @@ e_britannia = {
 				b_stow_of_wedale = {
 					pictish = "Gallath"
 					welsh = "Galladd"
-					irish = "An Geal √Äth"
+					irish = "An Geal ¿th"
 				}
 				b_leith = {
 					pictish = "Aberlath"
 					welsh = "Aberlydd"
-					irish = "Inverl√¨te"
+					irish = "InverlÏte"
 				}
 				b_torphichen = {
 					pictish = "Trehechan"
 					welsh = "Treffechan"
-					irish = "T√≥ir F√©ich√≠n"
+					irish = "TÛir FÈichÌn"
 				}
 			}
 			c_dunbar = {
@@ -39941,12 +39941,12 @@ e_britannia = {
 				
 				pictish = "Utudina"
 				welsh = "Din Baer"
-				irish = "D√πn B√°r"
+				irish = "D˘n B·r"
 	
 				b_dunbar = {
 					pictish = "Dun Ber"
 					welsh = "Din Baer"
-					irish = "D√πn B√°r"
+					irish = "D˘n B·r"
 				}
 				b_berwick = {
 					pictish = "Caer Brinech"
@@ -39966,7 +39966,7 @@ e_britannia = {
 				b_gordon = {
 					pictish = "Gor Dun"
 					welsh = "Gor Din"
-					irish = "G√≤r D√πn"
+					irish = "GÚr D˘n"
 				}
 				b_huntly = {
 					pictish = "Istrad Bach"
@@ -39981,7 +39981,7 @@ e_britannia = {
 				b_crichton = {
 					pictish = "Finuultreh"
 					welsh = "Ffinioltref"
-					irish = "Criochd√∫n"
+					irish = "Criochd˙n"
 				}
 			}
 			c_teviotdale = {
@@ -39995,17 +39995,17 @@ e_britannia = {
 				b_jedburgh = {
 					pictish = "Dungod"
 					welsh = "Dingod"
-					irish = "D√πngot"
+					irish = "D˘ngot"
 				}
 				b_roxburgh = {
 					pictish = "Iaartreh"
-					welsh = "I√¢rtref"
+					welsh = "I‚rtref"
 					irish = "Baile na h-Cearc"
 				}
 				b_peebles = {
 					pictish = "Peball"
 					welsh = "Pebyll"
-					irish = "Na P√πballan"
+					irish = "Na P˘ballan"
 				}
 				b_melrose = {
 					pictish = "Maelruusan"
@@ -40030,7 +40030,7 @@ e_britannia = {
 				b_ednam = {
 					pictish = "Aethontreh"
 					welsh = "Aeddantref"
-					irish = "Baile na h-Aodh√†n"
+					irish = "Baile na h-Aodh‡n"
 				}
 			}
 		}
@@ -40060,19 +40060,19 @@ e_britannia = {
 				b_dunkeld = {
 					pictish = "Dun Celadon"
 					welsh = "Din Celyddon"
-					irish = "D√πn Chailleann"
+					irish = "D˘n Chailleann"
 				}
 				b_perth = {
 				}
 				b_forteviot = {
 					pictish = "Nan Aruadocet"
-					welsh = "Nant Arwyddoc√¢d"
+					welsh = "Nant Arwyddoc‚d"
 					irish = "Fothair Tabhaicht"
 				}
 				b_dundee = {
 					pictish = "Orrea"
-					welsh = "Dind√¢n"
-					irish = "D√πn D√®agh"
+					welsh = "Dind‚n"
+					irish = "D˘n DËagh"
 				}
 				b_abernethy = {
 					pictish = "Aber Naiton"
@@ -40096,22 +40096,22 @@ e_britannia = {
 				
 				pictish = "Fib"
 				welsh = "Gwidd"
-				irish = "F√¨obha"
+				irish = "FÏobha"
 				
 				b_dunfermline = {
 					pictish = "Dunfurlan"
 					welsh = "Dinfirllyn"
-					irish = "D√πn Ph√†rlain"
+					irish = "D˘n Ph‡rlain"
 				}
 				b_cupar = {
 					pictish = "Cafredun"
 					welsh = "Cyffredin"
-					irish = "Comp√†irt"
+					irish = "Comp‡irt"
 				}
 				b_st_andrews = {
 					pictish = "Pinbed"
 					welsh = "Pennbaedd"
-					irish = "Cill R√≠gmonaid"
+					irish = "Cill RÌgmonaid"
 				}
 				b_kirkcaldy = {
 					pictish = "Caercaled"
@@ -40131,12 +40131,12 @@ e_britannia = {
 				b_lochore = {
 					pictish = "Laner"
 					welsh = "Llynaer"
-					irish = "Loch√°ir"
+					irish = "Loch·ir"
 				}
 				b_falkland = {
 					pictish = "Maluen"
 					welsh = "Malfin"
-					irish = "Fh√°clainne"
+					irish = "Fh·clainne"
 				}
 			}
 			c_strathearn = {
@@ -40145,7 +40145,7 @@ e_britannia = {
 				
 				pictish = "Uuanun"
 				welsh = "Ystrad Iwerddon"
-				irish = "Srath √àireann"
+				irish = "Srath »ireann"
 				
 				b_crieff = {
 					pictish = "Coiden"
@@ -40155,12 +40155,12 @@ e_britannia = {
 				b_dunblane = {
 					pictish = "Dul Blaan"
 					welsh = "Dinblyne"
-					irish = "D√πn Bhl√†thain"
+					irish = "D˘n Bhl‡thain"
 				}
 				b_tullibardine = {
 					pictish = "Duunrud"
 					welsh = "Duonrhyd"
-					irish = "Dubh√†th"
+					irish = "Dubh‡th"
 				}
 				b_auchterarder = {
 					pictish = "Uchel"
@@ -40175,7 +40175,7 @@ e_britannia = {
 				b_doune = {
 					pictish = "I Dun"
 					welsh = "Y Din"
-					irish = "An D√πn"
+					irish = "An D˘n"
 				}
 				b_inchaffray = {
 					pictish = "Insee Ufirin"
@@ -40199,7 +40199,7 @@ e_britannia = {
 				b_blair_atholl = {
 					pictish = "Athfocla"
 					welsh = "Brwydr Focla"
-					irish = "Bl√†r Athfhotla"
+					irish = "Bl‡r Athfhotla"
 				}
 				b_glen_dochart = {
 					pictish = "Lanuan"
@@ -40228,8 +40228,8 @@ e_britannia = {
 				}
 				b_strathardle = {
 					pictish = "Istrad Ardle"
-					welsh = "Ystrad Aerd√¥l"
-					irish = "Strath √Ärdail"
+					welsh = "Ystrad AerdÙl"
+					irish = "Strath ¿rdail"
 				}
 				b_struan = {
 					pictish = "Aberfel"
@@ -40329,7 +40329,7 @@ e_britannia = {
 				b_fortrose = {
 					pictish = "Caerrosan"
 					welsh = "Caerrhosan"
-					irish = "D√πnrois"
+					irish = "D˘nrois"
 				}
 				b_fearn = {
 					pictish = "Manech Rasan"
@@ -40376,7 +40376,7 @@ e_britannia = {
 				b_kintore = {
 					pictish = "Pintar"
 					welsh = "Penntyrau"
-					irish = "Ceann T√≤rr"
+					irish = "Ceann TÚrr"
 				}
 				b_inverurie = {
 					pictish = "Aberury"
@@ -40404,9 +40404,9 @@ e_britannia = {
 				color2={ 255 255 255 }
 				
 				norwegian = "Katanes"
-				danish = "Katan√¶s"
-				swedish = "Katan√§s"
-				norse = "Katan√¶s"
+				danish = "KatanÊs"
+				swedish = "Katan‰s"
+				norse = "KatanÊs"
 				pictish = "Cait"
 				welsh = "Caitnys"
 				irish = "Cataibh"
@@ -40418,23 +40418,23 @@ e_britannia = {
 					norse = "Vik"
 					pictish = "Aberbachuu"
 					welsh = "Aberbachwy"
-					irish = "Inbhir √ôige"
+					irish = "Inbhir Ÿige"
 				}
 				b_dunbeath = {
 					pictish = "Dunbathac"
 					welsh = "Dinbyddag"
-					irish = "D√πn Beithe"
+					irish = "D˘n Beithe"
 				}
 				b_dornoch = {
 					pictish = "Dirnfeth"
 					welsh = "Dyrnfedd"
-					irish = "D√≤rnach"
+					irish = "DÚrnach"
 				}
 				b_thurso = {
-					swedish = "Tjurs√•"
-					danish = "Tyrs√•"
-					norwegian = "Tyrs√•"
-					norse = "Tyrs√•"
+					swedish = "TjursÂ"
+					danish = "TyrsÂ"
+					norwegian = "TyrsÂ"
+					norse = "TyrsÂ"
 					pictish = "Aberteuafon"
 					welsh = "Abertaewafon"
 					irish = "Inbhir Tarbhainn"
@@ -40442,7 +40442,7 @@ e_britannia = {
 				b_dunrobin = {
 					pictish = "Dunrubert"
 					welsh = "Dinraibeart"
-					irish = "D√πnrhobert"
+					irish = "D˘nrhobert"
 				}
 				b_freswick = {
 					swedish = "Fresvik"
@@ -40451,7 +40451,7 @@ e_britannia = {
 					norse = "Fresvik"
 					pictish = "Aberfauur"
 					welsh = "Aberfawr"
-					irish = "Obar √Ärdair"
+					irish = "Obar ¿rdair"
 				}
 				b_latheron = {
 					pictish = "Lathaeron"
@@ -40482,7 +40482,7 @@ e_britannia = {
 		swedish = Irland
 		danish = Irland
 		norwegian = Irland
-		irish = √âire
+		irish = …ire
 		pictish = Iuerthon
 		welsh = Iwerddon
 		breton = Iwerzhon
@@ -40497,7 +40497,7 @@ e_britannia = {
 			norwegian = Strangfjord
 			swedish = Strangfjord
 			danish = Strangfjord
-			norse = Strangfjor√∞r
+			norse = Strangfjorr
 			irish = Ulaidh
 			
 			c_ulster = {
@@ -40507,18 +40507,18 @@ e_britannia = {
 				norwegian = Strangfjord
 				swedish = Strangfjord
 				danish = Strangfjord
-				norse = Strangfjor√∞r
+				norse = Strangfjorr
 				irish = Ulaidh
 			
 				b_downpatrick = {
 					norwegian = Strangfjord
 					swedish = Strangfjord
 					danish = Strangfjord
-					norse = Strangfjor√∞r
-					irish = "D√∫n P√°draig"
+					norse = Strangfjorr
+					irish = "D˙n P·draig"
 				}
 				b_dunseverick = {
-					irish = "D√∫n Sobhairce"
+					irish = "D˙n Sobhairce"
 				}
 				b_bangor = {
 					irish = "Inbhear Beg"
@@ -40530,20 +40530,20 @@ e_britannia = {
 					irish = "Con Doire"
 				}
 				b_dromore = {
-					irish = "Druim M√≥r"
+					irish = "Druim MÛr"
 				}
 				b_larne = {
 					irish = "Latharna"
 				}
 				b_dunluce = {
-					irish = "D√∫n Libhse"
+					irish = "D˙n Libhse"
 				}
 			}
 			c_oriel = {
 				color={ 30 180 45 }
 				color2={ 255 255 255 }
 	
-				irish = Airg√≠alla
+				irish = AirgÌalla
 				
 				b_clones = {
 					irish = "Cluain Eois"
@@ -40555,79 +40555,79 @@ e_britannia = {
 					norwegian = Kerlingfjord
 					swedish = Kerlingfjord
 					danish = Kerlingfjord
-					norse = Kerlingfjor√∞r
-					irish = "D√∫n Dealgan"
+					norse = Kerlingfjorr
+					irish = "D˙n Dealgan"
 				}
 				b_clogher = {
 					irish = "Clochar"
 				}
 				b_drogheda = {
-					irish = "Droichead √Åtha"
+					irish = "Droichead ¡tha"
 				}
 				b_monaghan = {
-					irish = "Muineach√°n"
+					irish = "Muineach·n"
 				}
 				b_olouth = {
-					irish = "L√∫ghbhaidh"
+					irish = "L˙ghbhaidh"
 				}
 				b_ardee = {
-					irish = "Baile √Åtha Fhirdhia"
+					irish = "Baile ¡tha Fhirdhia"
 				}
 			}
 			c_tyrone = {
 				color={ 66 157 22 }
 				color2={ 255 255 255 }
 				
-				irish = "T√≠r Eoghain"
+				irish = "TÌr Eoghain"
 	
 				b_coleraine = {
-					irish = "C√∫il Rathain"
+					irish = "C˙il Rathain"
 				}
 				b_dungannon = {
-					irish = "D√∫n Geanainn"
+					irish = "D˙n Geanainn"
 				}
 				b_aileach = {
 					irish = "Ailech"
 				}
 				b_maghera = {
-					irish = "Machaire R√°tha"
+					irish = "Machaire R·tha"
 				}
 				b_derry = {
 					irish = "Daire Coluimb Chille"
 				}
 				b_omagh = {
-					irish = "An √ìghmaigh"
+					irish = "An ”ghmaigh"
 				}
 				b_tullyhogue = {
-					irish = "Tulaigh √ìg"
+					irish = "Tulaigh ”g"
 				}
 				b_dungiven = {
-					irish = "D√∫n Geimhin"
+					irish = "D˙n Geimhin"
 				}
 			}
 			c_tyrconnell = {
 				color={ 25 190 31 }
 				color2={ 255 255 255 }
 				
-				irish = "T√≠r Chonaill"
+				irish = "TÌr Chonaill"
 			
 				b_gartan = {
-					irish = "Gart√°n"
+					irish = "Gart·n"
 				}
 				b_moville = {
 					irish = "Magh Bhile"
 				}
 				b_raphoe = {
-					irish = "R√°th Bhoth"
+					irish = "R·th Bhoth"
 				}
 				b_fahan = {
 					irish = "Fathain"
 				}
 				b_donegal = {
-					irish = "D√∫n na nGall"
+					irish = "D˙n na nGall"
 				}
 				b_ballyshannon = {
-					irish = "B√©al √Åtha Seanaidh"
+					irish = "BÈal ¡tha Seanaidh"
 				}
 				b_kilmacrenan = {
 					irish = "Cill Mhic nEanain"
@@ -40649,16 +40649,16 @@ e_britannia = {
 				color={ 40 230 65 }
 				color2={ 255 255 255 }
 				
-				irish = "Br√©ifne"
+				irish = "BrÈifne"
 	
 				b_dromahair = {
-					irish = "Droim √Åth Thiar"
+					irish = "Droim ¡th Thiar"
 				}
 				b_kilmore = {
-					irish = "Cill Mh√≥r"
+					irish = "Cill MhÛr"
 				}
 				b_cavan = {
-					irish = "An Cabh√°n"
+					irish = "An Cabh·n"
 				}
 				b_longford = {
 					irish = "An Longphort"
@@ -40683,25 +40683,25 @@ e_britannia = {
 				irish = "Iarthar Connachta"
 	
 				b_galway = {
-					irish = "D√∫n Bhun na Gaillimhe"
+					irish = "D˙n Bhun na Gaillimhe"
 				}
 				b_elphin = {
 					irish = "Ail Finn"
 				}
 				b_tuam = {
-					irish = "Tuaim D√° Ghualann"
+					irish = "Tuaim D· Ghualann"
 				}
 				b_clonfert = {
 					irish = "Cluain Fearta"
 				}
 				b_roscommon = {
-					irish = "Ros Com√°in"
+					irish = "Ros Com·in"
 				}
 				b_killala = {
 					irish = "Cill Ala"
 				}
 				b_anchory = {
-					irish = "Baile U√≠ Fhiach√°in"
+					irish = "Baile UÌ Fhiach·in"
 				}
 			}
 			c_ui_fiachrach = {
@@ -40725,14 +40725,14 @@ e_britannia = {
 					irish = "Mhuirthead"
 				}
 				b_inishkea = {
-					irish = "Inis G√©"
+					irish = "Inis GÈ"
 				}
 			}
 			c_hy_many = {
 				color={ 55 245 75 }
 				color2={ 255 255 255 }
 
-				irish = "U√≠ Maine"
+				irish = "UÌ Maine"
 
 				b_cruachu = {}
 				b_delbna = {}
@@ -40741,7 +40741,7 @@ e_britannia = {
 					irish = "Rath na dTarbh"
 				}
 				b_relignaree = {
-					irish = "Reilig na R√≠"
+					irish = "Reilig na RÌ"
 				}
 				b_oweynagat = {
 					irish = "Uaimh na gCat"
@@ -40781,10 +40781,10 @@ e_britannia = {
 				irish = "Cill Dara"
 	
 				b_knockaulin = {
-					irish = "D√∫n Ailinne"
+					irish = "D˙n Ailinne"
 				}
 				b_athlone = {
-					irish = "Baile √Åtha Luain"
+					irish = "Baile ¡tha Luain"
 				}
 				b_kildare = {
 					irish = "Cill Dara"
@@ -40796,10 +40796,10 @@ e_britannia = {
 					irish = "Naomh Brigid"
 				}
 				b_rathangan = {
-					irish = "R√°th Iomgh√°in"
+					irish = "R·th Iomgh·in"
 				}
 				b_durrow = {
-					irish = "Dar√∫"
+					irish = "Dar˙"
 				}
 				b_clonard = {
 					irish = "Cluain Ioraird"
@@ -40825,19 +40825,19 @@ e_britannia = {
 					irish = "Fionnghlas"
 				}
 				b_wicklow = {
-					irish = "Cill Mhant√°in"
+					irish = "Cill Mhant·in"
 				}
 				b_ath_cliath = {
-					irish = "Baile √Åtha Cliath"
+					irish = "Baile ¡tha Cliath"
 				}
 				b_christ_church = {
-					irish = "Ardeaglais Chr√≠ost"
+					irish = "Ardeaglais ChrÌost"
 				}
 				b_mellifont = {
-					irish = "An Mhainistir Mh√≥r"
+					irish = "An Mhainistir MhÛr"
 				}
 				b_trim = {
-					irish = "Baile √Åtha Troim"
+					irish = "Baile ¡tha Troim"
 				}
 			}
 			c_meath = {
@@ -40861,7 +40861,7 @@ e_britannia = {
 				b_birr = {}
 				b_uisnech = {}
 				b_frewin = {
-					irish = "Fr√©mainn"
+					irish = "FrÈmainn"
 				}
 				b_fir_cell = {}
 				b_cenel_fiachach = {}
@@ -40877,7 +40877,7 @@ e_britannia = {
 			norwegian = Veisafjord
 			swedish = Veisafjord
 			danish = Veisafjord
-			norse = Veisafjor√∞r
+			norse = Veisafjorr
 			irish = Laigin
 			
 			c_leinster = {
@@ -40887,36 +40887,36 @@ e_britannia = {
 				norwegian = Veisafjord
 				swedish = Veisafjord
 				danish = Veisafjord
-				norse = Veisafjor√∞r
+				norse = Veisafjorr
 				irish = Laigin
 	
 				b_wexford = {
 					norwegian = Veisafjord
 					swedish = Veisafjord
 					danish = Veisafjord
-					norse = Veisafjor√∞r
+					norse = Veisafjorr
 					irish = "Loch Garman"
 				}
 				b_leighlin = {
 					irish = "Leithghlinn"
 				}
 				b_arklow = {
-					irish = "An tInbhear M√≥r"
+					irish = "An tInbhear MÛr"
 				}
 				b_carlow = {
 					irish = "Ceatharlach"
 				}
 				b_ferns = {
-					irish = "Fearna M√≥r Maedh√≥g"
+					irish = "Fearna MÛr MaedhÛg"
 				}
 				b_glendalough = {
-					irish = "Gleann D√° Loch"
+					irish = "Gleann D· Loch"
 				}
 				b_naas = {
-					irish = "N√°s na R√≠ogh"
+					irish = "N·s na RÌogh"
 				}
 				b_enniscorthy = {
-					irish = "Inis C√≥rthaidh"
+					irish = "Inis CÛrthaidh"
 				}
 			}
 			c_ossory = {
@@ -40929,22 +40929,22 @@ e_britannia = {
 					irish = "Cill Chainnigh"
 				}
 				b_gowran = {
-					irish = "Gabhr√°n"
+					irish = "Gabhr·n"
 				}
 				b_clonmacnoise = {
-					irish = "Cluain Mhic N√≥is"
+					irish = "Cluain Mhic NÛis"
 				}
 				b_aghaboe = {
-					irish = "Achadh Bh√≥"
+					irish = "Achadh BhÛ"
 				}
 				b_jerpoint = {
-					irish = "Sheireap√∫in"
+					irish = "Sheireap˙in"
 				}
 				b_callan = {
 					irish = "Callainn"
 				}
 				b_grennan = {
-					irish = "An Ghrian√°n"
+					irish = "An Ghrian·n"
 				}
 				b_grannagh = {
 					irish = "An Greannach"
@@ -40996,7 +40996,7 @@ e_britannia = {
 					irish = "Bun na Raite"
 				}
 				b_killaloe = {
-					irish = "Cill D√°lua"
+					irish = "Cill D·lua"
 				}
 				b_emly = {
 					irish = "Imleach Iubhair"
@@ -41005,10 +41005,10 @@ e_britannia = {
 					irish = "Inis"
 				}
 				b_kilfenora = {
-					irish = "Cill Fhionn√∫rach"
+					irish = "Cill Fhionn˙rach"
 				}
 				b_askeaton = {
-					irish = "Eas G√©itine"
+					irish = "Eas GÈitine"
 				}
 				b_adare = {
 				}
@@ -41020,30 +41020,30 @@ e_britannia = {
 				norwegian = Vedrafjord
 				swedish = Vedrafjord
 				danish = Vedrafjord
-				norse = Ve√∞rafjor√∞r
+				norse = Verafjorr
 				irish = Urmhumhain
 		
 				b_waterford = {
 					norwegian = Vedrafjord
 					swedish = Vedrafjord
 					danish = Vedrafjord
-					norse = Ve√∞rafjor√∞r
-					irish = "Port L√°irge"
+					norse = Verafjorr
+					irish = "Port L·irge"
 				}
 				b_cahir = {
-					irish = "Cathair Dh√∫n Iascaigh"
+					irish = "Cathair Dh˙n Iascaigh"
 				}
 				b_cashel = {
-					irish = "D√∫n Caiseal"
+					irish = "D˙n Caiseal"
 				}
 				b_clonmel = {
 					irish = "Cluain Meala"
 				}
 				b_lismore = {
-					irish = "Lios M√≥r"
+					irish = "Lios MÛr"
 				}
 				b_roscrea = {
-					irish = "Ros Cr√©"
+					irish = "Ros CrÈ"
 				}
 				b_nenagh = {
 					irish = "Aonach Urmhumhan"
@@ -41062,7 +41062,7 @@ e_britannia = {
 					irish = "Corcaigh"
 				}
 				b_dunasead = {
-					irish = "D√∫n na S√©ad"
+					irish = "D˙n na SÈad"
 				}
 				b_clone = {
 				}
@@ -41075,7 +41075,7 @@ e_britannia = {
 					irish = "Cluain"
 				}
 				b_fermoy = {
-					irish = "Mainistir Fhear Ma√≠"
+					irish = "Mainistir Fhear MaÌ"
 				}
 				b_blarney = {
 					irish = "An Bhlarna"
@@ -41093,7 +41093,7 @@ e_britannia = {
 				b_innisfallen = {
 				}
 				b_ross = {
-					irish = "Ros √ì gCairbre"
+					irish = "Ros ” gCairbre"
 				}
 				b_killarney = {
 				}
@@ -42056,7 +42056,7 @@ d_geats = {
 	
 	dignity = 8
 	
-	capital	= 297 # V√§sterg√∂tland
+	capital	= 297 # V‰stergˆtland
 	
 	allow = {
 		always = no
@@ -43617,7 +43617,7 @@ e_mexikha = {
 #		always = no
 #	}
 #	
-#	capital = 262 # L√ºbeck
+#	capital = 262 # L¸beck
 #	
 #	dignity = 10
 #}	
@@ -43768,7 +43768,7 @@ b_caetani = {
 	religion = catholic
 }
 
-# L√úBECK:
+# L‹BECK:
 
 b_bardewik = {
 	culture = german
@@ -49324,7 +49324,7 @@ e_tibet = {
 		
 		han = "Tubo"
 
-		d_lhasa = { # A.k.a "√ú-Tsang"
+		d_lhasa = { # A.k.a "‹-Tsang"
 			color={ 225 75 0 }
 			color2= { 255 255 255 }
 
@@ -49371,11 +49371,11 @@ e_tibet = {
 				color={ 175 15 5 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Lh√ºnzhub"
+				bodpa = "Lh¸nzhub"
 				han = "Linzhou"
 					
 				b_lhunzhub = {
-					bodpa = "Lh√ºnzhub"
+					bodpa = "Lh¸nzhub"
 					han = "Linzhou"
 				}
 				b_reting = { #temple
@@ -49393,7 +49393,7 @@ e_tibet = {
 					han = "Pangduo"
 				}
 				b_sumcheng = {
-					bodpa = "Sumch√™ng"
+					bodpa = "SumchÍng"
 					han = "Songpan"
 				}
 			}
@@ -49438,15 +49438,15 @@ e_tibet = {
 				color={ 191 13 0 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Takts√©"
+				bodpa = "TaktsÈ"
 				han = "Dazi"
 
 				b_taktse = {
-					bodpa = "Takts√©"
+					bodpa = "TaktsÈ"
 					han = "Dazi"
 				}
 				b_qonggyai = {
-					bodpa = "Chonggy√©"
+					bodpa = "ChonggyÈ"
 					han = "Qiongjie"
 				}
 				b_qoi = {
@@ -49466,15 +49466,15 @@ e_tibet = {
 				color={ 197 17 7 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Lh√ºnz√™"
+				bodpa = "Lh¸nzÍ"
 				han = "Longzi"
 
 				b_lhunze = {
-					bodpa = "Lh√ºnz√™"
+					bodpa = "Lh¸nzÍ"
 					han = "Longzi"
 				}
 				b_yumai = {
-					bodpa = "Y√ºmai"
+					bodpa = "Y¸mai"
 				}
 				b_sangngagqoiling = {
 					han = "San'anqulin"
@@ -49494,21 +49494,21 @@ e_tibet = {
 				color={ 171 23 0 }
 				color2= { 255 255 255 }
 				
-				bodpa = "N√™dong"
+				bodpa = "NÍdong"
 				han = "Naidong"
 
 				b_yungbulakang = {
 					han = "Yongbulangong"
 				}
 				b_zetang = {
-					bodpa = "Z√™tang"
+					bodpa = "ZÍtang"
 					han = "Zedang"
 				}
 				b_tradruk = { #temple
 					han = "Changzhu"
 				}
 				b_nedong = {
-					bodpa = "N√™dong"
+					bodpa = "NÍdong"
 					han = "Naidong"
 				}
 				b_phagmodru = {
@@ -49526,32 +49526,32 @@ e_tibet = {
 
 			capital = 1499 # Shigatse
 			
-			bodpa = "Xigaz√™"
+			bodpa = "XigazÍ"
 			han = "Rikaze"
 			
 			c_shigatse = {
 				color={ 195 63 0 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Xigaz√™"
+				bodpa = "XigazÍ"
 				han = "Rikaze"
 
 				b_shigatse = {
-					bodpa = "Xigaz√™"
+					bodpa = "XigazÍ"
 					han = "Rikaze"
 				}
 				b_namling = {
 					han = "Nanmulin"
 				}
 				b_tashilhunpo = { #temple
-					bodpa = "Tashi Lh√ºnpo"
+					bodpa = "Tashi Lh¸npo"
 					han = "Zhashi Lunbu"
 				}
 				b_shalu = { #temple
 					han = "Xialu"
 				}
 				b_samzhubze = {
-					bodpa = "Samzhubz√™"
+					bodpa = "SamzhubzÍ"
 					han = "Sangzhuzi"
 				}
 				b_yungdrungling = { #temple
@@ -49565,15 +49565,15 @@ e_tibet = {
 				color={ 195 73 30 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Lhaz√™"
+				bodpa = "LhazÍ"
 				han = "Lazi"
 
 				b_lhatse = {
-					bodpa = "Lhaz√™"
+					bodpa = "LhazÍ"
 					han = "Lazi"
 				}
 				b_deleg = {
-					bodpa = "D√™l√™g"
+					bodpa = "DÍlÍg"
 					han = "Delei"
 				}
 				b_drampagyang = { #temple
@@ -49589,7 +49589,7 @@ e_tibet = {
 					han = "Quxia"
 				}
 				b_puncogling = {
-					bodpa = "P√ºncogling"
+					bodpa = "P¸ncogling"
 					han = "Pengcuolin"
 				}
 			}
@@ -49597,11 +49597,11 @@ e_tibet = {
 				color={ 215 35 0 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Gyangz√™"
+				bodpa = "GyangzÍ"
 				han = "Jiangze"
 
 				b_gyantse = {
-					bodpa = "Gyangz√™"
+					bodpa = "GyangzÍ"
 					han = "Jiangze"
 				}
 				b_palcho = { #temple
@@ -49638,15 +49638,15 @@ e_tibet = {
 					han = "Sajiasi"
 				}
 				b_geding = {
-					bodpa = "G√™ding"
+					bodpa = "GÍding"
 					han = "Jiding"
 				}
 				b_dinggye = {
-					bodpa = "Dinggy√™"
+					bodpa = "DinggyÍ"
 					han = "Dingjie"
 				}
 				b_zhentang = {
-					bodpa = "Zh√™ntang"
+					bodpa = "ZhÍntang"
 					han = "Chentang"
 				}
 				b_gamba = {
@@ -49660,7 +49660,7 @@ e_tibet = {
 				color={ 150 100 0 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Mangy√ºl"
+				bodpa = "Mangy¸l"
 				han = "Mangyu"
 				nepali = "Keruna"
 
@@ -49694,11 +49694,11 @@ e_tibet = {
 				color={ 180 150 0 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Gy√™sar"
+				bodpa = "GyÍsar"
 				han = "Jiesa"
 				
 				b_gyesar = {
-					bodpa = "Gy√™sar"
+					bodpa = "GyÍsar"
 					han = "Jiesa"
 				}
 				b_karongshar = {
@@ -49753,11 +49753,11 @@ e_tibet = {
 					han = "Kongma"
 				}
 				b_daqen = {
-					bodpa = "Daq√™n"
+					bodpa = "DaqÍn"
 					han = "Daqian"
 				}
 				b_yochak = {
-					bodpa = "Y√∂chak"
+					bodpa = "Yˆchak"
 					han = "Youqia"
 				}
 			}
@@ -49774,7 +49774,7 @@ e_tibet = {
 					han = "Bange"
 				}
 				b_siling = {
-					bodpa = "S√™ling"
+					bodpa = "SÍling"
 					han = "Selin"
 				}
 				b_maryo = {
@@ -49841,7 +49841,7 @@ e_tibet = {
 					han = "Cuoren"
 				}
 				b_zholhun = {
-					bodpa = "Zh√∂lh√ºn"
+					bodpa = "Zhˆlh¸n"
 					han = "Xuehuan"
 				}
 				b_drangtsen = {
@@ -49854,7 +49854,7 @@ e_tibet = {
 					han = "Chaoyang"
 				}
 				b_yulpun = {
-					bodpa = "Y√ºlp√ºn"
+					bodpa = "Y¸lp¸n"
 					han = "Yupan"
 				}
 			}
@@ -49877,11 +49877,11 @@ e_tibet = {
 					han = "Yuereba"
 				}
 				b_satso = {
-					bodpa = "Sats√∂"
+					bodpa = "Satsˆ"
 					han = "Sacuo"
 				}
 				b_zhoyon = {
-					bodpa = "Zh√∂yon"
+					bodpa = "Zhˆyon"
 					han = "Xueyuan"
 				}
 				b_laxong = {
@@ -49905,7 +49905,7 @@ e_tibet = {
 				}
 				b_kumkol = {
 					han = "Kumukuli"
-					mongol = "Kum K√∂l"
+					mongol = "Kum Kˆl"
 				}
 				b_ayakkum = {
 					han = "Ayakekumu"
@@ -49917,7 +49917,7 @@ e_tibet = {
 					han = "Muzitage"
 				}
 				b_zhotsen = {
-					bodpa = "Zh√∂tsen"
+					bodpa = "Zhˆtsen"
 					han = "Xuejing"
 				}
 			}
@@ -49940,7 +49940,7 @@ e_tibet = {
 					han = "Qiangma"
 				}
 				b_sewa = {
-					bodpa = "S√™wa"
+					bodpa = "SÍwa"
 					han = "Sewu"
 				}
 				b_gangnyi = {
@@ -50028,11 +50028,11 @@ e_tibet = {
 				b_tsaparang = {
 				}
 				b_tholing = {
-					bodpa = "Th√∂ling"
+					bodpa = "Thˆling"
 					han = "Tuolin"
 				}
 				b_tholinggompa = { #temple
-					bodpa = "Th√∂ling Gompa"
+					bodpa = "Thˆling Gompa"
 					han = "Tuolinsi"
 				}
 				b_mangga = {
@@ -50060,14 +50060,14 @@ e_tibet = {
 					han = "Gurujia"
 				}
 				b_monicer = {
-					bodpa = "Moinc√™r"
+					bodpa = "MoincÍr"
 					han = "Menshi"
 				}
 				b_tirthapuri = { #temple
 					han = "Deretabore"
 				}
 				b_dolchu = { #temple
-					bodpa = "D√∂lchu"
+					bodpa = "Dˆlchu"
 					han = "Duolaqiu"
 				}
 				b_xalazakung = {
@@ -50098,7 +50098,7 @@ e_tibet = {
 				}
 				b_kailash = { # Holy Site
 					han = "Kailashen"
-					zhangzhung = "Tits√©"
+					zhangzhung = "TitsÈ"
 					hindustani = "Kailasa"
 				}
 				b_teglakar = {
@@ -50123,11 +50123,11 @@ e_tibet = {
 				color={ 72 168 216 }
 				color2= { 255 255 255 }
 				
-				bodpa = "G√™'gyai"
+				bodpa = "GÍ'gyai"
 				han = "Geji"
 				
 				b_gegyai = {
-					bodpa = "G√™'gyai"
+					bodpa = "GÍ'gyai"
 					han = "Geji"
 				}
 				b_zhungpa = {
@@ -50160,7 +50160,7 @@ e_tibet = {
 					han = "Payang"
 				}
 				b_gela_b = {
-					bodpa = "G√™la"
+					bodpa = "GÍla"
 					han = "Jila"
 				}
 				b_lunggar = {
@@ -50195,7 +50195,7 @@ e_tibet = {
 					han = "Ga'er"
 				}
 				b_senggezangbo = {
-					bodpa = "S√™ngg√™zangbo"
+					bodpa = "SÍnggÍzangbo"
 					han = "Shiquanhe"
 				}
 				b_kunsa = {
@@ -50217,11 +50217,11 @@ e_tibet = {
 				color={ 134 142 206 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Coq√™n"
+				bodpa = "CoqÍn"
 				han = "Cuoqin"
 
 				b_coqen = {
-					bodpa = "Coq√™n"
+					bodpa = "CoqÍn"
 					han = "Cuoqin"
 				}
 				b_zhuglung = {
@@ -50256,7 +50256,7 @@ e_tibet = {
 					han = "Xiama"
 				}
 				b_nyer = {
-					bodpa = "Ny√™r"
+					bodpa = "NyÍr"
 					han = "Nier"
 				}
 				b_rungra = {
@@ -50275,11 +50275,11 @@ e_tibet = {
 				color={ 124 142 216 }
 				color2= { 255 255 255 }
 				
-				bodpa = "G√™rz√™"
+				bodpa = "GÍrzÍ"
 				han = "Gaize"
 
 				b_gerze = {
-					bodpa = "G√™rz√™"
+					bodpa = "GÍrzÍ"
 					han = "Gaize"
 				}
 				b_gotsang = {
@@ -50292,7 +50292,7 @@ e_tibet = {
 					han = "Laguo"
 				}
 				b_nangangonna = {
-					bodpa = "Nanga Ng√∂nna"
+					bodpa = "Nanga Ngˆnna"
 					han = "Nakawona"
 				}
 				b_jakar_b = {
@@ -50335,7 +50335,7 @@ e_tibet = {
 				color2= { 255 255 255 }
 				
 				bodpa = "Kulung"
-				mongol = "Kh√∂ndl√∂n"
+				mongol = "Khˆndlˆn"
 
 				b_bangdag = {
 					han = "Bangda"
@@ -50453,16 +50453,16 @@ e_tibet = {
 
 			capital = 1506 # Dege
 			
-			bodpa = "D√™g√™"
+			bodpa = "DÍgÍ"
 
 			c_dege = {
 				color={ 151 11 0 }
 				color2= { 255 255 255 }
 				
-				bodpa = "D√™g√™"
+				bodpa = "DÍgÍ"
 
 				b_dege = {
-					bodpa = "D√™g√™"
+					bodpa = "DÍgÍ"
 				}
 				b_dzongsar = { #temple
 				}
@@ -50492,10 +50492,10 @@ e_tibet = {
 				b_bolo = {
 				}
 				b_zeba = {
-					bodpa = "Z√™ba"
+					bodpa = "ZÍba"
 				}
 				b_bumgye = {
-					bodpa = "Bumgy√™"
+					bodpa = "BumgyÍ"
 					han = "Benxie"
 				}
 				b_zhagyab = {
@@ -50548,7 +50548,7 @@ e_tibet = {
 					han = "Chengguan"
 				}
 				b_riwoche = { #temple
-					bodpa = "Riwoq√™"
+					bodpa = "RiwoqÍ"
 					han = "Leiwuqi"
 				}
 				b_karub = {
@@ -50571,11 +50571,11 @@ e_tibet = {
 				color={ 160 50 0 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Bom√™"
+				bodpa = "BomÍ"
 				han = "Bomi"
 
 				b_bome = {
-					bodpa = "Bom√™"
+					bodpa = "BomÍ"
 					han = "Bomi"
 				}
 				b_zhamo = {
@@ -50610,10 +50610,10 @@ e_tibet = {
 					han = "Duomatang"
 				}
 				b_sadeng = {
-					bodpa = "Sad√™ng"
+					bodpa = "SadÍng"
 				}
 				b_dengqen = {
-					bodpa = "D√™ngq√™n"
+					bodpa = "DÍngqÍn"
 					han = "Dingqing"
 				}
 				b_shagong = {
@@ -50650,7 +50650,7 @@ e_tibet = {
 				}
 				b_beba = {
 					han = "Baiba"
-					bodpa = "B√™ba"
+					bodpa = "BÍba"
 				}
 				b_gongbogyamda = {
 					han = "Gongbujiangda"
@@ -50664,11 +50664,11 @@ e_tibet = {
 				color={ 129 50 9 }
 				color2= { 255 255 255 }
 				
-				bodpa = "M√™dog"
+				bodpa = "MÍdog"
 				han = "Motuo"
 
 				b_medog = {
-					bodpa = "M√™dog"
+					bodpa = "MÍdog"
 					han = "Motuo"
 				}
 				b_baibung = {
@@ -51261,12 +51261,12 @@ e_tibet = {
 				color={ 38 109 114 }
 				color2= { 255 255 255 }
 				
-				bodpa = "D√™rl√™nka"
+				bodpa = "DÍrlÍnka"
 				mongol = "Delhi"
 				khitan = "Delhi"
 
 				b_delingha = {
-					bodpa = "D√™rl√™nka"
+					bodpa = "DÍrlÍnka"
 					mongol = "Delhi"
 					khitan = "Delhi"
 				}
@@ -51423,7 +51423,7 @@ e_tibet = {
 
 			capital = 1503 # Nangqen
 			
-			bodpa = "Nangq√™n"
+			bodpa = "NangqÍn"
 			han = "Nangqian"
 			
 			c_nangqen = {
@@ -51431,7 +51431,7 @@ e_tibet = {
 				color={ 54 152 132 }
 				color2= { 255 255 255 }
 				
-				bodpa = "Nangq√™n"
+				bodpa = "NangqÍn"
 				han = "Nangqian"
 				
 				b_xangda = {
@@ -51483,7 +51483,7 @@ e_tibet = {
 				b_denkok = {
 				}
 				b_serxu = {
-					bodpa = "S√™rx√º"
+					bodpa = "SÍrx¸"
 					han = "Shiqu"
 				}
 				b_gemeng = {

--- a/MoreCulturalNamesModBuilder.csproj
+++ b/MoreCulturalNamesModBuilder.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <None Update="appsettings.json"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
+    <None Update="Data/ck2_landed_titles.txt"> <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
     <None Update="Data/ck2hip_landed_titles.txt"> <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
     <None Update="Data/ck3_landed_titles.txt"> <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
   </ItemGroup>

--- a/Program.cs
+++ b/Program.cs
@@ -39,17 +39,20 @@ namespace MoreCulturalNamesModBuilder
                 .AddSingleton<IRepository<LanguageEntity>>(s => new XmlRepository<LanguageEntity>(dataStoreSettings.LanguageStorePath))
                 .AddSingleton<IRepository<LocationEntity>>(s => new XmlRepository<LocationEntity>(dataStoreSettings.TitleStorePath))
                 .AddSingleton<ICK2ModBuilder, CK2ModBuilder>()
+                .AddSingleton<ICK2HIPModBuilder, CK2HIPModBuilder>()
                 .AddSingleton<ICK3ModBuilder, CK3ModBuilder>()
                 .AddSingleton<IImperatorRomeModBuilder, ImperatorRomeModBuilder>()
                 .BuildServiceProvider();
             
             IModBuilder ck2Builder = serviceProvider.GetService<ICK2ModBuilder>();
+            IModBuilder ck2hipBuilder = serviceProvider.GetService<ICK2HIPModBuilder>();
             IModBuilder ck3Builder = serviceProvider.GetService<ICK3ModBuilder>();
             IModBuilder imperatorRomeBuilder = serviceProvider.GetService<IImperatorRomeModBuilder>();
             
             ck2Builder.Build();
-            ck3Builder.Build();
-            imperatorRomeBuilder.Build();
+            ck2hipBuilder.Build();
+            //ck3Builder.Build();
+            //imperatorRomeBuilder.Build();
         }
 
         static void LoadConfiguration(string[] args)

--- a/Program.cs
+++ b/Program.cs
@@ -28,7 +28,7 @@ namespace MoreCulturalNamesModBuilder
         /// <summary>
         /// The entry point of the program, where the program control starts and ends.
         /// </summary>
-        /// <param name="args">CLI arguments</param>
+        /// <param name="args">The command line arguments.</param>
         public static void Main(string[] args)
         {
             LoadConfiguration(args);
@@ -51,15 +51,15 @@ namespace MoreCulturalNamesModBuilder
             
             ck2Builder.Build();
             ck2hipBuilder.Build();
-            //ck3Builder.Build();
-            //imperatorRomeBuilder.Build();
+            ck3Builder.Build();
+            imperatorRomeBuilder.Build();
         }
 
         static void LoadConfiguration(string[] args)
         {
             IConfiguration config =new ConfigurationBuilder()
-                    .AddJsonFile("appsettings.json", true, true)
-                    .Build();
+                .AddJsonFile("appsettings.json", true, true)
+                .Build();
 
             dataStoreSettings = new DataStoreSettings();
             outputSettings = new OutputSettings();

--- a/Service/ModBuilders/CrusaderKings2/CK2HIPModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/CK2HIPModBuilder.cs
@@ -37,6 +37,7 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
         protected override string GenerateDescriptorContent()
         {
             return
+                $"# Version {outputSettings.ModVersion} ({DateTime.Now})" + Environment.NewLine +
                 $"name = \"{outputSettings.CK2HipModName}\"" + Environment.NewLine +
                 $"dependencies = {{ \"HIP - Historical Immersion Project\" }}" + Environment.NewLine +
                 $"tags = {{ map immersion HIP }}";

--- a/Service/ModBuilders/CrusaderKings2/CK2HIPModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/CK2HIPModBuilder.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using NuciDAL.Repositories;
+
+using MoreCulturalNamesModBuilder.Configuration;
+using MoreCulturalNamesModBuilder.DataAccess.DataObjects;
+
+namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
+{
+    public sealed class CK2HIPModBuilder : CK2ModBuilder, ICK2HIPModBuilder
+    {
+        public override string Game => "CK2HIP";
+
+        protected override string InputLandedTitlesFileName => "ck2hip_landed_titles.txt";
+
+        protected override string OutputLandedTitlesFileName => "swmh_landed_titles.txt";
+
+        public CK2HIPModBuilder(
+            IRepository<LanguageEntity> languageRepository,
+            IRepository<LocationEntity> locationRepository,
+            OutputSettings outputSettings)
+            : base(languageRepository, locationRepository, outputSettings)
+        {
+        }
+
+        protected override string GenerateMainDescriptorContent()
+        {
+            return GenerateDescriptorContent() + Environment.NewLine +
+                $"path = \"mod/{outputSettings.CK2HipModId}\"";
+        }
+
+        protected override string GenerateDescriptorContent()
+        {
+            return
+                $"name = \"{outputSettings.CK2HipModName}\"" + Environment.NewLine +
+                $"dependencies = {{ \"HIP - Historical Immersion Project\" }}" + Environment.NewLine +
+                $"tags = {{ map immersion HIP }}";
+        }
+    }
+}

--- a/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
@@ -49,6 +49,7 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
         protected virtual string GenerateDescriptorContent()
         {
             return
+                $"# Version {outputSettings.ModVersion} ({DateTime.Now})" + Environment.NewLine +
                 $"name = \"{outputSettings.CK2ModName}\"" + Environment.NewLine +
                 $"tags = {{ map immersion }}";
         }

--- a/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
@@ -14,11 +14,13 @@ using MoreCulturalNamesModBuilder.Service.Models;
 
 namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
 {
-    public sealed class CK2ModBuilder : ModBuilder, ICK2ModBuilder
+    public class CK2ModBuilder : ModBuilder, ICK2ModBuilder
     {
-        public override string Game => "CK2HIP";
+        public override string Game => "CK2";
 
-        const string LandedTitlesFileName = "swmh_landed_titles.txt";
+        protected virtual string InputLandedTitlesFileName => "ck2_landed_titles.txt";
+
+        protected virtual string OutputLandedTitlesFileName => "landed_titles.txt";
 
         public CK2ModBuilder(
             IRepository<LanguageEntity> languageRepository,
@@ -32,7 +34,7 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
 
         protected override void BuildMod()
         {
-            string mainDirectoryPath = Path.Combine(OutputDirectoryPath, outputSettings.CK2HipModId);
+            string mainDirectoryPath = Path.Combine(OutputDirectoryPath, ModId);
             string commonDirectoryPath = Path.Combine(mainDirectoryPath, "common");
             string landedTitlesDirectoryPath = Path.Combine(commonDirectoryPath, "landed_titles");
 
@@ -42,6 +44,19 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
 
             CreateDataFiles(landedTitlesDirectoryPath);
             CreateDescriptorFiles();
+        }
+
+        protected virtual string GenerateDescriptorContent()
+        {
+            return
+                $"name = \"{outputSettings.CK2ModName}\"" + Environment.NewLine +
+                $"tags = {{ map immersion }}";
+        }
+
+        protected virtual string GenerateMainDescriptorContent()
+        {
+            return GenerateDescriptorContent() + Environment.NewLine +
+                $"path = \"mod/{outputSettings.CK2ModId}\"";
         }
 
         void CreateDataFiles(string landedTitlesDirectoryPath)
@@ -62,10 +77,10 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
         void CreateDescriptorFiles()
         {
             string mainDescriptorContent = GenerateMainDescriptorContent();
-            string innerDescriptorContent = GenerateInnerDescriptorContent();
+            string innerDescriptorContent = GenerateDescriptorContent();
 
-            string mainDescriptorFilePath = Path.Combine(OutputDirectoryPath, $"{outputSettings.CK2HipModId}.mod");
-            string innerDescriptorFilePath = Path.Combine(OutputDirectoryPath, outputSettings.CK2HipModId, "descriptor.mod");
+            string mainDescriptorFilePath = Path.Combine(OutputDirectoryPath, $"{ModId}.mod");
+            string innerDescriptorFilePath = Path.Combine(OutputDirectoryPath, ModId, "descriptor.mod");
 
             File.WriteAllText(mainDescriptorFilePath, mainDescriptorContent);
             File.WriteAllText(innerDescriptorFilePath, innerDescriptorContent);
@@ -73,7 +88,7 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
 
         string BuildLandedTitlesFile()
         {
-            string landedTitlesFile = ReadLandedTitlesFileLines(Path.Combine(ApplicationPaths.DataDirectory, "ck2hip_landed_titles.txt"));
+            string landedTitlesFile = ReadLandedTitlesFileLines(Path.Combine(ApplicationPaths.DataDirectory, InputLandedTitlesFileName));
             landedTitlesFile = CleanLandedTitlesFile(landedTitlesFile);
 
             List<string> landedTitlesFileLines = landedTitlesFile.Split('\n').ToList();
@@ -141,6 +156,7 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
 
             return string.Join(Environment.NewLine, lines);
         }
+
         string CleanLandedTitlesFile(string content)
         {
             IEnumerable<GameId> gameLanguageIds = languages.Values
@@ -189,26 +205,12 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
 
         void WriteLandedTitlesFile(string content, string landedTitlesDirectoryPath)
         {
-            string filePath = Path.Combine(landedTitlesDirectoryPath, LandedTitlesFileName);
+            string filePath = Path.Combine(landedTitlesDirectoryPath, OutputLandedTitlesFileName);
 
             Encoding encoding = Encoding.GetEncoding("windows-1252");
             byte[] contentBytes = encoding.GetBytes(content.ToCharArray());
             
             File.WriteAllBytes(filePath, contentBytes);
-        }
-
-        string GenerateMainDescriptorContent()
-        {
-            return GenerateInnerDescriptorContent() + Environment.NewLine +
-                $"path = \"mod/{outputSettings.CK2HipModId}\"";
-        }
-
-        string GenerateInnerDescriptorContent()
-        {
-            return
-                $"name = \"{outputSettings.CK2HipModName}\"" + Environment.NewLine +
-                $"dependencies = {{ \"HIP - Historical Immersion Project\" }}" + Environment.NewLine +
-                $"tags = {{ map immersion HIP }}";
         }
     }
 }

--- a/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
@@ -110,13 +110,17 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
 
                 content.Add(line);
 
-                if (previousLine.Contains("gain_effect") ||
+                if (previousLine.Contains("dejure_liege_title") ||
+                    previousLine.Contains("gain_effect") ||
                     previousLine.Contains("allow") ||
                     previousLine.Contains("limit") ||
                     previousLine.Contains("trigger") ||
 
                     // Be careful with these
+                    nextLine.Contains("any_direct_de_jure_vassal_title") ||
+                    nextLine.Contains("has_holder") ||
                     nextLine.Contains("is_titular") || // Could cause problems, potentially
+                    nextLine.Contains("owner") ||
                     nextLine.Contains("owner_under_ROOT") ||
                     nextLine.Contains("show_scope_change"))
                 {

--- a/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
@@ -95,9 +95,9 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
             landedTitlesFileLines.Add(string.Empty);
 
             IEnumerable<GameId> gameLocationIds = locations.Values
-                    .SelectMany(x => x.GameIds)
-                    .Where(x => x.Game == Game)
-                    .OrderBy(x => x.Id);
+                .SelectMany(x => x.GameIds)
+                .Where(x => x.Game == Game)
+                .OrderBy(x => x.Id);
 
             List<string> content = new List<string> { string.Empty };
 

--- a/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/CK2ModBuilder.cs
@@ -167,8 +167,11 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
             string culturesPattern = string.Join('|', gameLanguageIds.Select(x => x.Id));
 
             string newContent = content;
+            newContent = Regex.Replace(newContent, "\\t", "    ", RegexOptions.Multiline); // Replace tabs
+            newContent = Regex.Replace(newContent, "\\s*=\\s*", " = ", RegexOptions.Multiline); // Standardise spacings aroung equals
+            newContent = Regex.Replace(newContent, "\\s*#[^\r\n]*", "", RegexOptions.Multiline); // Remove comments
             newContent = Regex.Replace(newContent, "^\\s*\n", "", RegexOptions.Multiline); // Remove empty/whitespace lines
-            newContent = Regex.Replace(newContent, "^\\s*#.*\n", "", RegexOptions.Multiline); // Remove comment lines
+            newContent = Regex.Replace(newContent, "\\s+$", "", RegexOptions.Multiline); // Remove trailing whitespaces
 
             newContent = Regex.Replace( // Break inline cultural name into multiple lines
                 newContent,
@@ -178,7 +181,7 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
             
             newContent = Regex.Replace( // Remove cultural names
                 newContent,
-                "^\\s*(" + culturesPattern + ")\\s*=\\s*\"*[^\"]*\".*\n",
+                "^\\s*(" + culturesPattern + ")\\s*=\\s*\"*[^\"\r\n]*\"*[^\r\n]*\r*\n",
                 "",
                 RegexOptions.Multiline);
 
@@ -187,9 +190,6 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
                 "(^\\s*)([^\\s]*\\s*=\\s*\\{)\\s*\\}",
                 "$1$2\n$1}",
                 RegexOptions.Multiline);
-            
-            newContent = Regex.Replace(newContent, "^\\s*\n", "", RegexOptions.Multiline); // Remove empty/whitespace lines
-            newContent = Regex.Replace(newContent, "^\\s*#.*\n", "", RegexOptions.Multiline); // Remove comment lines
 
             newContent = newContent.Replace("\r", "");
             

--- a/Service/ModBuilders/CrusaderKings2/ICK2HIPModBuilder.cs
+++ b/Service/ModBuilders/CrusaderKings2/ICK2HIPModBuilder.cs
@@ -1,0 +1,6 @@
+namespace MoreCulturalNamesModBuilder.Service.ModBuilders.CrusaderKings2
+{
+    public interface ICK2HIPModBuilder : ICK2ModBuilder
+    {
+    }
+}

--- a/Service/ModBuilders/ModBuilder.cs
+++ b/Service/ModBuilders/ModBuilder.cs
@@ -19,6 +19,8 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders
     {
         public virtual string Game { get; protected set; }
 
+        public string ModId => outputSettings.GetModId(Game);
+
         protected string OutputDirectoryPath => Path.Combine(outputSettings.ModOutputDirectory, Game);
 
         protected readonly IRepository<LanguageEntity> languageRepository;

--- a/Service/ModBuilders/ModBuilder.cs
+++ b/Service/ModBuilders/ModBuilder.cs
@@ -178,11 +178,11 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders
             processedName = Regex.Replace(processedName, "[Č]", "Ch");
             processedName = Regex.Replace(processedName, "[ĐƊḌ]", "D");
             processedName = Regex.Replace(processedName, "[Ē]", "Ë");
-            processedName = Regex.Replace(processedName, "[Ę]", "E");
+            processedName = Regex.Replace(processedName, "[ĘƏ]", "E");
             processedName = Regex.Replace(processedName, "[Ğ]", "G");
             processedName = Regex.Replace(processedName, "[İ]", "I");
             processedName = Regex.Replace(processedName, "[Ī]", "Ï");
-            processedName = Regex.Replace(processedName, "[Ƙ]", "K");
+            processedName = Regex.Replace(processedName, "[ƘḲ]", "K");
             processedName = Regex.Replace(processedName, "[Ł]", "L");
             processedName = Regex.Replace(processedName, "[Ń]", "N");
             processedName = Regex.Replace(processedName, "[Ō]", "Ö");
@@ -201,11 +201,11 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders
             processedName = Regex.Replace(processedName, "[ě]", "ie");
             processedName = Regex.Replace(processedName, "[ē]", "ë");
             processedName = Regex.Replace(processedName, "[ė]", "è");
-            processedName = Regex.Replace(processedName, "[ęе]", "e");
+            processedName = Regex.Replace(processedName, "[ęеə]", "e");
             processedName = Regex.Replace(processedName, "[ğ]", "g");
             processedName = Regex.Replace(processedName, "[ı]", "i");
             processedName = Regex.Replace(processedName, "[ī]", "ï");
-            processedName = Regex.Replace(processedName, "[ƙк]", "k");
+            processedName = Regex.Replace(processedName, "[ƙкḳ]", "k");
             processedName = Regex.Replace(processedName, "[ł]", "l");
             processedName = Regex.Replace(processedName, "[ń]", "n");
             processedName = Regex.Replace(processedName, "[ō]", "ö");

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,10 +1,15 @@
 {
     "outputSettings": {
+        "ck2ModId": "more-cultural-names",
+        "ck2ModName": "More Cultural Names",
+
         "ck2HipModId": "hip-more-cultural-names",
         "ck2HipModName": "HIP - More Cultural Names",
+
         "ck3GameVersion": "1.0.*",
         "ck3ModId": "more-cultural-names",
         "ck3ModName": "More Cultural Names",
+
         "imperatorRomeModId": "more-cultural-names",
         "imperatorRomeModName": "More Cultural Names"
     }


### PR DESCRIPTION
 - Separated the `Crusader Kings 2 HIP` generator into one for vanilla and one for HIP
 - Improved the `Crusader Kings 2` generator **(1)**
 - Extended the `Windows-1252` character substitutions
 - Include the version as a comment in the `Crusader Kings 2` descriptors
 - Remove comments and tabs from `Crusader Kings 2` files

**(1)**: This fixes potential problems where cultural names would get added occurances of their title other than the definition. This happened with a few titles with the vanilla landed_titles file