### PR TITLE
Fixed HOI4 builder

### DIFF
--- a/Service/ILocalisationFetcher.cs
+++ b/Service/ILocalisationFetcher.cs
@@ -8,6 +8,8 @@ namespace MoreCulturalNamesModBuilder.Service
     {
         IEnumerable<Localisation> GetGameLocationLocalisations(string locationGameId, string gameId);
 
+        IEnumerable<Localisation> GetGameLocationLocalisations(string locationGameId, string locationGameIdType, string gameId);
+
         Localisation GetTitleLocalisation(string titleId, string languageId, string game);
     }
 }

--- a/Service/LocalisationFetcher.cs
+++ b/Service/LocalisationFetcher.cs
@@ -55,11 +55,33 @@ namespace MoreCulturalNamesModBuilder.Service
                 .ToDictionary(key => key.Id, val => val);
         }
 
-        public IEnumerable<Localisation> GetGameLocationLocalisations(string locationGameId, string game)
+        public IEnumerable<Localisation> GetGameLocationLocalisations(
+            string locationGameId,
+            string game)
+            => GetGameLocationLocalisations(locationGameId, null, game);
+
+        public IEnumerable<Localisation> GetGameLocationLocalisations(
+            string locationGameId,
+            string locationGameIdType,
+            string game)
         {
             ConcurrentBag<Localisation> localisations = new ConcurrentBag<Localisation>();
 
-            Location location = locations.Values.FirstOrDefault(x => x.GameIds.Any(x => x.Game == game && x.Id == locationGameId));
+            Location location;
+
+            if (string.IsNullOrWhiteSpace(locationGameIdType))
+            {
+                location = locations.Values.FirstOrDefault(x => x.GameIds.Any(
+                    x => x.Game == game &&
+                    x.Id == locationGameId));
+            }
+            else
+            {
+                location = locations.Values.FirstOrDefault(x => x.GameIds.Any(x => 
+                x.Game == game &&
+                x.Id == locationGameId &&
+                x.Type == locationGameIdType));
+            }
 
             if (location is null)
             {

--- a/Service/ModBuilders/HOI4ModBuilder.cs
+++ b/Service/ModBuilders/HOI4ModBuilder.cs
@@ -70,7 +70,7 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders
             foreach (GameId stateGameId in stateGameIds)
             {
                 IDictionary<string, Localisation> localisations = localisationFetcher
-                    .GetGameLocationLocalisations(stateGameId.Id, Settings.Mod.Game)
+                    .GetGameLocationLocalisations(stateGameId.Id, "State", Settings.Mod.Game)
                     .ToDictionary(x => x.LanguageGameId, x => x);
 
                 stateLocalisations.Add(stateGameId.Id, localisations);
@@ -79,7 +79,7 @@ namespace MoreCulturalNamesModBuilder.Service.ModBuilders
             foreach (GameId cityGameId in cityGameIds)
             {
                 IDictionary<string, Localisation> localisations = localisationFetcher
-                    .GetGameLocationLocalisations(cityGameId.Id, Settings.Mod.Game)
+                    .GetGameLocationLocalisations(cityGameId.Id, "City", Settings.Mod.Game)
                     .ToDictionary(x => x.LanguageGameId, x => x);
 
                 cityLocalisations.Add(cityGameId.Id, localisations);

--- a/Service/NameNormaliser.cs
+++ b/Service/NameNormaliser.cs
@@ -353,7 +353,7 @@ namespace MoreCulturalNamesModBuilder.Service
             processedName = Regex.Replace(processedName, "[ǜ]", "ü");
             processedName = Regex.Replace(processedName, "[ƶ]", "z");
             processedName = Regex.Replace(processedName, "[‘ʻ’ʼʿʾʹʲ]", "'");
-            processedName = Regex.Replace(processedName, "[ⁿ]", "\"");
+            processedName = Regex.Replace(processedName, "[ʺⁿ]", "\"");
             processedName = Regex.Replace(processedName, "[–]", "-");
             processedName = Regex.Replace(processedName, "[‎·]", "");
             processedName = Regex.Replace(processedName, "[‎‎]", ""); // Invisible characters


### PR DESCRIPTION
 - Fix for some `Hearts of Iron 4` cities taking state names if they have the same ID
 - Replace an additional unsupported character with an equivalent one